### PR TITLE
Fix the failing `ingestion` tests

### DIFF
--- a/containers/ingestion/tests/assets/example_eicr_with_rr_data_with_person.json
+++ b/containers/ingestion/tests/assets/example_eicr_with_rr_data_with_person.json
@@ -1,0 +1,1055 @@
+{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:10c13861-86a8-4a9a-aec6-b615921178df",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "10c13861-86a8-4a9a-aec6-b615921178df",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"
+          ],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "code": "55751-2",
+                  "display": "Public Health Case Report",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "value": "8d86218e-0fea-11eb-8216-a80388425cfb"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+            "valueString": "1"
+          }
+        ],
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "code": "55751-2",
+              "display": "Public Health Case Report",
+              "system": "http://loinc.org"
+            }
+          ]
+        },
+        "date": "2020-05-05T15:00:45-04:00",
+        "title": "Initial Public Health Case Report",
+        "confidentiality": "N",
+        "section": [
+          {
+            "id": "a3a1114f-cf32-08e6-f169-562fc066801a",
+            "title": "Encounters",
+            "text": {
+              "status": "generated",
+              "div": "<table><thead><tr><th>Encounter<\/th><th>Date(s)<\/th><th>Location<\/th><\/tr><\/thead><tbody><tr><!-- data-id: id_fd7ee2ec-4d8e-4169-aeb6-836731cc7201_ref --><td>Office outpatient visit 15 minutes<\/td><td>05/13/2020<\/td><td>Houston Urgent Care Clinic<\/td><\/tr><tr><td><ul><li><table><thead><tr><\/tr><\/thead><tbody><tr><\/tr><\/tbody><\/table><\/li><\/ul><\/td><\/tr><\/tbody><\/table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "46240-8",
+                  "display": "History of encounters",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "279dec99-22de-49d1-2a72-83aa4caf001f",
+            "title": "History of Present Illness",
+            "text": {
+              "status": "generated",
+              "div": "No history of present illness"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10164-2",
+                  "display": "History of Present Illness",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "e9466741-8c4f-69b6-1161-784fead85325",
+            "title": "Medications Administered",
+            "text": {
+              "status": "generated",
+              "div": "No medications administered"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29549-3",
+                  "display": "Medications Administered",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "3c081c28-d1c2-b515-4122-dc0697216f11",
+            "title": "Problem List",
+            "text": {
+              "status": "generated",
+              "div": "No problems reported"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11450-4",
+                  "display": "Problem List",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "2ff1770b-cc37-86b7-eb9f-bdf97c85440c",
+            "title": "Reason for visit",
+            "text": {
+              "status": "generated"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29299-5",
+                  "display": "Reason for visit",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "939ff42b-04cc-9443-2b52-3bf78ab84bdd",
+            "title": "Results",
+            "text": {
+              "status": "generated",
+              "div": "<table><thead><tr><th>Results Panel<\/th><th>Date(s)<\/th><\/tr><\/thead><tbody><tr><!-- data-id: id_2047cca3-559f-45da-8775-406538fa4815_ref --><td>SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection<\/td><td><\/td><\/tr><tr><td><ul><li><paragraph>*** In the table below, row entries with values under RCTC columns triggered this Electronic Initial Case Report (eICR)<\/paragraph><table><thead><tr><th>Test<\/th><th>Lab Test RCTC OID ***<\/th><th>Lab Test RCTC Version ***<\/th><th>Outcome<\/th><th>Date(s)<\/th><th>Lab Result RCTC OID ***<\/th><th>Lab Result RCTC Version ***<\/th><\/tr><\/thead><tbody><tr><!-- data-id: id_9890e2c3-019a-4168-8403-a0a069994440_ref --><td>SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection<\/td><td>2.16.840.1.114222.4.11.7508<\/td><td>20200429<\/td><td>Detected (qualifier value)<\/td><td>05/13/2020<\/td><td><\/td><td><\/td><\/tr><\/tbody><\/table><\/li><\/ul><\/td><\/tr><\/tbody><\/table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "30954-2",
+                  "display": "Relevant diagnostic tests and/or laboratory data",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/062a8097-9fac-01f5-ca15-216e690f5d6f"
+              }
+            ]
+          },
+          {
+            "id": "74d188fb-222d-eb9c-f18e-c6fa6e3aecc5",
+            "title": "Plan of Treatment",
+            "text": {
+              "status": "generated",
+              "div": "<paragraph>*** In the table below, row entries with values under RCTC columns triggered this Electronic Initial Case Report (eICR)<\/paragraph><table><thead><tr><th>Lab Test Order<\/th><th>Code<\/th><th>CodeSystem<\/th><th>RCTC OID ***<\/th><th>RCTC Version ***<\/th><th>Ordered Date<\/th><\/tr><\/thead><tbody><tr><!-- data-id: id_35e51f68-1d48-43e8-bcfd-769b007104e8_ref --><td>SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection<\/td><td>94310-0<\/td><td>LOINC<\/td><td><\/td><td><\/td><td>05/13/2020<\/td><\/tr><\/tbody><\/table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "18776-5",
+                  "display": "Plan of Treatment",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "8d9715f9-2853-6232-7246-299092ec5c00",
+            "title": "Social History",
+            "text": {
+              "status": "generated",
+              "div": "<table><thead><tr><th>Birth Sex<\/th><th>Value<\/th><th>Date<\/th><\/tr><\/thead><tbody><tr><td>Sex Assigned At Birth<\/td><td>Female<\/td><td>10/02/1990<\/td><\/tr><\/tbody><\/table><table><thead><tr><th>Social History Observation Type<\/th><th>Value<\/th><th>Dates(s)<\/th><\/tr><\/thead><tbody><tr><!-- data-id: id_799478b3-a3af-4bfe-8501-fb832a3a4645_ref --><td>Occupation / Employment details<\/td><td>Postsecondary teachers<\/td><td><\/td><\/tr><tr><td>Pregnancy Status<\/td><td>No<\/td><td><\/td><\/tr><\/tbody><\/table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29762-2",
+                  "display": "Social History",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "9375ee92-2dde-3991-d08d-48127c37b7ca",
+            "title": "Reportability Response Information Section",
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Reportability Response Information Section<\/div>"
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-composition",
+                "valueIdentifier": {
+                  "use": "official",
+                  "type": {
+                    "coding": [
+                      {
+                        "code": "88085-6",
+                        "display": "Reportability response report Document Public health",
+                        "system": "http://loinc.org"
+                      }
+                    ]
+                  },
+                  "value": "deb6d64f-a4ce-402d-ad4f-3d3d912ccdef"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-extension",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "RRVS19",
+                      "display": "eICR processed",
+                      "system": "urn:oid:2.16.840.1.114222.4.5.274"
+                    }
+                  ]
+                }
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "code": "88085-6",
+                  "display": "Reportability response report Document Public health",
+                  "system": "http://loinc.org"
+                }
+              ]
+            },
+            "entry": [
+              {
+                "display": "Relevant Reportable Condition Observation - Coronavirus infection (disorder)",
+                "reference": "Observation/17f6392f-9340-45d3-a1c8-bc0a30d09f53"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        },
+        "encounter": {
+          "reference": "Encounter/74349de7-8460-0535-1a63-32a884da7953"
+        },
+        "custodian": {
+          "reference": "Organization/daf02ea4-2048-a2c3-e24f-7313a37bd19b"
+        },
+        "author": [
+          {
+            "reference": "Device/4838911e-2cd4-280a-d907-47dcfcd0ca92"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Composition/10c13861-86a8-4a9a-aec6-b615921178df"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:74349de7-8460-0535-1a63-32a884da7953",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "74349de7-8460-0535-1a63-32a884da7953",
+        "status": "unknown",
+        "class": {
+          "code": "AMB",
+          "display": "Ambulatory",
+          "system": "urn:oid:2.16.840.1.113883.5.4"
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.19",
+            "value": "9937015"
+          }
+        ],
+        "period": {
+          "start": "2020-05-13",
+          "end": "2020-05-13"
+        },
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        },
+        "location": [
+          {
+            "id": "2.16.840.1.113883.4.6",
+            "location": {
+              "reference": "Location/6f413a19-36e7-8bb5-087b-1cc791fd46e8",
+              "display": "Houston Urgent Care                                                  Clinic"
+            },
+            "extension": [
+              {
+                "url": "http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html#Location.type",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "OF",
+                      "display": "Outpatient Facility",
+                      "system": "urn:oid:2.16.840.1.113883.5.111"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/79bdfaa0-ce22-d988-0414-9478c38f3bdf"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "PractitionerRole/c7fa2361-52dd-2f0d-0b28-63578455ea0a"
+            }
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/74349de7-8460-0535-1a63-32a884da7953"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6f413a19-36e7-8bb5-087b-1cc791fd46e8",
+      "resource": {
+        "resourceType": "Location",
+        "id": "6f413a19-36e7-8bb5-087b-1cc791fd46e8",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1915"
+          }
+        ],
+        "name": "Houston Urgent Care                                                  Clinic",
+        "address": {
+          "use": "work",
+          "line": [
+            "1234 Facility                                                  Drive"
+          ],
+          "city": "Houston",
+          "state": "TX",
+          "postalCode": "77002"
+        },
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-777-0123",
+            "use": "work"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "code": "OF",
+                "display": "Outpatient Facility",
+                "system": "urn:oid:2.16.840.1.113883.5.111"
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Location/6f413a19-36e7-8bb5-087b-1cc791fd46e8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:79bdfaa0-ce22-d988-0414-9478c38f3bdf",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "79bdfaa0-ce22-d988-0414-9478c38f3bdf",
+        "name": "Houston Urgent Care                                                  Clinic",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "1234 Facility                                                  Drive"
+            ],
+            "city": "Houston",
+            "state": "TX",
+            "postalCode": "77002"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-777-0123",
+            "use": "work"
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/79bdfaa0-ce22-d988-0414-9478c38f3bdf"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4581f291-448a-04ad-0508-e348f799a4b0",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "4581f291-448a-04ad-0508-e348f799a4b0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ],
+          "source": "ecr"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
+            "valueString": "Responsible Party"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "66666666666"
+          }
+        ],
+        "name": [
+          {
+            "family": "Amanda",
+            "given": ["Assigned"]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1234 Provider                                                  Street"
+            ],
+            "city": "Houston",
+            "state": "TX",
+            "country": "US",
+            "postalCode": "77002"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-777-0123",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/4581f291-448a-04ad-0508-e348f799a4b0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "c7fa2361-52dd-2f0d-0b28-63578455ea0a",
+        "practitioner": {
+          "reference": "Practitioner/4581f291-448a-04ad-0508-e348f799a4b0"
+        },
+        "organization": {
+          "reference": "Organization/daf02ea4-2048-a2c3-e24f-7313a37bd19b"
+        },
+        "meta": {
+          "source": "ecr"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:daf02ea4-2048-a2c3-e24f-7313a37bd19b",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "daf02ea4-2048-a2c3-e24f-7313a37bd19b",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "TBDFacility#"
+          }
+        ],
+        "name": "Houston Urgent Care Clinic",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "1234 Facility                                                  Drive"
+            ],
+            "city": "Houston",
+            "state": "TX",
+            "postalCode": "77002"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-777-0123",
+            "use": "work"
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/daf02ea4-2048-a2c3-e24f-7313a37bd19b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f4556c30-6c86-2995-e2df-f45c8cb572c9",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "f4556c30-6c86-2995-e2df-f45c8cb572c9",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-routing-entity-organization"
+          ],
+          "source": "ecr"
+        },
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "urn:oid:2.16.840.1.114222.4.5.232",
+                "code": "RR7",
+                "display": "Routing Entity"
+              }
+            ]
+          }
+        ],
+        "name": "Houston Health Department",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "8000 N. Stadium                                                  Dr"
+            ],
+            "city": "Houston",
+            "state": "TX",
+            "postalCode": "77054"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/f4556c30-6c86-2995-e2df-f45c8cb572c9"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:17f6392f-9340-45d3-a1c8-bc0a30d09f53",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "17f6392f-9340-45d3-a1c8-bc0a30d09f53",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-reportability-information-observation"
+          ],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:17f6392f-9340-45d3-a1c8-bc0a30d09f53"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "64572001",
+              "display": "Condition",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "75323-6",
+              "display": "Condition",
+              "system": "http://loinc.org"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "186747009",
+              "display": "Coronavirus infection (disorder)",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-determination-of-reportability-rule-extension",
+            "valueString": "All results of tests for                                                  detection of SARS-CoV-2 nucleic acid in a clinical                                                  specimen by any method "
+          },
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-determination-of-reportability-rule-extension",
+            "valueString": "Detection of SARS-CoV-2                                                  nucleic acid in a clinical specimen by any                                                  method"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-determination-of-reportability-rule-extension",
+            "valueString": "Lab test ordered for                                                  detection of SARS-CoV-2 nucleic acid in a clinical                                                  specimen by any method"
+          }
+        ],
+        "performer": [
+          {
+            "reference": "Organization/f4556c30-6c86-2995-e2df-f45c8cb572c9",
+            "display": "Houston Health Department"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/17f6392f-9340-45d3-a1c8-bc0a30d09f53"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4838911e-2cd4-280a-d907-47dcfcd0ca92",
+      "resource": {
+        "resourceType": "Device",
+        "id": "4838911e-2cd4-280a-d907-47dcfcd0ca92",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:2.16.840.1.113883.3.72.5.20"
+          }
+        ],
+        "property": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/device-category",
+                  "code": "software",
+                  "display": "software"
+                }
+              ]
+            }
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Device/4838911e-2cd4-280a-d907-47dcfcd0ca92"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.19.5",
+            "value": "PT-470126"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-ssn",
+            "value": "444-44-4444"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Doe",
+            "given": ["Jane"]
+          }
+        ],
+        "birthDate": "1990-10-02",
+        "deceasedBoolean": false,
+        "gender": "female",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2076-8",
+                  "display": "Native Hawaiian or other Pacific Islander"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Native Hawaiian or other Pacific Islander"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Not Hispanic or Latino"
+              }
+            ]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": ["2222 Home Street"],
+            "city": "Houston",
+            "state": "TX",
+            "country": "US",
+            "postalCode": "77002"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-555-2003",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "janedoe@email.com",
+            "use": "home"
+          }
+        ],
+        "contact": [
+          {
+            "name": [
+              {
+                "use": "official",
+                "family": "Contact",
+                "given": ["Emer"],
+                "prefix": ["Mr"]
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "+1-555-555-6789",
+                "use": "mobile"
+              }
+            ]
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en",
+                  "display": "English"
+                }
+              ]
+            },
+            "preferred": true
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "CareTeam",
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        },
+        "meta": {
+          "source": "ecr"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "CarePlan",
+        "status": "unknown",
+        "intent": "proposal",
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        },
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "CarePlan/"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a40cd786-e08d-a4ea-e5fc-07c6757d822c",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "a40cd786-e08d-a4ea-e5fc-07c6757d822c",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:2047cca3-559f-45da-8775-406538fa4815"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "94310-0 ",
+              "display": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
+              "system": "http://loinc.org"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2020-05-13",
+          "end": "2020-05-13"
+        },
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        },
+        "result": [
+          {
+            "reference": "Observation/062a8097-9fac-01f5-ca15-216e690f5d6f"
+          }
+        ],
+        "meta": {
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/a40cd786-e08d-a4ea-e5fc-07c6757d822c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:062a8097-9fac-01f5-ca15-216e690f5d6f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "062a8097-9fac-01f5-ca15-216e690f5d6f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:9890e2c3-019a-4168-8403-a0a069994440"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "94310-0 ",
+              "display": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
+              "system": "http://loinc.org"
+            }
+          ]
+        },
+        "effectiveDateTime": "2020-05-13",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "260373001",
+              "display": "Detected (qualifier value)",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/062a8097-9fac-01f5-ca15-216e690f5d6f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d9ee89be-d99e-55c9-e255-c6b71f9f9a88",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "d9ee89be-d99e-55c9-e255-c6b71f9f9a88",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ],
+          "source": "ecr"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "76689-9",
+              "display": "Sex Assigned At Birth",
+              "system": "http://loinc.org"
+            }
+          ]
+        },
+        "effectiveDateTime": "1990-10-02",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "F",
+              "display": "Female",
+              "system": "urn:oid:2.16.840.1.113883.5.1"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/d9ee89be-d99e-55c9-e255-c6b71f9f9a88"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ccd25b34-cab0-f669-b4e9-217f70ea81bb",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ccd25b34-cab0-f669-b4e9-217f70ea81bb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:799478b3-a3af-4bfe-8501-fb832a3a4645"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "364703007",
+              "display": "Employment detail",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "2200",
+              "display": "Postsecondary teachers",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/ea5bde5d-7b26-47c9-84f5-6aef4a3b16a7"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ccd25b34-cab0-f669-b4e9-217f70ea81bb"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "Observation",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ],
+          "source": "ecr"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/"
+      }
+    }
+  ]
+}

--- a/containers/ingestion/tests/test_fhir_transport_http.py
+++ b/containers/ingestion/tests/test_fhir_transport_http.py
@@ -286,7 +286,7 @@ def test_upload_bundle_to_fhir_server_request_params_success_500(
         bundle["entry"].append(single_resource)
 
     my_count = len(bundle.get("entry"))
-    assert my_count == 545
+    assert my_count == 518
     manager = "azure"
     fhir_url = "some-FHIR-server-URL"
     test_request = {
@@ -348,7 +348,7 @@ def test_upload_bundle_to_fhir_server_partial_success_500(
         bundle["entry"].append(single_resource)
 
     my_count = len(bundle.get("entry"))
-    assert my_count == 545
+    assert my_count == 518
     test_request = {
         "bundle": bundle,
         "cred_manager": "azure",


### PR DESCRIPTION
# PULL REQUEST

## Summary

I added a FHIR bundle that was the result of our FHIR conversion process derrived from a valid eICR/RR pair. The bundle used can be found [here](https://github.com/CDCgov/dibbs-product-demos/blob/main/ecr-parser/data/fhir-conversion/eICR-TC-COVID-LabPos_20210412-bundle.json) on the `dibbs-product-demos` repo. Since the test is asserting the known length of resources in the original bundle I adjusted the number in the test.

## Related Issue

Fixes #3 
- #3 

## Acceptance Criteria

All 57 tests are passing locally.