### PR TITLE
refactor: Additional ruff rules

### DIFF
--- a/.github/workflows/container-orchestration.yaml
+++ b/.github/workflows/container-orchestration.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install ruff==0.4.3
+          pip install ruff==0.9.6
       - name: Run linter (ruff)
         run: |
           ruff check --output-format=github .

--- a/.github/workflows/container-orchestration.yaml
+++ b/.github/workflows/container-orchestration.yaml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_RUNNER_PYTHON_VERSION: 3.11
+  TEST_RUNNER_PYTHON_VERSION: 3.10
   CONTAINER: orchestration
 
 jobs:

--- a/.github/workflows/container-orchestration.yaml
+++ b/.github/workflows/container-orchestration.yaml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_RUNNER_PYTHON_VERSION: 3.10
+  TEST_RUNNER_PYTHON_VERSION: 3.11
   CONTAINER: orchestration
 
 jobs:

--- a/.github/workflows/linting-python.yaml
+++ b/.github/workflows/linting-python.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install ruff==0.4.3
+          pip install ruff
       - name: Run linter (ruff)
         run: |
           ruff check --output-format=github .

--- a/.github/workflows/linting-python.yaml
+++ b/.github/workflows/linting-python.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       python_runner_version:
-        default: 3.10
+        default: 3.11
         required: true
         type: number
 

--- a/.github/workflows/linting-python.yaml
+++ b/.github/workflows/linting-python.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install ruff
+          pip install ruff==0.9.6
       - name: Run linter (ruff)
         run: |
           ruff check --output-format=github .

--- a/.github/workflows/linting-python.yaml
+++ b/.github/workflows/linting-python.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       python_runner_version:
-        default: 3.11
+        default: 3.10
         required: true
         type: number
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/containers/ecr-viewer/seed-scripts/create-seed-data.py
+++ b/containers/ecr-viewer/seed-scripts/create-seed-data.py
@@ -90,13 +90,13 @@ def _process_files(args):
                 rr_data = None
                 if os.path.exists(os.path.join(folder_path, "CDA_RR.xml")):
                     with (
-                        open(os.path.join(folder_path, "CDA_RR.xml"), "r") as rr_file,
+                        open(os.path.join(folder_path, "CDA_RR.xml")) as rr_file,
                     ):
                         rr_data = rr_file.read()
 
                 # Open the necessary files in the folder
                 with (
-                    open(os.path.join(folder_path, "CDA_eICR.xml"), "r") as eicr_file,
+                    open(os.path.join(folder_path, "CDA_eICR.xml")) as eicr_file,
                 ):
                     payload = {
                         "message_type": "ecr",

--- a/containers/ecr-viewer/seed-scripts/locustfile.py
+++ b/containers/ecr-viewer/seed-scripts/locustfile.py
@@ -3,9 +3,7 @@ import random
 import shutil
 import subprocess
 
-from locust import between
-from locust import HttpUser
-from locust import task
+from locust import HttpUser, between, task
 
 
 class EcrViewer(HttpUser):

--- a/containers/fhir-converter/app/constants.py
+++ b/containers/fhir-converter/app/constants.py
@@ -3,8 +3,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 # Requests and responses for the service are defined in this file.
 # Examples of both are also stored here.

--- a/containers/fhir-converter/app/main.py
+++ b/containers/fhir-converter/app/main.py
@@ -1,19 +1,12 @@
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Body
-from fastapi import FastAPI
-from fastapi import HTTPException
-from fastapi import Response
-from fastapi import status
+from fastapi import Body, FastAPI, HTTPException, Response, status
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
-from app.constants import FhirConverterInput
-from app.constants import sample_request
-from app.constants import sample_response
-from app.service import convert_to_fhir
-from app.service import resolve_references
+from app.constants import FhirConverterInput, sample_request, sample_response
+from app.service import convert_to_fhir, resolve_references
 
 description = (Path(__file__).parent.parent / "README.md").read_text(encoding="utf-8")
 

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -3,13 +3,14 @@ from unittest import mock
 
 import hl7
 import pytest
-from app.main import add_rr_data_to_eicr
-from app.main import app
-from app.service import add_data_source_to_bundle
-from app.service import normalize_hl7_datetime
-from app.service import normalize_hl7_datetime_segment
-from app.service import resolve_references
-from app.service import standardize_hl7_datetimes
+from app.main import add_rr_data_to_eicr, app
+from app.service import (
+    add_data_source_to_bundle,
+    normalize_hl7_datetime,
+    normalize_hl7_datetime_segment,
+    resolve_references,
+    standardize_hl7_datetimes,
+)
 from fastapi.testclient import TestClient
 from lxml import etree
 

--- a/containers/ingestion/app/base_service.py
+++ b/containers/ingestion/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/ingestion/app/cloud/azure.py
+++ b/containers/ingestion/app/cloud/azure.py
@@ -1,18 +1,13 @@
 import json
-from datetime import datetime
-from datetime import timezone
-from typing import List
-from typing import Literal
-from typing import Union
+from datetime import datetime, timezone
+from typing import Literal, Union
 
 from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from azure.storage.blob import BlobServiceClient
-from azure.storage.blob import ContainerClient
+from azure.storage.blob import BlobServiceClient, ContainerClient
 
-from app.cloud.core import BaseCloudStorageConnection
-from app.cloud.core import BaseCredentialManager
+from app.cloud.core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class AzureCredentialManager(BaseCredentialManager):
@@ -217,7 +212,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
         elif isinstance(message, dict):
             blob_client.upload_blob(json.dumps(message).encode("utf-8"), overwrite=True)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -235,7 +230,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
 
         return container_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/containers/ingestion/app/cloud/core.py
+++ b/containers/ingestion/app/cloud/core.py
@@ -1,6 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
-from typing import List
+from abc import ABC, abstractmethod
 from typing import Union
 
 
@@ -63,7 +61,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -72,7 +70,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_objects(self, container_name: str, prefix: str) -> List[str]:
+    def list_objects(self, container_name: str, prefix: str) -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/containers/ingestion/app/cloud/gcp.py
+++ b/containers/ingestion/app/cloud/gcp.py
@@ -1,13 +1,11 @@
 import json
-from typing import List
 from typing import Union
 
 import google.auth.transport.requests
 from google.auth.credentials import Credentials
 from google.cloud import storage
 
-from app.cloud.core import BaseCloudStorageConnection
-from app.cloud.core import BaseCredentialManager
+from app.cloud.core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class GcpCredentialManager(BaseCredentialManager):
@@ -181,7 +179,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
 
         blob.upload_from_string(data=message, content_type=content_type)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists bucket names in storage.
 
@@ -194,7 +192,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
             bucket_name_list.append(bucket)
         return bucket_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a bucket.
 

--- a/containers/ingestion/app/config.py
+++ b/containers/ingestion/app/config.py
@@ -1,6 +1,5 @@
 from functools import lru_cache
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseSettings
 
@@ -17,7 +16,7 @@ class Settings(BaseSettings):
     storage_account_url: Optional[str]
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/ingestion/app/fhir/geospatial/core.py
+++ b/containers/ingestion/app/fhir/geospatial/core.py
@@ -1,5 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 
 class BaseFhirGeocodeClient(ABC):

--- a/containers/ingestion/app/fhir/harmonization/__init__.py
+++ b/containers/ingestion/app/fhir/harmonization/__init__.py
@@ -1,8 +1,10 @@
-from app.fhir.harmonization.standardization import double_metaphone_bundle
-from app.fhir.harmonization.standardization import double_metaphone_patient
-from app.fhir.harmonization.standardization import standardize_dob
-from app.fhir.harmonization.standardization import standardize_names
-from app.fhir.harmonization.standardization import standardize_phones
+from app.fhir.harmonization.standardization import (
+    double_metaphone_bundle,
+    double_metaphone_patient,
+    standardize_dob,
+    standardize_names,
+    standardize_phones,
+)
 
 __all__ = (
     "double_metaphone_bundle",

--- a/containers/ingestion/app/fhir/harmonization/standardization.py
+++ b/containers/ingestion/app/fhir/harmonization/standardization.py
@@ -1,14 +1,14 @@
 import copy
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
-from app.harmonization import double_metaphone_string
-from app.harmonization import DoubleMetaphone
-from app.harmonization import standardize_birth_date
-from app.harmonization import standardize_country_code
-from app.harmonization import standardize_name
-from app.harmonization import standardize_phone
+from app.harmonization import (
+    DoubleMetaphone,
+    double_metaphone_string,
+    standardize_birth_date,
+    standardize_country_code,
+    standardize_name,
+    standardize_phone,
+)
 
 
 def double_metaphone_bundle(bundle: dict, overwrite=True) -> dict:
@@ -234,7 +234,7 @@ def _standardize_phones_in_resource(
 
 def _extract_countries_from_resource(
     resource: dict, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
-) -> List[str]:
+) -> list[str]:
     """
     Builds a list containing all of the countries, standardized by code_type, in the
     addresses of a given FHIR resource as interpreted by the ISO 3611: standardized

--- a/containers/ingestion/app/fhir/linkage/__init__.py
+++ b/containers/ingestion/app/fhir/linkage/__init__.py
@@ -1,4 +1,6 @@
-from app.fhir.linkage.link import add_patient_identifier
-from app.fhir.linkage.link import add_patient_identifier_in_bundle
+from app.fhir.linkage.link import (
+    add_patient_identifier,
+    add_patient_identifier_in_bundle,
+)
 
 __all__ = ["add_patient_identifier_in_bundle", "add_patient_identifier"]

--- a/containers/ingestion/app/fhir/linkage/link.py
+++ b/containers/ingestion/app/fhir/linkage/link.py
@@ -1,8 +1,10 @@
 import copy
 
-from app.fhir.utils import find_entries_by_resource_type
-from app.fhir.utils import get_field
-from app.fhir.utils import get_one_line_address
+from app.fhir.utils import (
+    find_entries_by_resource_type,
+    get_field,
+    get_one_line_address,
+)
 from app.linkage.link import generate_hash_str
 
 
@@ -70,7 +72,7 @@ def add_patient_identifier(
     # TODO Determine if minimum quality criteria should be included, such as min
     # number of characters in last name, valid birth date, or address line
     # Generate and store unique hash code
-    link_str = f'{name_str}-{patient_resource["birthDate"]}-{address_line}'
+    link_str = f"{name_str}-{patient_resource['birthDate']}-{address_line}"
     hashcode = generate_hash_str(link_str, salt_str)
 
     if "identifier" not in patient_resource:

--- a/containers/ingestion/app/fhir/transport/__init__.py
+++ b/containers/ingestion/app/fhir/transport/__init__.py
@@ -1,7 +1,9 @@
 from app.fhir.transport.export import export_from_fhir_server
-from app.fhir.transport.http import fhir_server_get
-from app.fhir.transport.http import http_request_with_reauth
-from app.fhir.transport.http import upload_bundle_to_fhir_server
+from app.fhir.transport.http import (
+    fhir_server_get,
+    http_request_with_reauth,
+    upload_bundle_to_fhir_server,
+)
 
 __all__ = [
     "http_request_with_reauth",

--- a/containers/ingestion/app/fhir/transport/http.py
+++ b/containers/ingestion/app/fhir/transport/http.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 from typing import Literal
 
 import requests
@@ -13,7 +12,7 @@ def http_request_with_reauth(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/containers/ingestion/app/fhir/utils.py
+++ b/containers/ingestion/app/fhir/utils.py
@@ -1,11 +1,7 @@
 import json
 import random
 from functools import cache
-from typing import Any
-from typing import Callable
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Any, Callable, Literal, Union
 
 import fhirpathpy
 
@@ -13,9 +9,9 @@ selection_criteria_types = Literal["first", "last", "random", "all"]
 
 
 def apply_selection_criteria(
-    value: List[Any],
+    value: list[Any],
     selection_criteria: selection_criteria_types,
-) -> str | List:
+) -> str | list:
     """
     Returns value(s), according to the selection criteria, from a given list of values
     parsed from a FHIR resource. A single string value is returned - if the selected
@@ -76,7 +72,7 @@ def extract_value_with_resource_path(
         return value
 
 
-def find_entries_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
+def find_entries_by_resource_type(bundle: dict, resource_type: str) -> list[dict]:
     """
     Collect all entries of a specific type in a bundle of FHIR data and
     return references to them in a list.

--- a/containers/ingestion/app/geospatial/__init__.py
+++ b/containers/ingestion/app/geospatial/__init__.py
@@ -1,6 +1,5 @@
 from app.geospatial.census import CensusGeocodeClient
-from app.geospatial.core import BaseGeocodeClient
-from app.geospatial.core import GeocodeResult
+from app.geospatial.core import BaseGeocodeClient, GeocodeResult
 from app.geospatial.smarty import SmartyGeocodeClient
 
 __all__ = (

--- a/containers/ingestion/app/geospatial/census.py
+++ b/containers/ingestion/app/geospatial/census.py
@@ -1,10 +1,8 @@
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import requests
 
-from app.geospatial.core import BaseGeocodeClient
-from app.geospatial.core import GeocodeResult
+from app.geospatial.core import BaseGeocodeClient, GeocodeResult
 from app.transport import http_request_with_retry
 
 

--- a/containers/ingestion/app/geospatial/core.py
+++ b/containers/ingestion/app/geospatial/core.py
@@ -1,9 +1,6 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Optional, Union
 
 
 @dataclass
@@ -14,7 +11,7 @@ class GeocodeResult:
     https://www.hl7.org/fhir/datatypes.html#Address.
     """
 
-    line: List[str]
+    line: list[str]
     city: str
     state: str
     postal_code: str

--- a/containers/ingestion/app/geospatial/smarty.py
+++ b/containers/ingestion/app/geospatial/smarty.py
@@ -1,12 +1,9 @@
 from typing import Union
 
-from smartystreets_python_sdk import ClientBuilder
-from smartystreets_python_sdk import StaticCredentials
-from smartystreets_python_sdk import us_street
+from smartystreets_python_sdk import ClientBuilder, StaticCredentials, us_street
 from smartystreets_python_sdk.us_street.lookup import Lookup
 
-from app.geospatial.core import BaseGeocodeClient
-from app.geospatial.core import GeocodeResult
+from app.geospatial.core import BaseGeocodeClient, GeocodeResult
 
 
 class SmartyGeocodeClient(BaseGeocodeClient):

--- a/containers/ingestion/app/harmonization/__init__.py
+++ b/containers/ingestion/app/harmonization/__init__.py
@@ -1,9 +1,11 @@
 from app.harmonization.double_metaphone import DoubleMetaphone
-from app.harmonization.standardization import double_metaphone_string
-from app.harmonization.standardization import standardize_birth_date
-from app.harmonization.standardization import standardize_country_code
-from app.harmonization.standardization import standardize_name
-from app.harmonization.standardization import standardize_phone
+from app.harmonization.standardization import (
+    double_metaphone_string,
+    standardize_birth_date,
+    standardize_country_code,
+    standardize_name,
+    standardize_phone,
+)
 from app.harmonization.utils import compare_strings
 
 # from app.harmonization.hl7 import convert_hl7_batch_messages_to_list

--- a/containers/ingestion/app/harmonization/double_metaphone.py
+++ b/containers/ingestion/app/harmonization/double_metaphone.py
@@ -19,7 +19,7 @@ VOWELS = ["A", "E", "I", "O", "U", "Y"]
 SILENT_STARTERS = ["GN", "KN", "PN", "WR", "PS"]
 
 
-class DoubleMetaphone(object):
+class DoubleMetaphone:
     """
     A Double Metaphone parsing object capable of performing the double
     coding algorithm on a given input string.
@@ -849,7 +849,7 @@ class DoubleMetaphone(object):
         return [self.primary_phone, self.secondary_phone]
 
 
-class Word(object):
+class Word:
     """
     Helper class used for representing a single word for token
     parsing.
@@ -866,11 +866,9 @@ class Word(object):
         self.decoded = self.decoded.replace("\xc7", "s")
         self.decoded = self.decoded.replace("\xe7", "s")
         self.normalized = "".join(
-            (
-                c
-                for c in unicodedata.normalize("NFD", self.decoded)
-                if unicodedata.category(c) != "Mn"
-            )
+            c
+            for c in unicodedata.normalize("NFD", self.decoded)
+            if unicodedata.category(c) != "Mn"
         )
         self.upper = self.normalized.upper()
         self.length = len(self.upper)

--- a/containers/ingestion/app/harmonization/standardization.py
+++ b/containers/ingestion/app/harmonization/standardization.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import phonenumbers
 import pycountry
@@ -15,7 +13,7 @@ FHIR_DATE_FORMAT = "%Y-%m-%d"
 FHIR_DATE_DELIM = "-"
 
 
-def double_metaphone_string(string: str, dmeta=None) -> List[Union[str, None]]:
+def double_metaphone_string(string: str, dmeta=None) -> list[Union[str, None]]:
     """
     Performs the double metaphone phonetic encoding algorithm on the given
     string. Returns a list holding the primary and secondary phonetic
@@ -90,8 +88,8 @@ def standardize_country_code(
 
 
 def standardize_phone(
-    raw_phone: Union[str, List[str]], countries: List = [None, "US"]
-) -> Union[str, List[str]]:
+    raw_phone: Union[str, list[str]], countries: list = [None, "US"]
+) -> Union[str, list[str]]:
     """
     Parses phone number and generates its standardized ISO E.164 international format
     for each given phone number and optional list of associated countries. If an input
@@ -152,11 +150,11 @@ def standardize_phone(
 
 
 def standardize_name(
-    raw_name: Union[str, List[str]],
+    raw_name: Union[str, list[str]],
     trim: bool = True,
     case: Literal["upper", "lower", "title"] = "upper",
     remove_numbers: bool = True,
-) -> Union[str, List[str]]:
+) -> Union[str, list[str]]:
     """
     Performs basic standardization (described below) on each given name. Removes
     punctuation characters and performs a variety of additional cleaning operations.

--- a/containers/ingestion/app/main.py
+++ b/containers/ingestion/app/main.py
@@ -2,11 +2,13 @@ from pathlib import Path
 
 from app.base_service import BaseService
 from app.config import get_settings
-from app.routers import cloud_storage
-from app.routers import fhir_geospatial
-from app.routers import fhir_harmonization_standardization
-from app.routers import fhir_linkage_link
-from app.routers import fhir_transport_http
+from app.routers import (
+    cloud_storage,
+    fhir_geospatial,
+    fhir_harmonization_standardization,
+    fhir_linkage_link,
+    fhir_transport_http,
+)
 
 # Read settings immediately to fail fast in case there are invalid values.
 get_settings()

--- a/containers/ingestion/app/routers/cloud_storage.py
+++ b/containers/ingestion/app/routers/cloud_storage.py
@@ -1,15 +1,13 @@
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
-from fastapi import APIRouter
-from fastapi import Response
-from fastapi import status
-from pydantic import BaseModel
-from pydantic import Field
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel, Field
 
-from app.utils import get_cloud_provider_storage_connection
-from app.utils import search_for_required_values
-from app.utils import StandardResponse
+from app.utils import (
+    StandardResponse,
+    get_cloud_provider_storage_connection,
+    search_for_required_values,
+)
 
 router = APIRouter(
     prefix="/cloud/storage",

--- a/containers/ingestion/app/routers/fhir_geospatial.py
+++ b/containers/ingestion/app/routers/fhir_geospatial.py
@@ -1,22 +1,16 @@
-from typing import Annotated
-from typing import Literal
-from typing import Optional
+from typing import Annotated, Literal, Optional
 
-from fastapi import APIRouter
-from fastapi import Body
-from fastapi import Response
-from fastapi import status
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import validator
+from fastapi import APIRouter, Body, Response, status
+from pydantic import BaseModel, Field, validator
 
 from app.config import get_settings
-from app.fhir.geospatial import CensusFhirGeocodeClient
-from app.fhir.geospatial import SmartyFhirGeocodeClient
-from app.utils import check_for_fhir_bundle
-from app.utils import read_json_from_assets
-from app.utils import search_for_required_values
-from app.utils import StandardResponse
+from app.fhir.geospatial import CensusFhirGeocodeClient, SmartyFhirGeocodeClient
+from app.utils import (
+    StandardResponse,
+    check_for_fhir_bundle,
+    read_json_from_assets,
+    search_for_required_values,
+)
 
 router = APIRouter(
     prefix="/fhir/geospatial/geocode",

--- a/containers/ingestion/app/routers/fhir_harmonization_standardization.py
+++ b/containers/ingestion/app/routers/fhir_harmonization_standardization.py
@@ -1,17 +1,14 @@
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import validator
+from pydantic import BaseModel, Field, validator
 
-from app.fhir.harmonization.standardization import standardize_dob
-from app.fhir.harmonization.standardization import standardize_names
-from app.fhir.harmonization.standardization import standardize_phones
-from app.utils import check_for_fhir
-from app.utils import read_json_from_assets
-from app.utils import StandardResponse
+from app.fhir.harmonization.standardization import (
+    standardize_dob,
+    standardize_names,
+    standardize_phones,
+)
+from app.utils import StandardResponse, check_for_fhir, read_json_from_assets
 
 router = APIRouter(
     prefix="/fhir/harmonization/standardization",

--- a/containers/ingestion/app/routers/fhir_linkage_link.py
+++ b/containers/ingestion/app/routers/fhir_linkage_link.py
@@ -1,16 +1,14 @@
 from typing import Optional
 
-from fastapi import APIRouter
-from fastapi import Response
-from fastapi import status
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import validator
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel, Field, validator
 
 from app.fhir.linkage.link import add_patient_identifier_in_bundle
-from app.utils import check_for_fhir_bundle
-from app.utils import search_for_required_values
-from app.utils import StandardResponse
+from app.utils import (
+    StandardResponse,
+    check_for_fhir_bundle,
+    search_for_required_values,
+)
 
 router = APIRouter(
     prefix="/fhir/linkage/link",

--- a/containers/ingestion/app/routers/fhir_transport_http.py
+++ b/containers/ingestion/app/routers/fhir_transport_http.py
@@ -1,18 +1,15 @@
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
-from fastapi import APIRouter
-from fastapi import Response
-from fastapi import status
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import validator
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel, Field, validator
 
 from app.fhir.transport import upload_bundle_to_fhir_server
-from app.utils import check_for_fhir_bundle
-from app.utils import get_cred_manager
-from app.utils import search_for_required_values
-from app.utils import StandardResponse
+from app.utils import (
+    StandardResponse,
+    check_for_fhir_bundle,
+    get_cred_manager,
+    search_for_required_values,
+)
 
 router = APIRouter(
     prefix="/fhir/transport/http",

--- a/containers/ingestion/app/transport/http.py
+++ b/containers/ingestion/app/transport/http.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Literal
 
 import requests
@@ -10,7 +9,7 @@ def http_request_with_retry(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/containers/ingestion/app/utils.py
+++ b/containers/ingestion/app/utils.py
@@ -1,17 +1,12 @@
 import json
 import pathlib
-from typing import Optional
-from typing import Union
+from typing import Optional, Union
 
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import root_validator
+from pydantic import BaseModel, Field, root_validator
 
-from app.cloud.azure import AzureCloudContainerConnection
-from app.cloud.azure import AzureCredentialManager
+from app.cloud.azure import AzureCloudContainerConnection, AzureCredentialManager
 from app.cloud.core import BaseCredentialManager
-from app.cloud.gcp import GcpCloudStorageConnection
-from app.cloud.gcp import GcpCredentialManager
+from app.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
 from app.config import get_settings
 
 
@@ -75,9 +70,9 @@ def check_for_fhir_bundle(value: dict) -> dict:
     :return: The dictionary originally passed in as 'value'
     """
 
-    assert (
-        value.get("resourceType") == "Bundle"
-    ), "Must provide a FHIR resource or bundle"  # noqa
+    assert value.get("resourceType") == "Bundle", (
+        "Must provide a FHIR resource or bundle"
+    )  # noqa
     return value
 
 
@@ -176,4 +171,4 @@ def read_json_from_assets(filename: str):
     :param filename: The name of the JSON file to be loaded.
     :return: The content of the JSON file as a dictionary.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))

--- a/containers/ingestion/tests/conftest.py
+++ b/containers/ingestion/tests/conftest.py
@@ -12,7 +12,7 @@ def read_json_from_test_assets():
         """
         Reads a JSON file from the test assets directory.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             return json.load(file)
 
     return _read_json

--- a/containers/ingestion/tests/test_base_service.py
+++ b/containers/ingestion/tests/test_base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
 import toml
-from app.base_service import BaseService
-from app.base_service import DIBBS_CONTACT
-from app.base_service import LICENSES
+from app.base_service import DIBBS_CONTACT, LICENSES, BaseService
 from fastapi.testclient import TestClient
 
 with open(

--- a/containers/ingestion/tests/test_fhir_geospatial.py
+++ b/containers/ingestion/tests/test_fhir_geospatial.py
@@ -5,8 +5,7 @@ from unittest import mock
 
 from app.config import get_settings
 from app.main import app
-from fastapi import Response
-from fastapi import status
+from fastapi import Response, status
 from fastapi.testclient import TestClient
 
 client = TestClient(app)

--- a/containers/ingestion/tests/test_utils.py
+++ b/containers/ingestion/tests/test_utils.py
@@ -2,11 +2,13 @@ import os
 
 import pytest
 from app.config import get_settings
-from app.utils import check_for_fhir
-from app.utils import check_for_fhir_bundle
-from app.utils import get_cloud_provider_storage_connection
-from app.utils import get_cred_manager
-from app.utils import search_for_required_values
+from app.utils import (
+    check_for_fhir,
+    check_for_fhir_bundle,
+    get_cloud_provider_storage_connection,
+    get_cred_manager,
+    search_for_required_values,
+)
 
 
 def test_search_for_required_values_success():

--- a/containers/message-parser/app/base_service.py
+++ b/containers/message-parser/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/message-parser/app/cloud/azure.py
+++ b/containers/message-parser/app/cloud/azure.py
@@ -1,18 +1,13 @@
 import json
-from datetime import datetime
-from datetime import timezone
-from typing import List
-from typing import Literal
-from typing import Union
+from datetime import datetime, timezone
+from typing import Literal, Union
 
 from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from azure.storage.blob import BlobServiceClient
-from azure.storage.blob import ContainerClient
+from azure.storage.blob import BlobServiceClient, ContainerClient
 
-from app.cloud.core import BaseCloudStorageConnection
-from app.cloud.core import BaseCredentialManager
+from app.cloud.core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class AzureCredentialManager(BaseCredentialManager):
@@ -217,7 +212,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
         elif isinstance(message, dict):
             blob_client.upload_blob(json.dumps(message).encode("utf-8"), overwrite=True)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -235,7 +230,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
 
         return container_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/containers/message-parser/app/cloud/core.py
+++ b/containers/message-parser/app/cloud/core.py
@@ -1,6 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
-from typing import List
+from abc import ABC, abstractmethod
 from typing import Union
 
 
@@ -63,7 +61,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -72,7 +70,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_objects(self, container_name: str, prefix: str) -> List[str]:
+    def list_objects(self, container_name: str, prefix: str) -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/containers/message-parser/app/cloud/gcp.py
+++ b/containers/message-parser/app/cloud/gcp.py
@@ -1,13 +1,11 @@
 import json
-from typing import List
 from typing import Union
 
 import google.auth.transport.requests
 from google.auth.credentials import Credentials
 from google.cloud import storage
 
-from app.cloud.core import BaseCloudStorageConnection
-from app.cloud.core import BaseCredentialManager
+from app.cloud.core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class GcpCredentialManager(BaseCredentialManager):
@@ -181,7 +179,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
 
         blob.upload_from_string(data=message, content_type=content_type)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists bucket names in storage.
 
@@ -194,7 +192,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
             bucket_name_list.append(bucket)
         return bucket_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a bucket.
 

--- a/containers/message-parser/app/config.py
+++ b/containers/message-parser/app/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     fhir_converter_url: Optional[str]
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/message-parser/app/fhir/transport/http.py
+++ b/containers/message-parser/app/fhir/transport/http.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Literal
 
 import requests
@@ -12,7 +11,7 @@ def http_request_with_reauth(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -3,30 +3,32 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Body
-from fastapi import Response
-from fastapi import status
+from fastapi import Body, Response, status
 
 from app.base_service import BaseService
 from app.config import get_settings
-from app.models import FhirToPhdcInput
-from app.models import GetSchemaResponse
-from app.models import ListSchemasResponse
-from app.models import ParseMessageInput
-from app.models import ParseMessageResponse
-from app.models import ParsingSchemaModel
-from app.models import PutSchemaResponse
+from app.models import (
+    FhirToPhdcInput,
+    GetSchemaResponse,
+    ListSchemasResponse,
+    ParseMessageInput,
+    ParseMessageResponse,
+    ParsingSchemaModel,
+    PutSchemaResponse,
+)
 from app.phdc.builder import PHDCBuilder
-from app.utils import clean_schema
-from app.utils import convert_to_fhir
-from app.utils import extract_and_apply_parsers
-from app.utils import freeze_parsing_schema
-from app.utils import get_credential_manager
-from app.utils import get_metadata
-from app.utils import load_parsing_schema
-from app.utils import read_json_from_assets
-from app.utils import search_for_required_values
-from app.utils import transform_to_phdc_input_data
+from app.utils import (
+    clean_schema,
+    convert_to_fhir,
+    extract_and_apply_parsers,
+    freeze_parsing_schema,
+    get_credential_manager,
+    get_metadata,
+    load_parsing_schema,
+    read_json_from_assets,
+    search_for_required_values,
+    transform_to_phdc_input_data,
+)
 
 # Read settings immediately to fail fast in case there are invalid values.
 get_settings()

--- a/containers/message-parser/app/models.py
+++ b/containers/message-parser/app/models.py
@@ -1,11 +1,6 @@
-from typing import Dict
-from typing import Literal
-from typing import Optional
-from typing import Union
+from typing import Literal, Optional, Union
 
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import root_validator
+from pydantic import BaseModel, Field, root_validator
 
 PARSING_SCHEMA_DATA_TYPES = Literal[
     "string", "integer", "float", "boolean", "date", "datetime", "array", "struct"
@@ -264,18 +259,18 @@ class ParsingSchemaSecondaryFieldModel(BaseModel):
     fhir_path: str
     data_type: PARSING_SCHEMA_DATA_TYPES
     nullable: bool
-    secondary_schema: Optional[Dict[str, ParsingSchemaTertiaryFieldModel]]
+    secondary_schema: Optional[dict[str, ParsingSchemaTertiaryFieldModel]]
 
 
 class ParsingSchemaFieldModel(BaseModel):
     fhir_path: str
     data_type: PARSING_SCHEMA_DATA_TYPES
     nullable: bool
-    secondary_schema: Optional[Dict[str, ParsingSchemaSecondaryFieldModel]]
+    secondary_schema: Optional[dict[str, ParsingSchemaSecondaryFieldModel]]
 
 
 class ParsingSchemaModel(BaseModel):
-    parsing_schema: Dict[str, ParsingSchemaFieldModel] = Field(
+    parsing_schema: dict[str, ParsingSchemaFieldModel] = Field(
         description="A JSON formatted parsing schema to upload."
     )
     overwrite: Optional[bool] = Field(
@@ -293,5 +288,5 @@ class PutSchemaResponse(BaseModel):
     """
 
     message: str = Field(
-        "A message describing the result of a request to " "upload a parsing schema."
+        "A message describing the result of a request to upload a parsing schema."
     )

--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -1,21 +1,21 @@
 import logging
 import uuid
 from datetime import datetime
-from typing import List
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
 from lxml import etree as ET
 
 from app import utils
-from app.phdc.models import Address
-from app.phdc.models import CodedElement
-from app.phdc.models import Name
-from app.phdc.models import Observation
-from app.phdc.models import Organization
-from app.phdc.models import Patient
-from app.phdc.models import PHDCInputData
-from app.phdc.models import Telecom
+from app.phdc.models import (
+    Address,
+    CodedElement,
+    Name,
+    Observation,
+    Organization,
+    Patient,
+    PHDCInputData,
+    Telecom,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -741,7 +741,7 @@ class PHDCBuilder:
 
         return name_data
 
-    def _build_custodian(self, organizations: List[Organization]) -> ET.Element:
+    def _build_custodian(self, organizations: list[Organization]) -> ET.Element:
         """
         Builds a `custodian` XML element for custodian data, which refers to the
         organization from which the PHDC originates and that is in charge of
@@ -930,8 +930,8 @@ class PHDCBuilder:
         id: str,
         root: str = None,
         assigningAuthorityName: str = None,
-        telecom_data: Optional[List[Telecom]] = None,
-        address_data: Optional[List[Address]] = None,
+        telecom_data: Optional[list[Telecom]] = None,
+        address_data: Optional[list[Address]] = None,
         patient_data: Optional[Patient] = None,
     ) -> ET.Element:
         """

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -1,10 +1,5 @@
-from dataclasses import dataclass
-from dataclasses import field
-from typing import Dict
-from typing import List
-from typing import Literal
-from typing import Optional
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Union
 
 
 @dataclass
@@ -59,9 +54,9 @@ class Patient:
     A class containing all of the data elements for a patient element.
     """
 
-    name: List[Name] = None
-    address: List[Address] = None
-    telecom: List[Telecom] = None
+    name: list[Name] = None
+    address: list[Address] = None
+    telecom: list[Telecom] = None
     administrative_gender_code: Optional[str] = None
     race_code: Optional[str] = None
     ethnic_group_code: Optional[str] = None
@@ -94,7 +89,7 @@ class CodedElement:
     value: Optional[str] = None
     text: Optional[Union[str, int]] = None
 
-    def to_attributes(self) -> Dict[str, str]:
+    def to_attributes(self) -> dict[str, str]:
         """
         Given a standard CodedElements return a dictionary that can be iterated over to
         produce the corresponding XML element.
@@ -163,7 +158,7 @@ class PHDCInputData:
         "case_report"
     )
     patient: Patient = None
-    organization: List[Organization] = None
-    clinical_info: List[List[Observation]] = field(default_factory=list)
-    social_history_info: List[List[Observation]] = field(default_factory=list)
-    repeating_questions: List[List[Observation]] = field(default_factory=list)
+    organization: list[Organization] = None
+    clinical_info: list[list[Observation]] = field(default_factory=list)
+    social_history_info: list[list[Observation]] = field(default_factory=list)
+    repeating_questions: list[list[Observation]] = field(default_factory=list)

--- a/containers/message-parser/app/transport/http.py
+++ b/containers/message-parser/app/transport/http.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Literal
 
 import requests
@@ -10,7 +9,7 @@ def http_request_with_retry(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -6,8 +6,7 @@ import re
 import uuid
 from functools import cache
 from pathlib import Path
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import fhirpathpy
 import requests
@@ -20,13 +19,15 @@ from app.cloud.core import BaseCredentialManager
 from app.cloud.gcp import GcpCredentialManager
 from app.config import get_settings
 from app.fhir.transport import http_request_with_reauth
-from app.phdc.models import Address
-from app.phdc.models import Name
-from app.phdc.models import Observation
-from app.phdc.models import Organization
-from app.phdc.models import Patient
-from app.phdc.models import PHDCInputData
-from app.phdc.models import Telecom
+from app.phdc.models import (
+    Address,
+    Name,
+    Observation,
+    Organization,
+    Patient,
+    PHDCInputData,
+    Telecom,
+)
 from app.transport.http import http_request_with_retry
 
 DIBBS_REFERENCE_SIGNIFIER = "#REF#"
@@ -44,14 +45,14 @@ def load_parsing_schema(schema_name: str) -> dict:
     """
     custom_schema_path = Path(__file__).parent / "custom_schemas" / schema_name
     try:
-        with open(custom_schema_path, "r") as file:
+        with open(custom_schema_path) as file:
             parsing_schema = json.load(file)
     except FileNotFoundError:
         try:
             default_schema_path = (
                 Path(__file__).parent / "default_schemas" / schema_name
             )
-            with open(default_schema_path, "r") as file:
+            with open(default_schema_path) as file:
                 parsing_schema = json.load(file)
         except FileNotFoundError:
             raise FileNotFoundError(
@@ -336,7 +337,7 @@ def read_json_from_assets(filename: str) -> dict:
     :param filename: The name of the file to read.
     :return: A dictionary containing the contents of the file.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))
 
 
 def read_file_from_assets(filename: str) -> str:
@@ -346,9 +347,7 @@ def read_file_from_assets(filename: str) -> str:
     :param filename: The name of the file to read.
     :return: A string containing the contents of the file.
     """
-    with open(
-        (pathlib.Path(__file__).parent.parent / "assets" / filename), "r"
-    ) as file:
+    with open(pathlib.Path(__file__).parent.parent / "assets" / filename) as file:
         return file.read()
 
 

--- a/containers/message-parser/tests/conftest.py
+++ b/containers/message-parser/tests/conftest.py
@@ -15,7 +15,7 @@ def read_json_from_test_assets():
         """
         Reads a JSON file from the test assets directory.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             return json.load(file)
 
     return _read_json
@@ -35,7 +35,6 @@ def read_json_from_phdi_test_assets():
                 / "general"
                 / filename
             ),
-            "r",
         ) as file:
             return json.load(file)
 
@@ -48,7 +47,7 @@ def read_file_from_test_assets():
         """
         Reads a file from the test assets directory.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             return file.read()
 
     return _read_file
@@ -60,7 +59,7 @@ def parse_file_from_test_assets():
         """
         Parses a file from the assets directory into an ElementTree.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             parser = (
                 ET.XMLParser()
             )  # Adjust as necessary; removed `remove_blank_text=True` for compatibility
@@ -77,7 +76,7 @@ def read_schema_from_default_schemas():
         Reads a JSON schema from the default schemas directory.
         """
         with open(
-            (Path(__file__).parent.parent / "app" / "default_schemas" / filename), "r"
+            Path(__file__).parent.parent / "app" / "default_schemas" / filename
         ) as file:
             return json.load(file)
 

--- a/containers/message-parser/tests/test_base_service.py
+++ b/containers/message-parser/tests/test_base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
 import toml
-from app.base_service import BaseService
-from app.base_service import DIBBS_CONTACT
-from app.base_service import LICENSES
+from app.base_service import DIBBS_CONTACT, LICENSES, BaseService
 from fastapi.testclient import TestClient
 
 with open(

--- a/containers/message-parser/tests/test_cloud.py
+++ b/containers/message-parser/tests/test_cloud.py
@@ -1,15 +1,12 @@
 import io
 import json
 import pathlib
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
-from app.cloud.azure import AzureCloudContainerConnection
-from app.cloud.azure import AzureCredentialManager
-from app.cloud.gcp import GcpCloudStorageConnection
-from app.cloud.gcp import GcpCredentialManager
+from app.cloud.azure import AzureCloudContainerConnection, AzureCredentialManager
+from app.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
 from azure.storage.blob import ContainerClient
 
 

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -6,14 +6,16 @@ from unittest.mock import patch
 import pytest
 from app import utils
 from app.phdc.builder import PHDCBuilder
-from app.phdc.models import Address
-from app.phdc.models import CodedElement
-from app.phdc.models import Name
-from app.phdc.models import Observation
-from app.phdc.models import Organization
-from app.phdc.models import Patient
-from app.phdc.models import PHDCInputData
-from app.phdc.models import Telecom
+from app.phdc.models import (
+    Address,
+    CodedElement,
+    Name,
+    Observation,
+    Organization,
+    Patient,
+    PHDCInputData,
+    Telecom,
+)
 from lxml import etree as ET
 
 
@@ -25,7 +27,7 @@ def parse_file_from_test_assets(filename: str) -> ET.ElementTree:
     :return: An ElementTree containing the contents of the file.
     """
     with open(
-        (pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename), "r"
+        pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename
     ) as file:
         parser = ET.XMLParser(remove_blank_text=True)
         tree = ET.parse(

--- a/containers/message-parser/tests/test_phdc_validation.py
+++ b/containers/message-parser/tests/test_phdc_validation.py
@@ -5,14 +5,16 @@ from unittest.mock import patch
 import pytest
 from app import utils
 from app.phdc.builder import PHDCBuilder
-from app.phdc.models import Address
-from app.phdc.models import CodedElement
-from app.phdc.models import Name
-from app.phdc.models import Observation
-from app.phdc.models import Organization
-from app.phdc.models import Patient
-from app.phdc.models import PHDCInputData
-from app.phdc.models import Telecom
+from app.phdc.models import (
+    Address,
+    CodedElement,
+    Name,
+    Observation,
+    Organization,
+    Patient,
+    PHDCInputData,
+    Telecom,
+)
 from lxml import etree as ET
 
 

--- a/containers/message-parser/tests/test_schemas_endpoint.py
+++ b/containers/message-parser/tests/test_schemas_endpoint.py
@@ -24,7 +24,7 @@ def test_get_specific_schema():
     test_schema_path = (
         Path(__file__).parent.parent / "app" / "default_schemas" / "test_schema.json"
     )
-    with open(test_schema_path, "r") as file:
+    with open(test_schema_path) as file:
         test_schema = json.load(file)
 
     response = client.get("/schemas/test_schema.json")

--- a/containers/message-parser/tests/test_utils.py
+++ b/containers/message-parser/tests/test_utils.py
@@ -5,15 +5,17 @@ from unittest import mock
 
 import pytest
 from app.config import get_settings
-from app.utils import convert_to_fhir
-from app.utils import field_metadata
-from app.utils import freeze_parsing_schema
-from app.utils import freeze_parsing_schema_helper
-from app.utils import get_credential_manager
-from app.utils import get_metadata
-from app.utils import get_parsers
-from app.utils import load_parsing_schema
-from app.utils import search_for_required_values
+from app.utils import (
+    convert_to_fhir,
+    field_metadata,
+    freeze_parsing_schema,
+    freeze_parsing_schema_helper,
+    get_credential_manager,
+    get_metadata,
+    get_parsers,
+    load_parsing_schema,
+    search_for_required_values,
+)
 from frozendict import frozendict
 
 
@@ -21,7 +23,7 @@ def test_load_parsing_schema_success():
     test_schema_path = (
         Path(__file__).parent.parent / "app" / "default_schemas" / "test_schema.json"
     )
-    with open(test_schema_path, "r") as file:
+    with open(test_schema_path) as file:
         test_schema = json.load(file)
 
     schema = load_parsing_schema("test_schema.json")
@@ -164,7 +166,7 @@ def test_freeze_parsing_schema():
     test_schema_path = (
         Path(__file__).parent.parent / "app" / "default_schemas" / "test_schema.json"
     )
-    with open(test_schema_path, "r") as file:
+    with open(test_schema_path) as file:
         test_schema = json.load(file)
 
     frozen_schema = freeze_parsing_schema(test_schema)

--- a/containers/message-refiner/app/base_service.py
+++ b/containers/message-refiner/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/message-refiner/app/config.py
+++ b/containers/message-refiner/app/config.py
@@ -1,7 +1,6 @@
 from functools import lru_cache
 
-from pydantic import BaseSettings
-from pydantic import Field
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
@@ -16,7 +15,7 @@ class Settings(BaseSettings):
     )
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> Settings:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/message-refiner/app/main.py
+++ b/containers/message-refiner/app/main.py
@@ -2,20 +2,14 @@ from pathlib import Path
 from typing import Annotated
 
 import httpx
-from fastapi import Query
-from fastapi import Request
-from fastapi import Response
-from fastapi import status
+from fastapi import Query, Request, Response, status
 from fastapi.openapi.utils import get_openapi
 
 from app.base_service import BaseService
 from app.config import get_settings
 from app.models import RefineECRResponse
-from app.refine import refine
-from app.refine import validate_message
-from app.refine import validate_sections_to_include
-from app.utils import create_clinical_services_dict
-from app.utils import read_json_from_assets
+from app.refine import refine, validate_message, validate_sections_to_include
+from app.utils import create_clinical_services_dict, read_json_from_assets
 
 settings = get_settings()
 TCR_ENDPOINT = f"{settings['tcr_url']}/get-value-sets?condition_code="

--- a/containers/message-refiner/app/models.py
+++ b/containers/message-refiner/app/models.py
@@ -1,5 +1,4 @@
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 
 class RefineECRResponse(BaseModel):

--- a/containers/message-refiner/app/refine.py
+++ b/containers/message-refiner/app/refine.py
@@ -1,8 +1,5 @@
 import logging
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Optional, Union
 
 from lxml import etree
 
@@ -72,8 +69,8 @@ def validate_sections_to_include(sections_to_include: str | None) -> tuple[list,
 
 def refine(
     validated_message: etree.Element,
-    sections_to_include: Optional[List[str]] = None,
-    clinical_services: Optional[Dict[str, List[str]]] = None,
+    sections_to_include: Optional[list[str]] = None,
+    clinical_services: Optional[dict[str, list[str]]] = None,
 ) -> str:
     """
     Refines an eICR XML document by processing its sections based on the provided parameters.
@@ -208,8 +205,8 @@ def _process_section(
     section: etree.Element,
     combined_xpaths: str,
     namespaces: dict,
-    template_ids: List[str],
-    clinical_services_codes: Optional[List[str]] = None,
+    template_ids: list[str],
+    clinical_services_codes: Optional[list[str]] = None,
 ) -> None:
     """
     Processes a section by checking for elements, finding observations,
@@ -243,7 +240,7 @@ def _process_section(
 
 
 def _generate_combined_xpath(
-    template_ids: List[str], clinical_services_dict: Dict[str, List[str]]
+    template_ids: list[str], clinical_services_dict: dict[str, list[str]]
 ) -> str:
     """
     Generate a combined XPath expression for templateIds and all codes across all systems, ensuring they are within 'observation' elements.
@@ -291,7 +288,7 @@ def _get_observations(
     section: etree.Element,
     combined_xpath: str,
     namespaces: dict = {"hl7": "urn:hl7-org:v3"},
-) -> List[etree.Element]:
+) -> list[etree.Element]:
     """
     Get matching observations from a section or a callable returning a section based on combined XPath query.
 
@@ -327,7 +324,7 @@ def _get_observations(
 def _are_elements_present(
     section: etree.Element,
     search_type: str,
-    search_values: List[str],
+    search_values: list[str],
     namespaces: dict = {"hl7": "urn:hl7-org:v3"},
 ) -> bool:
     """
@@ -350,7 +347,7 @@ def _are_elements_present(
     return bool(section.xpath(combined_xpath, namespaces=namespaces))
 
 
-def _find_path_to_entry(element: etree.Element) -> List[etree.Element]:
+def _find_path_to_entry(element: etree.Element) -> list[etree.Element]:
     """
     Helper function to find the path from a given element to the parent <entry> element.
     """
@@ -367,7 +364,7 @@ def _find_path_to_entry(element: etree.Element) -> List[etree.Element]:
 
 
 def _prune_unwanted_siblings(
-    paths: List[List[etree.Element]], desired_elements: List[etree.Element]
+    paths: list[list[etree.Element]], desired_elements: list[etree.Element]
 ):
     """
     Prunes unwanted siblings based on the desired elements.
@@ -392,7 +389,7 @@ def _prune_unwanted_siblings(
 
 def _extract_observation_data(
     observation: etree.Element,
-) -> Dict[str, Union[str, bool]]:
+) -> dict[str, Union[str, bool]]:
     """
     Extracts relevant data from an observation element, including checking for trigger code template ID.
 
@@ -425,7 +422,7 @@ def _extract_observation_data(
     return data
 
 
-def _create_or_update_text_element(observations: List[etree.Element]) -> etree.Element:
+def _create_or_update_text_element(observations: list[etree.Element]) -> etree.Element:
     """
     Creates or updates a <text> element with a table containing information from the given observations.
 
@@ -461,7 +458,7 @@ def _create_or_update_text_element(observations: List[etree.Element]) -> etree.E
 
 
 def _update_text_element(
-    section: etree.Element, observations: List[etree.Element]
+    section: etree.Element, observations: list[etree.Element]
 ) -> None:
     """
     Updates the <text> element of a section to include information from observations.

--- a/containers/message-refiner/app/utils.py
+++ b/containers/message-refiner/app/utils.py
@@ -1,7 +1,5 @@
 import json
 import pathlib
-from typing import Dict
-from typing import List
 
 
 def read_json_from_assets(filename: str) -> dict:
@@ -11,7 +9,7 @@ def read_json_from_assets(filename: str) -> dict:
     :param filename: The name of the file to read.
     :return: A dictionary containing the contents of the file.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))
 
 
 def load_section_loincs(loinc_json: dict) -> tuple[list, dict]:
@@ -40,8 +38,8 @@ def load_section_loincs(loinc_json: dict) -> tuple[list, dict]:
 
 
 def create_clinical_services_dict(
-    clinical_services_list: List[Dict],
-) -> Dict[str, List[str]]:
+    clinical_services_list: list[dict],
+) -> dict[str, list[str]]:
     """
     Transform the original Trigger Code Reference API response to have keys as systems
     and values as lists of codes, while ensuring the systems are recognized and using their

--- a/containers/message-refiner/tests/conftest.py
+++ b/containers/message-refiner/tests/conftest.py
@@ -18,7 +18,7 @@ def read_file_from_test_assets():
         """
         Reads a file from the test assets directory.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             return file.read()
 
     return _read_file
@@ -30,7 +30,7 @@ def parse_file_from_test_assets():
         """
         Parses a file from the assets directory into an ElementTree.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             parser = ET.XMLParser()
             tree = ET.parse(file, parser)
             return tree

--- a/containers/message-refiner/tests/test_refine.py
+++ b/containers/message-refiner/tests/test_refine.py
@@ -1,21 +1,22 @@
 import pathlib
-from typing import List
 
 import pytest
-from app.refine import _are_elements_present
-from app.refine import _create_minimal_section
-from app.refine import _create_or_update_text_element
-from app.refine import _extract_observation_data
-from app.refine import _find_path_to_entry
-from app.refine import _generate_combined_xpath
-from app.refine import _get_observations
-from app.refine import _get_section_by_code
-from app.refine import _process_section
-from app.refine import _prune_unwanted_siblings
-from app.refine import _update_text_element
-from app.refine import refine
-from app.refine import validate_message
-from app.refine import validate_sections_to_include
+from app.refine import (
+    _are_elements_present,
+    _create_minimal_section,
+    _create_or_update_text_element,
+    _extract_observation_data,
+    _find_path_to_entry,
+    _generate_combined_xpath,
+    _get_observations,
+    _get_section_by_code,
+    _process_section,
+    _prune_unwanted_siblings,
+    _update_text_element,
+    refine,
+    validate_message,
+    validate_sections_to_include,
+)
 from lxml import etree
 
 TRIGGER_CODE_TEMPLATE_IDS = [
@@ -36,7 +37,7 @@ def parse_file_from_test_assets(filename: str) -> etree.ElementTree:
     :return: An ElementTree containing the contents of the file.
     """
     with open(
-        (pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename), "r"
+        pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename
     ) as file:
         parser = etree.XMLParser(remove_blank_text=True)
         tree = etree.parse(file, parser)
@@ -52,7 +53,6 @@ def read_file_from_test_assets(filename: str) -> str:
     """
     with open(
         (pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename),
-        "r",
     ) as file:
         return file.read()
 
@@ -60,7 +60,7 @@ def read_file_from_test_assets(filename: str) -> str:
 def _get_entries_for_section(
     section: etree.Element,
     namespaces: dict = {"hl7": "urn:hl7-org:v3"},
-) -> List[etree.Element]:
+) -> list[etree.Element]:
     """
     Gets the entries of a section of an eICR and returns a list of <entry> elements.
 

--- a/containers/message-refiner/tests/test_refiner.py
+++ b/containers/message-refiner/tests/test_refiner.py
@@ -1,11 +1,8 @@
 import pathlib
-from unittest.mock import AsyncMock
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from app.main import app
-from app.main import get_clinical_services
+from app.main import app, get_clinical_services
 from fastapi.testclient import TestClient
 from lxml import etree
 
@@ -20,7 +17,7 @@ def parse_file_from_test_assets(filename: str) -> etree.ElementTree:
     :return: An ElementTree containing the contents of the file.
     """
     with open(
-        (pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename), "r"
+        pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename
     ) as file:
         parser = etree.XMLParser(remove_blank_text=True)
         tree = etree.parse(file, parser)
@@ -36,7 +33,6 @@ def read_file_from_test_assets(filename: str) -> str:
     """
     with open(
         (pathlib.Path(__file__).parent.parent / "tests" / "assets" / filename),
-        "r",
     ) as file:
         return file.read()
 

--- a/containers/orchestration/app/base_service.py
+++ b/containers/orchestration/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/orchestration/app/config.py
+++ b/containers/orchestration/app/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     trigger_code_reference_url: str
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -4,39 +4,46 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Body
-from fastapi import File
-from fastapi import Form
-from fastapi import HTTPException
-from fastapi import Response
-from fastapi import status
-from fastapi import UploadFile
-from fastapi import WebSocket
-from fastapi import WebSocketDisconnect
-from opentelemetry import metrics
-from opentelemetry import trace
+from fastapi import (
+    Body,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
+from opentelemetry import metrics, trace
 from opentelemetry.trace.status import StatusCode
 
 from app.base_service import BaseService
 from app.config import get_settings
-from app.constants import process_message_response_examples
-from app.constants import sample_get_config_response
-from app.constants import sample_list_configs_response
-from app.constants import upload_config_response_examples
-from app.models import GetConfigResponse
-from app.models import ListConfigsResponse
-from app.models import OrchestrationRequest
-from app.models import OrchestrationResponse
-from app.models import ProcessingConfigModel
-from app.models import PutConfigResponse
+from app.constants import (
+    process_message_response_examples,
+    sample_get_config_response,
+    sample_list_configs_response,
+    upload_config_response_examples,
+)
+from app.models import (
+    GetConfigResponse,
+    ListConfigsResponse,
+    OrchestrationRequest,
+    OrchestrationResponse,
+    ProcessingConfigModel,
+    PutConfigResponse,
+)
 from app.services import call_apis
-from app.utils import _combine_response_bundles
-from app.utils import _socket_response_is_valid
-from app.utils import load_config_assets
-from app.utils import load_json_from_binary
-from app.utils import load_processing_config
-from app.utils import unzip_http
-from app.utils import unzip_ws
+from app.utils import (
+    _combine_response_bundles,
+    _socket_response_is_valid,
+    load_config_assets,
+    load_json_from_binary,
+    load_processing_config,
+    unzip_http,
+    unzip_ws,
+)
 
 # Integrate main app tracer with automatic instrumentation context
 tracer = trace.get_tracer("orchestration_main_tracer")

--- a/containers/orchestration/app/models.py
+++ b/containers/orchestration/app/models.py
@@ -1,11 +1,6 @@
-from typing import List
-from typing import Literal
-from typing import Optional
-from typing import Union
+from typing import Literal, Optional, Union
 
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import root_validator
+from pydantic import BaseModel, Field, root_validator
 
 
 # Request and response models
@@ -113,10 +108,10 @@ class ListConfigsResponse(BaseModel):
     The config for responses from the /configs endpoint.
     """
 
-    default_configs: List[str] = Field(
+    default_configs: list[str] = Field(
         description="The configs that ship with with this service by default."
     )
-    custom_configs: List[str] = Field(
+    custom_configs: list[str] = Field(
         description="Additional configs that users have uploaded to this service beyond"
         " the ones come by default."
     )
@@ -129,7 +124,7 @@ class WorkflowServiceStepModel(BaseModel):
 
 
 class ProcessingConfigModel(BaseModel):
-    workflow: dict[str, List[WorkflowServiceStepModel]] = Field(
+    workflow: dict[str, list[WorkflowServiceStepModel]] = Field(
         description="A JSON-formatted config dict containing a single key `workflow` "
         "that maps to a list of `WorkflowServiceStep` objects, each defining one step "
         "in the orchestration configuration to upload."

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -2,23 +2,21 @@ import json
 import os
 
 import requests
-from fastapi import HTTPException
-from fastapi import Response
-from fastapi import WebSocket
+from fastapi import HTTPException, Response, WebSocket
 from opentelemetry import trace
 from opentelemetry.trace.status import StatusCode
 
 from app.handlers.request_builders.ecr_viewer import build_save_fhir_data_body
 from app.handlers.request_builders.fhir_converter import build_fhir_converter_request
-from app.handlers.request_builders.ingestion import build_geocoding_request
-from app.handlers.request_builders.ingestion import build_ingestion_dob_request
-from app.handlers.request_builders.ingestion import build_ingestion_name_request
-from app.handlers.request_builders.ingestion import build_ingestion_phone_request
-from app.handlers.request_builders.ingestion import build_validation_request
-from app.handlers.request_builders.message_parser import (
-    build_message_parser_message_request,
+from app.handlers.request_builders.ingestion import (
+    build_geocoding_request,
+    build_ingestion_dob_request,
+    build_ingestion_name_request,
+    build_ingestion_phone_request,
+    build_validation_request,
 )
 from app.handlers.request_builders.message_parser import (
+    build_message_parser_message_request,
     build_message_parser_phdc_request,
 )
 from app.handlers.request_builders.trigger_code_reference import (
@@ -26,10 +24,14 @@ from app.handlers.request_builders.trigger_code_reference import (
 )
 from app.handlers.response_builders.ecr_viewer import unpack_save_fhir_data_response
 from app.handlers.response_builders.fhir_converter import unpack_fhir_converter_response
-from app.handlers.response_builders.ingestion import unpack_ingestion_standardization
-from app.handlers.response_builders.ingestion import unpack_validation_response
-from app.handlers.response_builders.message_parser import unpack_fhir_to_phdc_response
-from app.handlers.response_builders.message_parser import unpack_parsed_message_response
+from app.handlers.response_builders.ingestion import (
+    unpack_ingestion_standardization,
+    unpack_validation_response,
+)
+from app.handlers.response_builders.message_parser import (
+    unpack_fhir_to_phdc_response,
+    unpack_parsed_message_response,
+)
 from app.handlers.response_builders.trigger_code_reference import (
     unpack_stamp_condition_extensions_response,
 )

--- a/containers/orchestration/app/utils.py
+++ b/containers/orchestration/app/utils.py
@@ -4,13 +4,11 @@ import os
 import pathlib
 from functools import cache
 from pathlib import Path
-from typing import Dict
 from typing import Optional
 from zipfile import ZipFile
 
 from dotenv import load_dotenv
-from fastapi import Response
-from fastapi import UploadFile
+from fastapi import Response, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
@@ -36,14 +34,14 @@ def load_processing_config(config_name: str) -> dict:
     """
     custom_config_path = Path(__file__).parent / "custom_configs" / config_name
     try:
-        with open(custom_config_path, "r") as file:
+        with open(custom_config_path) as file:
             processing_config = json.load(file)
     except FileNotFoundError:
         try:
             default_config_path = (
                 Path(__file__).parent / "default_configs" / config_name
             )
-            with open(default_config_path, "r") as file:
+            with open(default_config_path) as file:
                 processing_config = json.load(file)
         except FileNotFoundError:
             raise FileNotFoundError(
@@ -68,17 +66,17 @@ def replace_env_var_placeholders(config: dict) -> None:
             settings["url"] = os.path.expandvars(settings["url"])
 
 
-def read_json_from_assets(filename: str) -> Dict:
+def read_json_from_assets(filename: str) -> dict:
     """
     Loads a JSON file from the 'assets' directory.
 
     :param filename: Name of the JSON file to load.
     :return: Parsed JSON content as a dictionary.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))
 
 
-def unzip_ws(file_bytes) -> Dict:
+def unzip_ws(file_bytes) -> dict:
     """
     Extracts and processes data from a zip file's bytes.
 
@@ -92,7 +90,7 @@ def unzip_ws(file_bytes) -> Dict:
         raise FileNotFoundError("This is not a valid .zip file.")
 
 
-def unzip_http(upload_file: UploadFile) -> Dict:
+def unzip_http(upload_file: UploadFile) -> dict:
     """
     Extracts and processes ECR data from an uploaded zip file.
 
@@ -103,14 +101,14 @@ def unzip_http(upload_file: UploadFile) -> Dict:
     return search_for_ecr_data(zipped_file)
 
 
-def load_json_from_binary(upload_file: UploadFile) -> Dict:
+def load_json_from_binary(upload_file: UploadFile) -> dict:
     """
     Helper method to transform a buffered IO of bytes into a json dictionary.
     """
     return json.load(io.BytesIO(upload_file.file.read()))
 
 
-def search_for_ecr_data(valid_zipfile: ZipFile) -> Dict:
+def search_for_ecr_data(valid_zipfile: ZipFile) -> dict:
     """
     Searches for and extracts eICR and optional RR data from a valid zip file.
 
@@ -152,7 +150,7 @@ def search_for_file_in_zip(filename: str, zipfile: ZipFile) -> Optional[str]:
         return None
 
 
-def load_config_assets(upload_config_response_examples, PutConfigResponse) -> Dict:
+def load_config_assets(upload_config_response_examples, PutConfigResponse) -> dict:
     """
     Loads JSON config assets, updating the input dict in place.
 
@@ -172,7 +170,7 @@ class CustomJSONResponse(JSONResponse):
         self._content = content
         self.url = url
 
-    def json(self) -> Dict:
+    def json(self) -> dict:
         """
         Returns the JSON content as a dictionary.
 

--- a/containers/orchestration/tests/test_configs_endpoint.py
+++ b/containers/orchestration/tests/test_configs_endpoint.py
@@ -21,7 +21,7 @@ def test_get_specific_config():
     test_config_path = (
         Path(__file__).parent.parent / "app" / "default_configs" / "test_config.json"
     )
-    with open(test_config_path, "r") as file:
+    with open(test_config_path) as file:
         test_config = json.load(file)
 
     response = client.get("/configs/test_config.json")

--- a/containers/orchestration/tests/test_handlers.py
+++ b/containers/orchestration/tests/test_handlers.py
@@ -1,29 +1,32 @@
 import json
 import os
 from pathlib import Path
-from unittest.mock import MagicMock
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from app.handlers.request_builders.fhir_converter import build_fhir_converter_request
-from app.handlers.request_builders.ingestion import build_geocoding_request
-from app.handlers.request_builders.ingestion import build_ingestion_dob_request
-from app.handlers.request_builders.ingestion import build_ingestion_name_request
-from app.handlers.request_builders.ingestion import build_ingestion_phone_request
-from app.handlers.request_builders.ingestion import build_validation_request
-from app.handlers.request_builders.message_parser import (
-    build_message_parser_message_request,
+from app.handlers.request_builders.ingestion import (
+    build_geocoding_request,
+    build_ingestion_dob_request,
+    build_ingestion_name_request,
+    build_ingestion_phone_request,
+    build_validation_request,
 )
 from app.handlers.request_builders.message_parser import (
+    build_message_parser_message_request,
     build_message_parser_phdc_request,
 )
 from app.handlers.request_builders.trigger_code_reference import (
     build_stamp_condition_extensions_request,
 )
 from app.handlers.response_builders.fhir_converter import unpack_fhir_converter_response
-from app.handlers.response_builders.ingestion import unpack_ingestion_standardization
-from app.handlers.response_builders.ingestion import unpack_validation_response
-from app.handlers.response_builders.message_parser import unpack_fhir_to_phdc_response
-from app.handlers.response_builders.message_parser import unpack_parsed_message_response
+from app.handlers.response_builders.ingestion import (
+    unpack_ingestion_standardization,
+    unpack_validation_response,
+)
+from app.handlers.response_builders.message_parser import (
+    unpack_fhir_to_phdc_response,
+    unpack_parsed_message_response,
+)
 from app.handlers.response_builders.trigger_code_reference import (
     unpack_stamp_condition_extensions_response,
 )

--- a/containers/orchestration/tests/test_process_message_endpoint.py
+++ b/containers/orchestration/tests/test_process_message_endpoint.py
@@ -17,10 +17,10 @@ test_config_path = (
 
 fhir_bundle_path = Path(__file__).parent / "assets" / "patient_bundle.json"
 
-with open(fhir_bundle_path, "r") as file:
+with open(fhir_bundle_path) as file:
     fhir_bundle = json.load(file)
 
-with open(test_config_path, "r") as file:
+with open(test_config_path) as file:
     test_config = json.load(file)
 
 

--- a/containers/orchestration/tests/test_utils.py
+++ b/containers/orchestration/tests/test_utils.py
@@ -5,10 +5,12 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from app.utils import _combine_response_bundles
-from app.utils import load_processing_config
-from app.utils import replace_env_var_placeholders
-from app.utils import search_for_ecr_data
+from app.utils import (
+    _combine_response_bundles,
+    load_processing_config,
+    replace_env_var_placeholders,
+    search_for_ecr_data,
+)
 from fastapi import Response
 
 
@@ -16,7 +18,7 @@ def test_load_processing_config_success():
     test_config_path = (
         Path(__file__).parent.parent / "app" / "default_configs" / "test_config.json"
     )
-    with open(test_config_path, "r") as file:
+    with open(test_config_path) as file:
         test_config = json.load(file)
 
     config = load_processing_config("test_config.json")

--- a/containers/record-linkage/app/base_service.py
+++ b/containers/record-linkage/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/record-linkage/app/config.py
+++ b/containers/record-linkage/app/config.py
@@ -1,8 +1,7 @@
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import BaseSettings
-from pydantic import Field
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
@@ -33,7 +32,7 @@ class Settings(BaseSettings):
     )
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/record-linkage/app/linkage/config.py
+++ b/containers/record-linkage/app/linkage/config.py
@@ -12,7 +12,7 @@ class DBSettings(BaseSettings):
     mpi_port: str
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/containers/record-linkage/app/linkage/core.py
+++ b/containers/record-linkage/app/linkage/core.py
@@ -1,6 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
-from typing import List
+from abc import ABC, abstractmethod
 
 from sqlalchemy import Select
 
@@ -14,7 +12,7 @@ class BaseMPIConnectorClient(ABC):
     """
 
     @abstractmethod
-    def get_block_data() -> List[list]:
+    def get_block_data() -> list[list]:
         """
         Returns a list of lists containing records from the MPI database that
         match on the incoming record's block criteria and values. If blocking

--- a/containers/record-linkage/app/linkage/dal.py
+++ b/containers/record-linkage/app/linkage/dal.py
@@ -1,18 +1,12 @@
 import datetime
 import logging
 from contextlib import contextmanager
-from typing import List
 
-from sqlalchemy import create_engine
-from sqlalchemy import MetaData
-from sqlalchemy import select
-from sqlalchemy import Table
-from sqlalchemy import text
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import MetaData, Table, create_engine, select, text
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 
-class DataAccessLayer(object):
+class DataAccessLayer:
     """
     Base class for Database API objects - manages transactions,
     sessions and holds a reference to the engine.
@@ -169,7 +163,7 @@ class DataAccessLayer(object):
                         logging.info(
                             f"""Starting statement execution getting
                               new_primary_key for record #{n_records}at:
-                                {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
                         new_primary_key = session.execute(statement)
                         # TODO: I don't like this, but seems to
@@ -178,7 +172,7 @@ class DataAccessLayer(object):
                         # PK defined in the table and that doesn't work
                         logging.info(
                             f""" Done with statement execution getting new_primary_key
-                              for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                              for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
                         new_primary_keys.append(new_primary_key.first()[0])
                     else:
@@ -190,7 +184,7 @@ class DataAccessLayer(object):
                         session.execute(statement)
                         logging.info(
                             f"""Done with statement execution
-                              for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                              for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
         return new_primary_keys
 
@@ -247,7 +241,7 @@ class DataAccessLayer(object):
                                 logging.info(
                                     f"""Starting statement execution getting
                                     new_primary_key for record #{n_records}at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
                                 new_primary_key = session.execute(statement)
                                 # TODO: I don't like this, but seems to
@@ -256,14 +250,14 @@ class DataAccessLayer(object):
                                 # PK defined in the table and that doesn't work
                                 logging.info(
                                     f""" Done with statement execution getting new_primary_key
-                                    for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                    for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
                                 new_primary_keys.append(new_primary_key.first()[0])
                             else:
                                 logging.info("Did not return primary keys")
                                 logging.info(
                                     f"""Starting statement creation for record #{n_records} at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
 
                                 if "dob" in record:
@@ -285,7 +279,7 @@ class DataAccessLayer(object):
                                 statements.append(statement)
                                 logging.info(
                                     f"""Done with statement creation for record #{n_records} at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
 
                     return_results[table.name] = {"primary_keys": new_primary_keys}
@@ -303,7 +297,7 @@ class DataAccessLayer(object):
 
     def select_results(
         self, select_statement: select, include_col_header: bool = True
-    ) -> List[list]:
+    ) -> list[list]:
         """
         Perform a select query and add the results to a
         list of lists.  Then add the column header as the

--- a/containers/record-linkage/app/linkage/link.py
+++ b/containers/record-linkage/app/linkage/link.py
@@ -4,17 +4,16 @@ import hashlib
 import json
 import logging
 import pathlib
-from typing import Callable
-from typing import List
-from typing import Union
+from typing import Callable, Union
 
 from pydantic import Field
 
-from app.linkage.mpi import BaseMPIConnectorClient
-from app.linkage.mpi import DIBBsMPIConnectorClient
-from app.linkage.utils import compare_strings
-from app.linkage.utils import datetime_to_str
-from app.linkage.utils import extract_value_with_resource_path
+from app.linkage.mpi import BaseMPIConnectorClient, DIBBsMPIConnectorClient
+from app.linkage.utils import (
+    compare_strings,
+    datetime_to_str,
+    extract_value_with_resource_path,
+)
 
 LINKING_FIELDS_TO_FHIRPATHS = {
     "first_name": "Patient.name.given",
@@ -29,7 +28,7 @@ LINKING_FIELDS_TO_FHIRPATHS = {
 }
 
 
-def compile_match_lists(match_lists: List[dict], cluster_mode: bool = False):
+def compile_match_lists(match_lists: list[dict], cluster_mode: bool = False):
     """
     Turns a list of matches of either clusters or candidate pairs found
     during linkage into a single unified structure holding all found matches
@@ -67,7 +66,7 @@ def compile_match_lists(match_lists: List[dict], cluster_mode: bool = False):
     return matches
 
 
-def eval_perfect_match(feature_comparisons: List, **kwargs) -> bool:
+def eval_perfect_match(feature_comparisons: list, **kwargs) -> bool:
     """
     Determines whether a given set of feature comparisons represent a
     'perfect' match (i.e. whether all features that were compared match
@@ -80,7 +79,7 @@ def eval_perfect_match(feature_comparisons: List, **kwargs) -> bool:
     return sum(feature_comparisons) == len(feature_comparisons)
 
 
-def eval_log_odds_cutoff(feature_comparisons: List, **kwargs) -> bool:
+def eval_log_odds_cutoff(feature_comparisons: list, **kwargs) -> bool:
     """
     Determines whether a given set of feature comparisons matches enough
     to be the result of a true patient link instead of just random chance.
@@ -97,7 +96,7 @@ def eval_log_odds_cutoff(feature_comparisons: List, **kwargs) -> bool:
 
 
 def extract_blocking_values_from_record(
-    record: dict, blocking_fields: List[dict]
+    record: dict, blocking_fields: list[dict]
 ) -> dict:
     """
     Extracts values from a given patient record for eventual use in database
@@ -187,8 +186,8 @@ def extract_blocking_values_from_record(
 
 
 def feature_match_exact(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -209,8 +208,8 @@ def feature_match_exact(
 
 
 def feature_match_four_char(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -233,8 +232,8 @@ def feature_match_four_char(
 
 
 def feature_match_fuzzy_string(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -276,8 +275,8 @@ def feature_match_fuzzy_string(
 
 
 def feature_match_log_odds_exact(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -306,8 +305,8 @@ def feature_match_log_odds_exact(
 
 
 def feature_match_log_odds_fuzzy_compare(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -363,7 +362,7 @@ def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
 
 def link_record_against_mpi(
     record: dict,
-    algo_config: List[dict],
+    algo_config: list[dict],
     external_person_id: str = None,
     mpi_client: BaseMPIConnectorClient = None,
 ) -> tuple[bool, str]:
@@ -542,7 +541,7 @@ def load_json_probs(path: pathlib.Path):
     :raises JSONDecodeError: If the file cannot be read as valid JSON.
     """
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             prob_dict = json.load(file)
         return prob_dict
     except FileNotFoundError:
@@ -554,12 +553,12 @@ def load_json_probs(path: pathlib.Path):
 
 
 def match_within_block(
-    block: List[List],
+    block: list[list],
     feature_funcs: dict[str, Callable],
     col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
-) -> List[tuple]:
+) -> list[tuple]:
     """
     Performs matching on all candidate pairs of records within a given block
     of data. Actual partitioning of the data should be done outside this
@@ -615,7 +614,7 @@ def match_within_block(
     return match_pairs
 
 
-def read_linkage_config(config_file: pathlib.Path) -> List[dict]:
+def read_linkage_config(config_file: pathlib.Path) -> list[dict]:
     """
     Reads and generates a record linkage algorithm configuration list from
     the provided filepath, which should point to a JSON file. A record
@@ -724,7 +723,7 @@ def score_linkage_vs_truth(
     return (sensitivity, specificity, ppv, f1)
 
 
-def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) -> None:
+def write_linkage_config(linkage_algo: list[dict], file_to_write: pathlib.Path) -> None:
     """
     Save a provided algorithm description as a JSON dictionary at the provided
     filepath location. Algorithm descriptions are lists of dictionaries, one
@@ -767,7 +766,7 @@ def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) 
         out.write(json.dumps(linkage_json))
 
 
-def _bind_func_names_to_invocations(algo_config: List[dict]):
+def _bind_func_names_to_invocations(algo_config: list[dict]):
     """
     Helper method that re-maps the string names of functions to their
     callable invocations as defined within the `link.py` module.
@@ -783,7 +782,7 @@ def _bind_func_names_to_invocations(algo_config: List[dict]):
 
 
 def _eval_record_in_cluster(
-    block: List[List],
+    block: list[list],
     i: int,
     cluster: set,
     cluster_ratio: float,
@@ -817,8 +816,8 @@ def _eval_record_in_cluster(
 
 
 def _compare_records(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     col_to_idx: dict[str, int],
     matching_rule: callable,
@@ -847,8 +846,8 @@ def _compare_records(
 
 
 def _compare_records_field_helper(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     feature_funcs: dict,
@@ -869,8 +868,8 @@ def _compare_records_field_helper(
 
 
 def _compare_address_elements(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     feature_col: str,
     col_to_idx: dict[str, int],
@@ -893,8 +892,8 @@ def _compare_address_elements(
 
 
 def _compare_name_elements(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     feature_col: str,
     col_to_idx: dict[str, int],
@@ -958,7 +957,7 @@ def _find_strongest_link(linkage_scores: dict) -> str:
     return best_person
 
 
-def _flatten_patient_resource(resource: dict, col_to_idx: dict) -> List:
+def _flatten_patient_resource(resource: dict, col_to_idx: dict) -> list:
     """
     Helper method that flattens an incoming patient resource into a list whose
     elements are the keys of the FHIR dictionary, reformatted and ordered
@@ -1027,7 +1026,7 @@ def _get_fuzzy_params(col: str, **kwargs) -> tuple[str, str]:
     return similarity_measure, threshold
 
 
-def _group_patient_block_by_person(data_block: List[list]) -> dict[str, List]:
+def _group_patient_block_by_person(data_block: list[list]) -> dict[str, list]:
     """
     Helper method that partitions the block of patient data returned from the MPI
     into clusters of records according to their linked Person ID.
@@ -1042,8 +1041,8 @@ def _group_patient_block_by_person(data_block: List[list]) -> dict[str, List]:
 
 
 def _map_matches_to_record_ids(
-    match_list: Union[List[tuple], List[set]], data_block, cluster_mode: bool = False
-) -> List[tuple]:
+    match_list: Union[list[tuple], list[set]], data_block, cluster_mode: bool = False
+) -> list[tuple]:
     """
     Helper function to turn a list of tuples of row indices in a block
     of data into a list of tuples of the IDs of the records within
@@ -1067,13 +1066,13 @@ def _map_matches_to_record_ids(
 
 
 def _match_within_block_cluster_ratio(
-    block: List[List],
+    block: list[list],
     cluster_ratio: float,
     feature_funcs: dict[str, Callable],
     col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
-) -> List[set]:
+) -> list[set]:
     """
     A matching function for statistically testing the impact of membership
     ratio to the quality of clusters formed. This function behaves similarly

--- a/containers/record-linkage/app/linkage/mpi.py
+++ b/containers/record-linkage/app/linkage/mpi.py
@@ -2,21 +2,14 @@ import datetime
 import logging
 import uuid
 from functools import cache
-from typing import Dict
-from typing import List
 from typing import Union
 
-from sqlalchemy import and_
-from sqlalchemy import Select
-from sqlalchemy import select
-from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import aggregate_order_by
-from sqlalchemy.dialects.postgresql import array_agg
+from sqlalchemy import Select, and_, select, text
+from sqlalchemy.dialects.postgresql import aggregate_order_by, array_agg
 
 from app.linkage.core import BaseMPIConnectorClient
 from app.linkage.dal import DataAccessLayer
-from app.linkage.utils import extract_value_with_resource_path
-from app.linkage.utils import load_mpi_env_vars_os
+from app.linkage.utils import extract_value_with_resource_path, load_mpi_env_vars_os
 
 
 class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
@@ -116,7 +109,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
             },
         }
 
-    def get_block_data(self, block_criteria: Dict) -> List[list]:
+    def get_block_data(self, block_criteria: dict) -> list[list]:
         """
         Returns a list of lists containing records from the MPI database that
         match on the incoming record's block criteria and values. If blocking
@@ -182,7 +175,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
 
     def insert_matched_patient(
         self,
-        patient_resource: Dict,
+        patient_resource: dict,
         person_id=None,
         external_person_id=None,
     ) -> str:
@@ -234,12 +227,12 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
             if external_person_id is not None:
                 logging.info(
                     f"""external_person_id was not None;
-                      starting _insert_external_person_id at:{datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                      starting _insert_external_person_id at:{datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                 )
                 self._insert_external_person_id(person_id, external_person_id)
                 logging.info(
                     f"""external_person_id was not None;
-                      done with _insert_external_person_id at:{datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                      done with _insert_external_person_id at:{datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                 )
         except Exception as error:  # pragma: no cover
             raise ValueError(f"{error}")
@@ -648,8 +641,8 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
         return external_source_id
 
     def _generate_dict_record_from_results(
-        self, results_list: List[list]
-    ) -> List[dict]:
+        self, results_list: list[list]
+    ) -> list[dict]:
         """
         Converts a list of list of records into a
         dictionary using the column name header, in the

--- a/containers/record-linkage/app/linkage/seed.py
+++ b/containers/record-linkage/app/linkage/seed.py
@@ -1,11 +1,9 @@
 # This script converts patient data from parquet to patient FHIR resources.
 import uuid
 from datetime import datetime
-from typing import Dict
-from typing import Tuple
 
 
-def extract_given_name(data: Dict):
+def extract_given_name(data: dict):
     """
     Extracts given names from `data`.
 
@@ -28,7 +26,7 @@ def extract_given_name(data: Dict):
         return None
 
 
-def adjust_birthdate(data: Dict):
+def adjust_birthdate(data: dict):
     """
     Converts birthdate format in `data` to 'YYYY-MM-DD'.
 
@@ -45,7 +43,7 @@ def adjust_birthdate(data: Dict):
     return dob
 
 
-def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
+def convert_to_patient_fhir_resources(data: dict) -> tuple:
     """
     Converts and returns a row of patient data into patient resource in a FHIR-formatted
     patient resouce with a newly generated patient id as well as the

--- a/containers/record-linkage/app/linkage/utils.py
+++ b/containers/record-linkage/app/linkage/utils.py
@@ -1,13 +1,8 @@
 import json
 import random
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 from functools import cache
-from typing import Any
-from typing import Callable
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Any, Callable, Literal, Union
 
 import fhirpathpy
 import rapidfuzz
@@ -146,9 +141,9 @@ selection_criteria_types = Literal["first", "last", "random", "all"]
 
 
 def apply_selection_criteria(
-    value: List[Any],
+    value: list[Any],
     selection_criteria: selection_criteria_types,
-) -> str | List:
+) -> str | list:
     """
     Returns value(s), according to the selection criteria, from a given list of values
     parsed from a FHIR resource. A single string value is returned - if the selected

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -1,23 +1,15 @@
 import copy
 from pathlib import Path
-from typing import Annotated
-from typing import Optional
+from typing import Annotated, Optional
 
-from fastapi import Body
-from fastapi import Response
-from fastapi import status
-from pydantic import BaseModel
-from pydantic import Field
+from fastapi import Body, Response, status
+from pydantic import BaseModel, Field
 
 from app.base_service import BaseService
-from app.linkage.algorithms import DIBBS_BASIC
-from app.linkage.algorithms import DIBBS_ENHANCED
-from app.linkage.link import add_person_resource
-from app.linkage.link import link_record_against_mpi
+from app.linkage.algorithms import DIBBS_BASIC, DIBBS_ENHANCED
+from app.linkage.link import add_person_resource, link_record_against_mpi
 from app.linkage.mpi import DIBBsMPIConnectorClient
-from app.utils import get_settings
-from app.utils import read_json_from_assets
-from app.utils import run_migrations
+from app.utils import get_settings, read_json_from_assets, run_migrations
 
 # Ensure MPI is configured as expected.
 run_migrations()

--- a/containers/record-linkage/app/utils.py
+++ b/containers/record-linkage/app/utils.py
@@ -16,7 +16,7 @@ def read_json_from_assets(filename: str):
     """
     Loads a JSON file from the 'assets' directory.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))
 
 
 def run_pyway(

--- a/containers/record-linkage/tests/test_dal.py
+++ b/containers/record-linkage/tests/test_dal.py
@@ -5,10 +5,7 @@ import pathlib
 from app.linkage.dal import DataAccessLayer
 from app.linkage.mpi import DIBBsMPIConnectorClient
 from app.utils import _clean_up
-from sqlalchemy import Engine
-from sqlalchemy import select
-from sqlalchemy import Table
-from sqlalchemy import text
+from sqlalchemy import Engine, Table, select, text
 
 
 def _init_db() -> DataAccessLayer:

--- a/containers/record-linkage/tests/test_linkage.py
+++ b/containers/record-linkage/tests/test_linkage.py
@@ -3,41 +3,40 @@ import json
 import os
 import pathlib
 import uuid
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 from json.decoder import JSONDecodeError
 
 import pytest
-from app.linkage.algorithms import DIBBS_BASIC
-from app.linkage.algorithms import DIBBS_ENHANCED
+from app.linkage.algorithms import DIBBS_BASIC, DIBBS_ENHANCED
 from app.linkage.dal import DataAccessLayer
-from app.linkage.link import _compare_address_elements
-from app.linkage.link import _compare_name_elements
-from app.linkage.link import _condense_extract_address_from_resource
-from app.linkage.link import _convert_given_name_to_first_name
-from app.linkage.link import _flatten_patient_resource
-from app.linkage.link import _get_fuzzy_params
-from app.linkage.link import _match_within_block_cluster_ratio
-from app.linkage.link import add_person_resource
-from app.linkage.link import eval_log_odds_cutoff
-from app.linkage.link import eval_perfect_match
-from app.linkage.link import extract_blocking_values_from_record
-from app.linkage.link import feature_match_exact
-from app.linkage.link import feature_match_four_char
-from app.linkage.link import feature_match_fuzzy_string
-from app.linkage.link import feature_match_log_odds_exact
-from app.linkage.link import feature_match_log_odds_fuzzy_compare
-from app.linkage.link import generate_hash_str
-from app.linkage.link import link_record_against_mpi
-from app.linkage.link import load_json_probs
-from app.linkage.link import match_within_block
-from app.linkage.link import read_linkage_config
-from app.linkage.link import score_linkage_vs_truth
-from app.linkage.link import write_linkage_config
+from app.linkage.link import (
+    _compare_address_elements,
+    _compare_name_elements,
+    _condense_extract_address_from_resource,
+    _convert_given_name_to_first_name,
+    _flatten_patient_resource,
+    _get_fuzzy_params,
+    _match_within_block_cluster_ratio,
+    add_person_resource,
+    eval_log_odds_cutoff,
+    eval_perfect_match,
+    extract_blocking_values_from_record,
+    feature_match_exact,
+    feature_match_four_char,
+    feature_match_fuzzy_string,
+    feature_match_log_odds_exact,
+    feature_match_log_odds_fuzzy_compare,
+    generate_hash_str,
+    link_record_against_mpi,
+    load_json_probs,
+    match_within_block,
+    read_linkage_config,
+    score_linkage_vs_truth,
+    write_linkage_config,
+)
 from app.linkage.mpi import DIBBsMPIConnectorClient
 from app.utils import _clean_up
-from sqlalchemy import select
-from sqlalchemy import text
+from sqlalchemy import select, text
 
 
 def _init_db() -> DataAccessLayer:
@@ -1117,14 +1116,14 @@ def test_multi_element_blocking():
 
 
 def test_convert_given_name_to_first_name():
-    assert (
-        _convert_given_name_to_first_name([]) == []
-    ), "Empty data should return empty data"
+    assert _convert_given_name_to_first_name([]) == [], (
+        "Empty data should return empty data"
+    )
 
     data = [["last_name"], ["LENNON"], ["MCCARTNEY"], ["HARRISON"], ["STARKLEY"]]
-    assert (
-        _convert_given_name_to_first_name(data) == data
-    ), "Data without given names should return the same data"
+    assert _convert_given_name_to_first_name(data) == data, (
+        "Data without given names should return the same data"
+    )
 
     data = [
         [

--- a/containers/record-linkage/tests/test_linkage_utils.py
+++ b/containers/record-linkage/tests/test_linkage_utils.py
@@ -1,5 +1,4 @@
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
 from app.linkage.link import datetime_to_str

--- a/containers/record-linkage/tests/test_mpi.py
+++ b/containers/record-linkage/tests/test_mpi.py
@@ -9,9 +9,7 @@ import pytest
 from app.linkage.dal import DataAccessLayer
 from app.linkage.mpi import DIBBsMPIConnectorClient
 from app.utils import _clean_up
-from sqlalchemy import Select
-from sqlalchemy import select
-from sqlalchemy import text
+from sqlalchemy import Select, select, text
 
 patient_resource = json.load(
     open(

--- a/containers/record-linkage/tests/test_seed.py
+++ b/containers/record-linkage/tests/test_seed.py
@@ -1,9 +1,11 @@
 import pathlib
 
 import pyarrow.parquet as pq
-from app.linkage.seed import adjust_birthdate
-from app.linkage.seed import convert_to_patient_fhir_resources
-from app.linkage.seed import extract_given_name
+from app.linkage.seed import (
+    adjust_birthdate,
+    convert_to_patient_fhir_resources,
+    extract_given_name,
+)
 
 mpi_test_file_path = (
     pathlib.Path(__file__).parent.parent.parent.parent

--- a/containers/record-linkage/tests/test_utils.py
+++ b/containers/record-linkage/tests/test_utils.py
@@ -4,8 +4,7 @@ from typing import Literal
 from unittest import mock
 
 import pytest
-from app.utils import run_migrations
-from app.utils import run_pyway
+from app.utils import run_migrations, run_pyway
 
 MOCK_SETTINGS = {
     "mpi_db_type": "postgres",

--- a/containers/trigger-code-reference/app/base_service.py
+++ b/containers/trigger-code-reference/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/trigger-code-reference/app/main.py
+++ b/containers/trigger-code-reference/app/main.py
@@ -2,19 +2,19 @@ import string
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Body
-from fastapi import Query
-from fastapi import Response
+from fastapi import Body, Query, Response
 
 from app.base_service import BaseService
 from app.models import InsertConditionInput
-from app.utils import _find_codes_by_resource_type
-from app.utils import add_code_extension_and_human_readable_name
-from app.utils import find_conditions
-from app.utils import get_clean_snomed_code
-from app.utils import get_concepts_dict
-from app.utils import get_concepts_list
-from app.utils import read_json_from_assets
+from app.utils import (
+    _find_codes_by_resource_type,
+    add_code_extension_and_human_readable_name,
+    find_conditions,
+    get_clean_snomed_code,
+    get_concepts_dict,
+    get_concepts_list,
+    read_json_from_assets,
+)
 
 RESOURCE_TO_SERVICE_TYPES = {
     "Observation": ["dxtc", "ostc", "lotc", "lrtc", "mrtc", "sdtc"],

--- a/containers/trigger-code-reference/app/models.py
+++ b/containers/trigger-code-reference/app/models.py
@@ -1,5 +1,4 @@
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 
 class InsertConditionInput(BaseModel):

--- a/containers/trigger-code-reference/app/utils.py
+++ b/containers/trigger-code-reference/app/utils.py
@@ -1,7 +1,6 @@
 import json
 import sqlite3
 from pathlib import Path
-from typing import List
 from typing import Union
 
 import fhirpathpy
@@ -48,7 +47,7 @@ def get_clean_snomed_code(snomed_code: Union[list, str, int, float]) -> list:
     return clean_snomed_code
 
 
-def format_icd9_crosswalks(db_list: List[tuple]) -> List[tuple]:
+def format_icd9_crosswalks(db_list: list[tuple]) -> list[tuple]:
     """
     Utility function to transform the returned tuple rows from the DB into a
     list of properly formatted three-part tuples. This function handles ICD-9
@@ -72,7 +71,7 @@ def format_icd9_crosswalks(db_list: List[tuple]) -> List[tuple]:
     return formatted_list
 
 
-def get_concepts_list(snomed_code: list) -> List[tuple]:
+def get_concepts_list(snomed_code: list) -> list[tuple]:
     """
     Given a SNOMED code, this function runs a SQL query that joins
     conditions to value sets, then uses the value set ids to get the
@@ -103,8 +102,8 @@ def get_concepts_list(snomed_code: list) -> List[tuple]:
         valueset_to_concept vc ON vs.id = vc.valueset_id
     LEFT JOIN
         concepts cs ON vc.concept_id = cs.id
-    LEFT JOIN 
-        (SELECT icd10_code, GROUP_CONCAT(icd9_code, '|') AS icd9_conversions from icd_crosswalk GROUP BY icd10_code) ON gem_formatted_code = icd10_code 
+    LEFT JOIN
+        (SELECT icd10_code, GROUP_CONCAT(icd9_code, '|') AS icd9_conversions from icd_crosswalk GROUP BY icd10_code) ON gem_formatted_code = icd10_code
     WHERE
         c.id = ?
     GROUP BY
@@ -132,7 +131,7 @@ def get_concepts_list(snomed_code: list) -> List[tuple]:
 
 
 def get_concepts_dict(
-    concept_list: List[tuple],
+    concept_list: list[tuple],
     filter_concept_list: Union[str, list] = None,
 ) -> dict:
     """
@@ -172,7 +171,7 @@ def get_concepts_dict(
     return concept_dict
 
 
-def _find_codes_by_resource_type(resource: dict) -> List[str]:
+def _find_codes_by_resource_type(resource: dict) -> list[str]:
     """
     For a given resource, extracts the chief clinical codes within the
     resource body. The FHIRpath location of this resource depends on the
@@ -261,7 +260,7 @@ def read_json_from_assets(filename: str) -> dict:
     :param filename: The name of the file to read.
     :return: A dictionary containing the contents of the file.
     """
-    return json.load(open((Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(Path(__file__).parent.parent / "assets" / filename))
 
 
 def find_conditions(bundle: dict) -> set[str]:

--- a/containers/trigger-code-reference/seed-scripts/seed-ersd-database.py
+++ b/containers/trigger-code-reference/seed-scripts/seed-ersd-database.py
@@ -5,13 +5,10 @@ import sqlite3
 import string
 import time
 from pathlib import Path
-from typing import List
-from typing import Tuple
 
 import docker
 import requests
-from docker.errors import APIError
-from docker.errors import BuildError
+from docker.errors import APIError, BuildError
 from docker.models.containers import Container
 from dotenv import load_dotenv
 from requests.auth import HTTPBasicAuth
@@ -88,7 +85,7 @@ def load_ersd_schema(ports: dict):
     Loads the ersd.json to the message-parser endpoint to use to parse eRSD
     :param ports: port for the message-parser endpoint URL
     """
-    with open("seed-scripts/config/ersd.json", "r") as json_file:
+    with open("seed-scripts/config/ersd.json") as json_file:
         ersd_schema = json.load(json_file)
     # Create payload to upload the schema to message-parser
     url = f"http://localhost:{list(ports.values())[0]}/schemas/ersd.json"
@@ -167,7 +164,7 @@ def build_valuesets_dict(data: dict) -> dict:
     return valuesets_dict
 
 
-def check_id_uniqueness(list_of_lists: List[List[str]]) -> bool:
+def check_id_uniqueness(list_of_lists: list[list[str]]) -> bool:
     """This is a helper function that confirms that the first item
     in each list of the lists of lists is unique. This is needed to
     confirm that the assumptions we have about tables with a unique primary
@@ -185,7 +182,7 @@ def check_id_uniqueness(list_of_lists: List[List[str]]) -> bool:
 def build_valuesets_table(
     data: dict,
     valuesets_dict: dict,
-) -> Tuple[List[List[str]], List[List[str]]]:
+) -> tuple[list[list[str]], list[list[str]]]:
     """
     Look through eRSD json to create valuesets table, where the primary key
     is the valueset_id that contains the name and codes for each service.
@@ -237,7 +234,7 @@ def build_valuesets_table(
         return [], []
 
 
-def build_conditions_table(data: dict) -> List[List[str]]:
+def build_conditions_table(data: dict) -> list[list[str]]:
     """
     Look through eRSD json to create conditions table, where the primary key
     is a SNOMED condition code and has the name and system for each condition.
@@ -280,7 +277,7 @@ def build_conditions_table(data: dict) -> List[List[str]]:
 def build_concepts_table(
     data: dict,
     valuesets_dict: dict,
-) -> Tuple[List[List[str]], List[List[str]], dict]:
+) -> tuple[list[list[str]], list[list[str]], dict]:
     """
     This builds the table for concepts, which has a unique row for
     each unique valueset_id-concept code combination.
@@ -333,7 +330,7 @@ def build_crosswalk_table():
     """
     table_rows = []
     row_id = 1
-    with open("seed-scripts/diagnosis_gems_2018/2018_I10gem.txt", "r") as gem:
+    with open("seed-scripts/diagnosis_gems_2018/2018_I10gem.txt") as gem:
         for row in gem:
             line = row.strip()
             if line != "":
@@ -355,7 +352,7 @@ def apply_migration(connection: sqlite3.Connection, migration_file: str):
     :param connection: sqlite3 connection
     :param migration_file: location of the .sql file to execute
     """
-    with open(migration_file, "r") as file:
+    with open(migration_file) as file:
         sql_script = file.read()
     cursor = connection.cursor()
     try:
@@ -384,7 +381,7 @@ def delete_table(connection: sqlite3.Connection, table_name: str):
 def load_table(
     connection: sqlite3.Connection,
     table_name: str,
-    insert_rows: List[List[str]],
+    insert_rows: list[list[str]],
     auto_increment_id: bool = False,
 ):
     """

--- a/containers/trigger-code-reference/tests/conftest.py
+++ b/containers/trigger-code-reference/tests/conftest.py
@@ -12,7 +12,7 @@ def read_json_from_test_assets():
         """
         Reads a JSON file from the test assets directory.
         """
-        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+        with open(Path(__file__).parent / "assets" / filename) as file:
             return json.load(file)
 
     return _read_json

--- a/containers/trigger-code-reference/tests/test_utils.py
+++ b/containers/trigger-code-reference/tests/test_utils.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from app.utils import _find_codes_by_resource_type
-from app.utils import add_code_extension_and_human_readable_name
-from app.utils import convert_inputs_to_list
-from app.utils import get_clean_snomed_code
-from app.utils import get_concepts_dict
-from app.utils import get_concepts_list
+from app.utils import (
+    _find_codes_by_resource_type,
+    add_code_extension_and_human_readable_name,
+    convert_inputs_to_list,
+    get_clean_snomed_code,
+    get_concepts_dict,
+    get_concepts_list,
+)
 
 
 @pytest.fixture

--- a/containers/validation/app/base_service.py
+++ b/containers/validation/app/base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from fastapi import FastAPI
-from fastapi import Request
-from fastapi import Response
+from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and

--- a/containers/validation/app/constants.py
+++ b/containers/validation/app/constants.py
@@ -1,8 +1,6 @@
-from typing import Literal
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 
 # Request and and response models

--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -4,12 +4,13 @@ from typing import Annotated
 from fastapi import Body
 
 from app.base_service import BaseService
-from app.constants import ValidateInput
-from app.constants import ValidateResponse
-from app.utils import check_for_and_extract_rr_data
-from app.utils import load_ecr_config
-from app.utils import read_json_from_assets
-from app.utils import validate_error_types
+from app.constants import ValidateInput, ValidateResponse
+from app.utils import (
+    check_for_and_extract_rr_data,
+    load_ecr_config,
+    read_json_from_assets,
+    validate_error_types,
+)
 from app.validation.validation import validate_ecr
 
 # TODO: Remove hard coded location for config path

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -3,8 +3,7 @@ import pathlib
 import re
 
 import yaml
-from fastapi import HTTPException
-from fastapi import status
+from fastapi import HTTPException, status
 from lxml.etree import XMLSyntaxError
 
 from app.fhir.conversion import add_rr_data_to_eicr
@@ -47,7 +46,7 @@ def load_ecr_config(file_path: pathlib.Path = None) -> dict:
             path = file_path
 
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             if path.suffix == ".yaml":
                 config = yaml.safe_load(file)
                 if not validate_config(config):
@@ -151,4 +150,4 @@ def read_json_from_assets(filename: str):
     :raises FileNotFoundError: If the file is not in the assets directory.
     :raises JSONDecodeError: If the file content is not valid JSON.
     """
-    return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+    return json.load(open(pathlib.Path(__file__).parent.parent / "assets" / filename))

--- a/containers/validation/app/validation/__init__.py
+++ b/containers/validation/app/validation/__init__.py
@@ -1,23 +1,27 @@
-from app.validation.validation import _add_message_ids
-from app.validation.validation import _append_error_message
-from app.validation.validation import _clear_all_errors_and_ids
-from app.validation.validation import _organize_error_messages
-from app.validation.validation import _response_builder
-from app.validation.validation import validate_ecr
-from app.validation.xml_utils import _check_xml_names_and_attribs_exist
-from app.validation.xml_utils import _get_ecr_custom_message
-from app.validation.xml_utils import _get_xml_attributes
-from app.validation.xml_utils import _get_xml_message_id
-from app.validation.xml_utils import _get_xml_relative_iterator
-from app.validation.xml_utils import _get_xml_relatives_details
-from app.validation.xml_utils import _validate_xml_related_element
-from app.validation.xml_utils import _validate_xml_relatives
-from app.validation.xml_utils import ECR_NAMESPACES
-from app.validation.xml_utils import get_ecr_message_ids
-from app.validation.xml_utils import get_xml_element_details
-from app.validation.xml_utils import validate_xml_attributes
-from app.validation.xml_utils import validate_xml_elements
-from app.validation.xml_utils import validate_xml_value
+from app.validation.validation import (
+    _add_message_ids,
+    _append_error_message,
+    _clear_all_errors_and_ids,
+    _organize_error_messages,
+    _response_builder,
+    validate_ecr,
+)
+from app.validation.xml_utils import (
+    ECR_NAMESPACES,
+    _check_xml_names_and_attribs_exist,
+    _get_ecr_custom_message,
+    _get_xml_attributes,
+    _get_xml_message_id,
+    _get_xml_relative_iterator,
+    _get_xml_relatives_details,
+    _validate_xml_related_element,
+    _validate_xml_relatives,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 
 __all__ = [
     "validate_ecr",

--- a/containers/validation/app/validation/validation.py
+++ b/containers/validation/app/validation/validation.py
@@ -1,11 +1,13 @@
 from lxml import etree
 
-from app.validation.xml_utils import ECR_NAMESPACES
-from app.validation.xml_utils import get_ecr_message_ids
-from app.validation.xml_utils import get_xml_element_details
-from app.validation.xml_utils import validate_xml_attributes
-from app.validation.xml_utils import validate_xml_elements
-from app.validation.xml_utils import validate_xml_value
+from app.validation.xml_utils import (
+    ECR_NAMESPACES,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 
 ERROR_MESSAGES = {
     "fatal": [],

--- a/containers/validation/tests/integration/conftest.py
+++ b/containers/validation/tests/integration/conftest.py
@@ -12,7 +12,7 @@ def read_file_from_test_assets():
         Reads a file from the test assets directory.
         """
         with open(
-            (Path(__file__).parent.parent / "assets" / filename), "r", encoding="utf-8"
+            (Path(__file__).parent.parent / "assets" / filename), encoding="utf-8"
         ) as file:
             return file.read()
 

--- a/containers/validation/tests/test_base_service.py
+++ b/containers/validation/tests/test_base_service.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
 import toml
-from app.base_service import BaseService
-from app.base_service import DIBBS_CONTACT
-from app.base_service import LICENSES
+from app.base_service import DIBBS_CONTACT, LICENSES, BaseService
 from fastapi.testclient import TestClient
 
 with open(

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -1,9 +1,7 @@
 import pathlib
 
 import yaml
-from app.utils import load_ecr_config
-from app.utils import validate_config
-from app.utils import validate_error_types
+from app.utils import load_ecr_config, validate_config, validate_error_types
 
 config_path = pathlib.Path(__file__).parent.parent / "config" / "sample_ecr_config.yaml"
 
@@ -44,7 +42,6 @@ def test_validate_error_types():
 def test_validate_config_bad():
     with open(
         pathlib.Path(__file__).parent / "assets" / "sample_ecr_config_bad.yaml",
-        "r",
     ) as file:
         config_bad = yaml.safe_load(file)
         result = validate_config(config_bad)
@@ -54,7 +51,6 @@ def test_validate_config_bad():
 def test_validate_config_good():
     with open(
         pathlib.Path(__file__).parent / "assets" / "sample_ecr_config.yaml",
-        "r",
     ) as file:
         config = yaml.safe_load(file)
         result = validate_config(config)

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -1,10 +1,12 @@
 import pathlib
 
-from app.main import app
-from app.main import validate_ecr_msg
-from app.main import validate_elr_msg
-from app.main import validate_fhir_bundle
-from app.main import validate_vxu_msg
+from app.main import (
+    app,
+    validate_ecr_msg,
+    validate_elr_msg,
+    validate_fhir_bundle,
+    validate_vxu_msg,
+)
 from fastapi.testclient import TestClient
 
 client = TestClient(app)

--- a/containers/validation/tests/test_xml_utils.py
+++ b/containers/validation/tests/test_xml_utils.py
@@ -1,21 +1,23 @@
 import pathlib
 
-from app.validation.xml_utils import _check_xml_names_and_attribs_exist
-from app.validation.xml_utils import _get_ecr_custom_message
-from app.validation.xml_utils import _get_xml_attributes
-from app.validation.xml_utils import _get_xml_message_id
-from app.validation.xml_utils import _get_xml_relative_iterator
-from app.validation.xml_utils import _get_xml_relatives_details
-from app.validation.xml_utils import _validate_xml_related_element
-from app.validation.xml_utils import _validate_xml_relatives
-from app.validation.xml_utils import ECR_NAMESPACES
-from app.validation.xml_utils import EICR_MSG_ID_XPATH
-from app.validation.xml_utils import get_ecr_message_ids
-from app.validation.xml_utils import get_xml_element_details
-from app.validation.xml_utils import RR_MSG_ID_XPATH
-from app.validation.xml_utils import validate_xml_attributes
-from app.validation.xml_utils import validate_xml_elements
-from app.validation.xml_utils import validate_xml_value
+from app.validation.xml_utils import (
+    ECR_NAMESPACES,
+    EICR_MSG_ID_XPATH,
+    RR_MSG_ID_XPATH,
+    _check_xml_names_and_attribs_exist,
+    _get_ecr_custom_message,
+    _get_xml_attributes,
+    _get_xml_message_id,
+    _get_xml_relative_iterator,
+    _get_xml_relatives_details,
+    _validate_xml_related_element,
+    _validate_xml_relatives,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 from lxml import etree
 
 test_include_errors = ["fatal", "errors", "warnings", "information"]

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -1,18 +1,13 @@
 import json
-from datetime import datetime
-from datetime import timezone
-from typing import List
-from typing import Literal
-from typing import Union
+from datetime import datetime, timezone
+from typing import Literal, Union
 
 from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from azure.storage.blob import BlobServiceClient
-from azure.storage.blob import ContainerClient
+from azure.storage.blob import BlobServiceClient, ContainerClient
 
-from phdi.cloud.core import BaseCloudStorageConnection
-from phdi.cloud.core import BaseCredentialManager
+from phdi.cloud.core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class AzureCredentialManager(BaseCredentialManager):
@@ -192,7 +187,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
         elif isinstance(message, dict):
             blob_client.upload_blob(json.dumps(message).encode("utf-8"), overwrite=True)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -210,7 +205,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
 
         return container_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -1,6 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
-from typing import List
+from abc import ABC, abstractmethod
 from typing import Union
 
 
@@ -63,7 +61,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists names for this CloudContainerConnection's containers.
 
@@ -72,7 +70,7 @@ class BaseCloudStorageConnection(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def list_objects(self, container_name: str, prefix: str) -> List[str]:
+    def list_objects(self, container_name: str, prefix: str) -> list[str]:
         """
         Lists names for objects within a container.
 

--- a/phdi/cloud/gcp.py
+++ b/phdi/cloud/gcp.py
@@ -1,13 +1,11 @@
 import json
-from typing import List
 from typing import Union
 
 import google.auth.transport.requests
 from google.auth.credentials import Credentials
 from google.cloud import storage
 
-from .core import BaseCloudStorageConnection
-from .core import BaseCredentialManager
+from .core import BaseCloudStorageConnection, BaseCredentialManager
 
 
 class GcpCredentialManager(BaseCredentialManager):
@@ -161,7 +159,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
 
         blob.upload_from_string(data=message, content_type=content_type)
 
-    def list_containers(self) -> List[str]:
+    def list_containers(self) -> list[str]:
         """
         Lists bucket names in storage.
 
@@ -174,7 +172,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
             bucket_name_list.append(bucket)
         return bucket_name_list
 
-    def list_objects(self, container_name: str, prefix: str = "") -> List[str]:
+    def list_objects(self, container_name: str, prefix: str = "") -> list[str]:
         """
         Lists names for objects within a bucket.
 

--- a/phdi/fhir/cloud/azure.py
+++ b/phdi/fhir/cloud/azure.py
@@ -1,7 +1,6 @@
 import io
-from typing import Iterator
+from collections.abc import Iterator
 from typing import TextIO
-from typing import Tuple
 
 from azure.storage.blob import download_blob_from_url
 
@@ -11,7 +10,7 @@ from phdi.cloud.azure import AzureCredentialManager
 def download_from_fhir_export_response(
     export_response: dict,
     cred_manager: AzureCredentialManager,
-) -> Iterator[Tuple[str, TextIO]]:
+) -> Iterator[tuple[str, TextIO]]:
     """
     Accepts the export response content as specified here:
     https://hl7.org/fhir/uv/bulkdata/export/index.html#response---complete-status

--- a/phdi/fhir/conversion/__init__.py
+++ b/phdi/fhir/conversion/__init__.py
@@ -1,5 +1,4 @@
-from phdi.fhir.conversion.convert import add_rr_data_to_eicr
-from phdi.fhir.conversion.convert import convert_to_fhir
+from phdi.fhir.conversion.convert import add_rr_data_to_eicr, convert_to_fhir
 
 __all__ = (
     "add_rr_data_to_eicr",

--- a/phdi/fhir/geospatial/core.py
+++ b/phdi/fhir/geospatial/core.py
@@ -1,5 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 
 class BaseFhirGeocodeClient(ABC):

--- a/phdi/fhir/harmonization/__init__.py
+++ b/phdi/fhir/harmonization/__init__.py
@@ -1,8 +1,10 @@
-from phdi.fhir.harmonization.standardization import double_metaphone_bundle
-from phdi.fhir.harmonization.standardization import double_metaphone_patient
-from phdi.fhir.harmonization.standardization import standardize_dob
-from phdi.fhir.harmonization.standardization import standardize_names
-from phdi.fhir.harmonization.standardization import standardize_phones
+from phdi.fhir.harmonization.standardization import (
+    double_metaphone_bundle,
+    double_metaphone_patient,
+    standardize_dob,
+    standardize_names,
+    standardize_phones,
+)
 
 __all__ = (
     "double_metaphone_bundle",

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -1,14 +1,14 @@
 import copy
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
-from phdi.harmonization import double_metaphone_string
-from phdi.harmonization import DoubleMetaphone
-from phdi.harmonization import standardize_birth_date
-from phdi.harmonization import standardize_country_code
-from phdi.harmonization import standardize_name
-from phdi.harmonization import standardize_phone
+from phdi.harmonization import (
+    DoubleMetaphone,
+    double_metaphone_string,
+    standardize_birth_date,
+    standardize_country_code,
+    standardize_name,
+    standardize_phone,
+)
 
 
 def double_metaphone_bundle(bundle: dict, overwrite=True) -> dict:
@@ -234,7 +234,7 @@ def _standardize_phones_in_resource(
 
 def _extract_countries_from_resource(
     resource: dict, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
-) -> List[str]:
+) -> list[str]:
     """
     Builds a list containing all of the countries, standardized by code_type, in the
     addresses of a given FHIR resource as interpreted by the ISO 3611: standardized

--- a/phdi/fhir/linkage/__init__.py
+++ b/phdi/fhir/linkage/__init__.py
@@ -1,4 +1,6 @@
-from phdi.fhir.linkage.link import add_patient_identifier
-from phdi.fhir.linkage.link import add_patient_identifier_in_bundle
+from phdi.fhir.linkage.link import (
+    add_patient_identifier,
+    add_patient_identifier_in_bundle,
+)
 
 __all__ = ["add_patient_identifier_in_bundle", "add_patient_identifier"]

--- a/phdi/fhir/linkage/link.py
+++ b/phdi/fhir/linkage/link.py
@@ -1,8 +1,10 @@
 import copy
 
-from phdi.fhir.utils import find_entries_by_resource_type
-from phdi.fhir.utils import get_field
-from phdi.fhir.utils import get_one_line_address
+from phdi.fhir.utils import (
+    find_entries_by_resource_type,
+    get_field,
+    get_one_line_address,
+)
 from phdi.linkage.link import generate_hash_str
 
 
@@ -70,7 +72,7 @@ def add_patient_identifier(
     # TODO Determine if minimum quality criteria should be included, such as min
     # number of characters in last name, valid birth date, or address line
     # Generate and store unique hash code
-    link_str = f'{name_str}-{patient_resource["birthDate"]}-{address_line}'
+    link_str = f"{name_str}-{patient_resource['birthDate']}-{address_line}"
     hashcode = generate_hash_str(link_str, salt_str)
 
     if "identifier" not in patient_resource:

--- a/phdi/fhir/tabulation/__init__.py
+++ b/phdi/fhir/tabulation/__init__.py
@@ -1,8 +1,10 @@
-from phdi.fhir.tabulation.tables import drop_invalid
-from phdi.fhir.tabulation.tables import extract_data_from_fhir_search
-from phdi.fhir.tabulation.tables import extract_data_from_fhir_search_incremental
-from phdi.fhir.tabulation.tables import extract_data_from_schema
-from phdi.fhir.tabulation.tables import tabulate_data
+from phdi.fhir.tabulation.tables import (
+    drop_invalid,
+    extract_data_from_fhir_search,
+    extract_data_from_fhir_search_incremental,
+    extract_data_from_schema,
+    tabulate_data,
+)
 
 __all__ = [
     "drop_invalid",

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -2,23 +2,18 @@ import json
 import pathlib
 import urllib.parse
 import warnings
-from typing import Dict
-from typing import List
-from typing import Tuple
 from typing import Union
-from urllib.parse import parse_qs
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode
 
 import requests
 
 from phdi.cloud.core import BaseCredentialManager
 from phdi.fhir.transport import http_request_with_reauth
 from phdi.fhir.utils import extract_value_with_resource_path
-from phdi.tabulation.tables import load_schema
-from phdi.tabulation.tables import write_data
+from phdi.tabulation.tables import load_schema, write_data
 
 
-def drop_invalid(data: List[list], schema: Dict, table_name: str) -> List[list]:
+def drop_invalid(data: list[list], schema: dict, table_name: str) -> list[list]:
     """
     Removes resources from tabulated data if the resource contains an invalid value, as
     specified in the invalid_values field in a user-defined schema. Users may provide
@@ -67,7 +62,7 @@ def drop_invalid(data: List[list], schema: Dict, table_name: str) -> List[list]:
 
 def extract_data_from_fhir_search(
     search_url: str, cred_manager: BaseCredentialManager = None
-) -> List[dict]:
+) -> list[dict]:
     """
     Performs a FHIR search, continuously using the "next" url to perform
     search continuations until no additional search results are available.
@@ -99,7 +94,7 @@ def extract_data_from_fhir_search(
 
 def extract_data_from_fhir_search_incremental(
     search_url: str, cred_manager: BaseCredentialManager = None
-) -> Tuple[List[dict], str]:
+) -> tuple[list[dict], str]:
     """
     Performs a FHIR search for a single page of data and returns a dictionary containing
     the data and a next URL. If there is no next URL (this is the last page of data),
@@ -155,7 +150,7 @@ def extract_data_from_fhir_search_incremental(
 
 def extract_data_from_schema(
     schema: dict, fhir_url: str, cred_manager: BaseCredentialManager = None
-) -> Dict[str, List[dict]]:
+) -> dict[str, list[dict]]:
     """
     Performs a full FHIR search for each table in the specified `schema`,
     and returns a dictionary mapping the table name to corresponding search results.
@@ -179,7 +174,7 @@ def extract_data_from_schema(
     return results
 
 
-def tabulate_data(data: List[dict], schema: dict, table_name: str) -> List[list]:
+def tabulate_data(data: list[dict], schema: dict, table_name: str) -> list[list]:
     """
     Transforms a list of FHIR bundle resource entries into a tabular
     format (given by a list of lists) using a user-defined schema.
@@ -288,7 +283,7 @@ def tabulate_data(data: List[dict], schema: dict, table_name: str) -> List[list]
     return tabulated_data
 
 
-def _build_reference_dicts(data: List[dict], directions_by_table: dict) -> dict:
+def _build_reference_dicts(data: list[dict], directions_by_table: dict) -> dict:
     """
     Groups resources previously determined to reference each other into
     dictionaries accessed using resource IDs. For each table, a dictionary

--- a/phdi/fhir/transport/__init__.py
+++ b/phdi/fhir/transport/__init__.py
@@ -1,7 +1,9 @@
 from phdi.fhir.transport.export import export_from_fhir_server
-from phdi.fhir.transport.http import fhir_server_get
-from phdi.fhir.transport.http import http_request_with_reauth
-from phdi.fhir.transport.http import upload_bundle_to_fhir_server
+from phdi.fhir.transport.http import (
+    fhir_server_get,
+    http_request_with_reauth,
+    upload_bundle_to_fhir_server,
+)
 
 __all__ = [
     "http_request_with_reauth",

--- a/phdi/fhir/transport/http.py
+++ b/phdi/fhir/transport/http.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 from typing import Literal
 
 import requests
@@ -13,7 +12,7 @@ def http_request_with_reauth(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -1,11 +1,7 @@
 import json
 import random
 from functools import cache
-from typing import Any
-from typing import Callable
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Any, Callable, Literal, Union
 
 import fhirpathpy
 
@@ -13,9 +9,9 @@ selection_criteria_types = Literal["first", "last", "random", "all"]
 
 
 def apply_selection_criteria(
-    value: List[Any],
+    value: list[Any],
     selection_criteria: selection_criteria_types,
-) -> str | List:
+) -> str | list:
     """
     Returns value(s), according to the selection criteria, from a given list of values
     parsed from a FHIR resource. A single string value is returned - if the selected
@@ -76,7 +72,7 @@ def extract_value_with_resource_path(
         return value
 
 
-def find_entries_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
+def find_entries_by_resource_type(bundle: dict, resource_type: str) -> list[dict]:
     """
     Collect all entries of a specific type in a bundle of FHIR data and
     return references to them in a list.

--- a/phdi/geospatial/__init__.py
+++ b/phdi/geospatial/__init__.py
@@ -1,6 +1,5 @@
 from phdi.geospatial.census import CensusGeocodeClient
-from phdi.geospatial.core import BaseGeocodeClient
-from phdi.geospatial.core import GeocodeResult
+from phdi.geospatial.core import BaseGeocodeClient, GeocodeResult
 from phdi.geospatial.smarty import SmartyGeocodeClient
 
 __all__ = (

--- a/phdi/geospatial/census.py
+++ b/phdi/geospatial/census.py
@@ -1,10 +1,8 @@
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import requests
 
-from phdi.geospatial.core import BaseGeocodeClient
-from phdi.geospatial.core import GeocodeResult
+from phdi.geospatial.core import BaseGeocodeClient, GeocodeResult
 from phdi.transport import http_request_with_retry
 
 

--- a/phdi/geospatial/core.py
+++ b/phdi/geospatial/core.py
@@ -1,9 +1,6 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Optional, Union
 
 
 @dataclass
@@ -14,7 +11,7 @@ class GeocodeResult:
     https://www.hl7.org/fhir/datatypes.html#Address.
     """
 
-    line: List[str]
+    line: list[str]
     city: str
     state: str
     postal_code: str

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -1,12 +1,9 @@
 from typing import Union
 
-from smartystreets_python_sdk import ClientBuilder
-from smartystreets_python_sdk import StaticCredentials
-from smartystreets_python_sdk import us_street
+from smartystreets_python_sdk import ClientBuilder, StaticCredentials, us_street
 from smartystreets_python_sdk.us_street.lookup import Lookup
 
-from phdi.geospatial.core import BaseGeocodeClient
-from phdi.geospatial.core import GeocodeResult
+from phdi.geospatial.core import BaseGeocodeClient, GeocodeResult
 
 
 class SmartyGeocodeClient(BaseGeocodeClient):

--- a/phdi/harmonization/__init__.py
+++ b/phdi/harmonization/__init__.py
@@ -1,14 +1,18 @@
 from phdi.harmonization.double_metaphone import DoubleMetaphone
-from phdi.harmonization.hl7 import convert_hl7_batch_messages_to_list
-from phdi.harmonization.hl7 import default_hl7_value
-from phdi.harmonization.hl7 import normalize_hl7_datetime
-from phdi.harmonization.hl7 import normalize_hl7_datetime_segment
-from phdi.harmonization.hl7 import standardize_hl7_datetimes
-from phdi.harmonization.standardization import double_metaphone_string
-from phdi.harmonization.standardization import standardize_birth_date
-from phdi.harmonization.standardization import standardize_country_code
-from phdi.harmonization.standardization import standardize_name
-from phdi.harmonization.standardization import standardize_phone
+from phdi.harmonization.hl7 import (
+    convert_hl7_batch_messages_to_list,
+    default_hl7_value,
+    normalize_hl7_datetime,
+    normalize_hl7_datetime_segment,
+    standardize_hl7_datetimes,
+)
+from phdi.harmonization.standardization import (
+    double_metaphone_string,
+    standardize_birth_date,
+    standardize_country_code,
+    standardize_name,
+    standardize_phone,
+)
 from phdi.harmonization.utils import compare_strings
 
 __all__ = (

--- a/phdi/harmonization/double_metaphone.py
+++ b/phdi/harmonization/double_metaphone.py
@@ -19,7 +19,7 @@ VOWELS = ["A", "E", "I", "O", "U", "Y"]
 SILENT_STARTERS = ["GN", "KN", "PN", "WR", "PS"]
 
 
-class DoubleMetaphone(object):
+class DoubleMetaphone:
     """
     A Double Metaphone parsing object capable of performing the double
     coding algorithm on a given input string.
@@ -750,7 +750,7 @@ class DoubleMetaphone(object):
         return [self.primary_phone, self.secondary_phone]
 
 
-class Word(object):
+class Word:
     """
     Helper class used for representing a single word for token
     parsing.
@@ -767,11 +767,9 @@ class Word(object):
         self.decoded = self.decoded.replace("\xc7", "s")
         self.decoded = self.decoded.replace("\xe7", "s")
         self.normalized = "".join(
-            (
-                c
-                for c in unicodedata.normalize("NFD", self.decoded)
-                if unicodedata.category(c) != "Mn"
-            )
+            c
+            for c in unicodedata.normalize("NFD", self.decoded)
+            if unicodedata.category(c) != "Mn"
         )
         self.upper = self.normalized.upper()
         self.length = len(self.upper)

--- a/phdi/harmonization/hl7.py
+++ b/phdi/harmonization/hl7.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from typing import List
 
 import hl7
 
@@ -81,7 +80,7 @@ def standardize_hl7_datetimes(message: str) -> str:
 
 def convert_hl7_batch_messages_to_list(
     content: str, delimiter: str = "\n"
-) -> List[str]:
+) -> list[str]:
     """
     Converts a batch file of messages into a list of strings
     representing parts of the message. This function is based

--- a/phdi/harmonization/standardization.py
+++ b/phdi/harmonization/standardization.py
@@ -1,8 +1,6 @@
 import datetime
 import pathlib
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import phonenumbers
 import pycountry
@@ -14,7 +12,7 @@ FHIR_DATE_FORMAT = "%Y-%m-%d"
 FHIR_DATE_DELIM = "-"
 
 
-def double_metaphone_string(string: str, dmeta=None) -> List[Union[str, None]]:
+def double_metaphone_string(string: str, dmeta=None) -> list[Union[str, None]]:
     """
     Performs the double metaphone phonetic encoding algorithm on the given
     string. Returns a list holding the primary and secondary phonetic
@@ -89,8 +87,8 @@ def standardize_country_code(
 
 
 def standardize_phone(
-    raw_phone: Union[str, List[str]], countries: List = [None, "US"]
-) -> Union[str, List[str]]:
+    raw_phone: Union[str, list[str]], countries: list = [None, "US"]
+) -> Union[str, list[str]]:
     """
     Parses phone number and generates its standardized ISO E.164 international format
     for each given phone number and optional list of associated countries. If an input
@@ -151,11 +149,11 @@ def standardize_phone(
 
 
 def standardize_name(
-    raw_name: Union[str, List[str]],
+    raw_name: Union[str, list[str]],
     trim: bool = True,
     case: Literal["upper", "lower", "title"] = "upper",
     remove_numbers: bool = True,
-) -> Union[str, List[str]]:
+) -> Union[str, list[str]]:
     """
     Performs basic standardization (described below) on each given name. Removes
     punctuation characters and performs a variety of additional cleaning operations.
@@ -207,7 +205,7 @@ def standardize_name(
 
 def _build_nicknames_db():
     nicknames_to_names = {}
-    with open(pathlib.Path(__file__).parent / "phdi_nicknames.csv", "r") as fp:
+    with open(pathlib.Path(__file__).parent / "phdi_nicknames.csv") as fp:
         for line in fp:
             if line.strip() != "":
                 name, nicks = line.strip().split(":", 1)

--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -1,29 +1,30 @@
-from phdi.linkage.algorithms import DIBBS_BASIC
-from phdi.linkage.algorithms import DIBBS_ENHANCED
+from phdi.linkage.algorithms import DIBBS_BASIC, DIBBS_ENHANCED
 from phdi.linkage.core import BaseMPIConnectorClient
-from phdi.linkage.link import add_person_resource
-from phdi.linkage.link import block_data
-from phdi.linkage.link import calculate_log_odds
-from phdi.linkage.link import calculate_m_probs
-from phdi.linkage.link import calculate_u_probs
-from phdi.linkage.link import compile_match_lists
-from phdi.linkage.link import eval_log_odds_cutoff
-from phdi.linkage.link import eval_perfect_match
-from phdi.linkage.link import extract_blocking_values_from_record
-from phdi.linkage.link import feature_match_exact
-from phdi.linkage.link import feature_match_four_char
-from phdi.linkage.link import feature_match_fuzzy_string
-from phdi.linkage.link import feature_match_log_odds_exact
-from phdi.linkage.link import feature_match_log_odds_fuzzy_compare
-from phdi.linkage.link import generate_hash_str
-from phdi.linkage.link import link_record_against_mpi
-from phdi.linkage.link import load_json_probs
-from phdi.linkage.link import match_within_block
-from phdi.linkage.link import perform_linkage_pass
-from phdi.linkage.link import profile_log_odds
-from phdi.linkage.link import read_linkage_config
-from phdi.linkage.link import score_linkage_vs_truth
-from phdi.linkage.link import write_linkage_config
+from phdi.linkage.link import (
+    add_person_resource,
+    block_data,
+    calculate_log_odds,
+    calculate_m_probs,
+    calculate_u_probs,
+    compile_match_lists,
+    eval_log_odds_cutoff,
+    eval_perfect_match,
+    extract_blocking_values_from_record,
+    feature_match_exact,
+    feature_match_four_char,
+    feature_match_fuzzy_string,
+    feature_match_log_odds_exact,
+    feature_match_log_odds_fuzzy_compare,
+    generate_hash_str,
+    link_record_against_mpi,
+    load_json_probs,
+    match_within_block,
+    perform_linkage_pass,
+    profile_log_odds,
+    read_linkage_config,
+    score_linkage_vs_truth,
+    write_linkage_config,
+)
 from phdi.linkage.mpi import DIBBsMPIConnectorClient
 from phdi.linkage.seed import convert_to_patient_fhir_resources
 from phdi.linkage.utils import datetime_to_str

--- a/phdi/linkage/config.py
+++ b/phdi/linkage/config.py
@@ -12,7 +12,7 @@ class DBSettings(BaseSettings):
     mpi_port: str
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> dict:
     """
     Load the values specified in the Settings class from the environment and return a

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -1,6 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
-from typing import List
+from abc import ABC, abstractmethod
 
 from sqlalchemy import Select
 
@@ -14,7 +12,7 @@ class BaseMPIConnectorClient(ABC):
     """
 
     @abstractmethod
-    def get_block_data() -> List[list]:
+    def get_block_data() -> list[list]:
         """
         Returns a list of lists containing records from the MPI database that
         match on the incoming record's block criteria and values. If blocking

--- a/phdi/linkage/dal.py
+++ b/phdi/linkage/dal.py
@@ -1,18 +1,12 @@
 import datetime
 import logging
 from contextlib import contextmanager
-from typing import List
 
-from sqlalchemy import create_engine
-from sqlalchemy import MetaData
-from sqlalchemy import select
-from sqlalchemy import Table
-from sqlalchemy import text
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import MetaData, Table, create_engine, select, text
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 
-class DataAccessLayer(object):
+class DataAccessLayer:
     """
     Base class for Database API objects - manages transactions,
     sessions and holds a reference to the engine.
@@ -169,7 +163,7 @@ class DataAccessLayer(object):
                         logging.info(
                             f"""Starting statement execution getting
                               new_primary_key for record #{n_records}at:
-                                {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
                         new_primary_key = session.execute(statement)
                         # TODO: I don't like this, but seems to
@@ -178,7 +172,7 @@ class DataAccessLayer(object):
                         # PK defined in the table and that doesn't work
                         logging.info(
                             f""" Done with statement execution getting new_primary_key
-                              for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                              for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
                         new_primary_keys.append(new_primary_key.first()[0])
                     else:
@@ -190,7 +184,7 @@ class DataAccessLayer(object):
                         session.execute(statement)
                         logging.info(
                             f"""Done with statement execution
-                              for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                              for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                         )
         return new_primary_keys
 
@@ -247,7 +241,7 @@ class DataAccessLayer(object):
                                 logging.info(
                                     f"""Starting statement execution getting
                                     new_primary_key for record #{n_records}at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
                                 new_primary_key = session.execute(statement)
                                 # TODO: I don't like this, but seems to
@@ -256,14 +250,14 @@ class DataAccessLayer(object):
                                 # PK defined in the table and that doesn't work
                                 logging.info(
                                     f""" Done with statement execution getting new_primary_key
-                                    for record #{n_records} at: {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                    for record #{n_records} at: {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
                                 new_primary_keys.append(new_primary_key.first()[0])
                             else:
                                 logging.info("Did not return primary keys")
                                 logging.info(
                                     f"""Starting statement creation for record #{n_records} at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
 
                                 if "dob" in record:
@@ -285,7 +279,7 @@ class DataAccessLayer(object):
                                 statements.append(statement)
                                 logging.info(
                                     f"""Done with statement creation for record #{n_records} at:
-                                        {datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                                        {datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                                 )
 
                     return_results[table.name] = {"primary_keys": new_primary_keys}
@@ -306,7 +300,7 @@ class DataAccessLayer(object):
         select_statement: select,
         include_col_header: bool = True,
         query_params: dict = None,
-    ) -> List[list]:
+    ) -> list[list]:
         """
         Perform a select query and add the results to a
         list of lists.  Then add the column header as the

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -7,9 +7,7 @@ import pathlib
 from itertools import combinations
 from math import log
 from random import sample
-from typing import Callable
-from typing import List
-from typing import Union
+from typing import Callable, Union
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -17,8 +15,7 @@ from pydantic import Field
 
 from phdi.fhir.utils import extract_value_with_resource_path
 from phdi.harmonization.utils import compare_strings
-from phdi.linkage.mpi import BaseMPIConnectorClient
-from phdi.linkage.mpi import DIBBsMPIConnectorClient
+from phdi.linkage.mpi import BaseMPIConnectorClient, DIBBsMPIConnectorClient
 from phdi.linkage.utils import datetime_to_str
 
 LINKING_FIELDS_TO_FHIRPATHS = {
@@ -34,14 +31,14 @@ LINKING_FIELDS_TO_FHIRPATHS = {
 }
 
 
-def block_data(data: pd.DataFrame, blocks: List) -> dict:
+def block_data(data: pd.DataFrame, blocks: list) -> dict:
     """
     Generates dictionary of blocked data where each key is a block
     and each value is a distinct list of lists containing the data
     for a given block.
 
     :param data: A pandas dataframe of records to be linked.
-    :param blocks: List of columns to be used in blocks.
+    :param blocks: list of columns to be used in blocks.
     :return: A dictionary of with the keys as the blocks and the
       values as the data within each block, stored as a list of
       lists.
@@ -92,7 +89,7 @@ def calculate_log_odds(
 def calculate_m_probs(
     data: pd.DataFrame,
     true_matches: dict,
-    cols: Union[List[str], None] = None,
+    cols: Union[list[str], None] = None,
     file_to_write: Union[pathlib.Path, None] = None,
 ):
     """
@@ -141,7 +138,7 @@ def calculate_u_probs(
     data: pd.DataFrame,
     true_matches: dict,
     n_samples: Union[int, None] = None,
-    cols: Union[List, None] = None,
+    cols: Union[list, None] = None,
     file_to_write: Union[pathlib.Path, None] = None,
 ):
     """
@@ -203,7 +200,7 @@ def calculate_u_probs(
     return u_probs
 
 
-def compile_match_lists(match_lists: List[dict], cluster_mode: bool = False):
+def compile_match_lists(match_lists: list[dict], cluster_mode: bool = False):
     """
     Turns a list of matches of either clusters or candidate pairs found
     during linkage into a single unified structure holding all found matches
@@ -241,7 +238,7 @@ def compile_match_lists(match_lists: List[dict], cluster_mode: bool = False):
     return matches
 
 
-def eval_perfect_match(feature_comparisons: List, **kwargs) -> bool:
+def eval_perfect_match(feature_comparisons: list, **kwargs) -> bool:
     """
     Determines whether a given set of feature comparisons represent a
     'perfect' match (i.e. whether all features that were compared match
@@ -254,7 +251,7 @@ def eval_perfect_match(feature_comparisons: List, **kwargs) -> bool:
     return sum(feature_comparisons) == len(feature_comparisons)
 
 
-def eval_log_odds_cutoff(feature_comparisons: List, **kwargs) -> bool:
+def eval_log_odds_cutoff(feature_comparisons: list, **kwargs) -> bool:
     """
     Determines whether a given set of feature comparisons matches enough
     to be the result of a true patient link instead of just random chance.
@@ -271,7 +268,7 @@ def eval_log_odds_cutoff(feature_comparisons: List, **kwargs) -> bool:
 
 
 def extract_blocking_values_from_record(
-    record: dict, blocking_fields: List[dict]
+    record: dict, blocking_fields: list[dict]
 ) -> dict:
     """
     Extracts values from a given patient record for eventual use in database
@@ -361,8 +358,8 @@ def extract_blocking_values_from_record(
 
 
 def feature_match_exact(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -383,8 +380,8 @@ def feature_match_exact(
 
 
 def feature_match_four_char(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -407,8 +404,8 @@ def feature_match_four_char(
 
 
 def feature_match_fuzzy_string(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -455,8 +452,8 @@ def feature_match_fuzzy_string(
 
 
 def feature_match_log_odds_exact(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -485,8 +482,8 @@ def feature_match_log_odds_exact(
 
 
 def feature_match_log_odds_fuzzy_compare(
-    record_i: List,
-    record_j: List,
+    record_i: list,
+    record_j: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     **kwargs: dict,
@@ -544,7 +541,7 @@ def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
 
 def link_record_against_mpi(
     record: dict,
-    algo_config: List[dict],
+    algo_config: list[dict],
     external_person_id: str = None,
     mpi_client: BaseMPIConnectorClient = None,
 ) -> tuple[bool, str]:
@@ -723,7 +720,7 @@ def load_json_probs(path: pathlib.Path):
     :raises JSONDecodeError: If the file cannot be read as valid JSON.
     """
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             prob_dict = json.load(file)
         return prob_dict
     except FileNotFoundError:
@@ -735,12 +732,12 @@ def load_json_probs(path: pathlib.Path):
 
 
 def match_within_block(
-    block: List[List],
+    block: list[list],
     feature_funcs: dict[str, Callable],
     col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
-) -> List[tuple]:
+) -> list[tuple]:
     """
     Performs matching on all candidate pairs of records within a given block
     of data. Actual partitioning of the data should be done outside this
@@ -802,7 +799,7 @@ def match_within_block(
 # primary data type to use here.
 def perform_linkage_pass(
     data: pd.DataFrame,
-    blocks: List,
+    blocks: list,
     feature_funcs: dict[str, Callable],
     matching_rule: Callable,
     cluster_ratio: Union[float, None] = None,
@@ -862,8 +859,8 @@ def profile_log_odds(
     data: pd.DataFrame,
     true_matches: dict,
     log_odds: dict,
-    exact_cols: List,
-    fuzzy_cols: List,
+    exact_cols: list,
+    fuzzy_cols: list,
     idx_to_col: dict,
     neg_samples: int = 50000,
 ) -> None:  # pragma: no cover
@@ -957,7 +954,7 @@ def profile_log_odds(
     plt.show()
 
 
-def read_linkage_config(config_file: pathlib.Path) -> List[dict]:
+def read_linkage_config(config_file: pathlib.Path) -> list[dict]:
     """
     Reads and generates a record linkage algorithm configuration list from
     the provided filepath, which should point to a JSON file. A record
@@ -1072,7 +1069,7 @@ def score_linkage_vs_truth(
     return (sensitivity, specificity, ppv, f1)
 
 
-def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) -> None:
+def write_linkage_config(linkage_algo: list[dict], file_to_write: pathlib.Path) -> None:
     """
     Save a provided algorithm description as a JSON dictionary at the provided
     filepath location. Algorithm descriptions are lists of dictionaries, one
@@ -1136,7 +1133,7 @@ def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) 
         out.write(json.dumps(linkage_json))
 
 
-def _bind_func_names_to_invocations(algo_config: List[dict]):
+def _bind_func_names_to_invocations(algo_config: list[dict]):
     """
     Helper method that re-maps the string names of functions to their
     callable invocations as defined within the `link.py` module.
@@ -1152,7 +1149,7 @@ def _bind_func_names_to_invocations(algo_config: List[dict]):
 
 
 def _eval_record_in_cluster(
-    block: List[List],
+    block: list[list],
     i: int,
     cluster: set,
     cluster_ratio: float,
@@ -1186,8 +1183,8 @@ def _eval_record_in_cluster(
 
 
 def _compare_records(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     col_to_idx: dict[str, int],
     matching_rule: callable,
@@ -1216,8 +1213,8 @@ def _compare_records(
 
 
 def _compare_records_field_helper(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_col: str,
     col_to_idx: dict[str, int],
     feature_funcs: dict,
@@ -1238,8 +1235,8 @@ def _compare_records_field_helper(
 
 
 def _compare_address_elements(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     feature_col: str,
     col_to_idx: dict[str, int],
@@ -1262,8 +1259,8 @@ def _compare_address_elements(
 
 
 def _compare_name_elements(
-    record: List,
-    mpi_patient: List,
+    record: list,
+    mpi_patient: list,
     feature_funcs: dict,
     feature_col: str,
     col_to_idx: dict[str, int],
@@ -1285,7 +1282,7 @@ def _compare_name_elements(
     return feature_comp
 
 
-def _condense_extract_address_from_resource(resource: dict, field: str) -> List[str]:
+def _condense_extract_address_from_resource(resource: dict, field: str) -> list[str]:
     """
     Formatting function to account for patient resources that have multiple
     associated addresses. Each address is a self-contained object, replete
@@ -1336,7 +1333,7 @@ def _find_strongest_link(linkage_scores: dict) -> str:
     return best_person
 
 
-def _flatten_patient_resource(resource: dict, col_to_idx: dict) -> List:
+def _flatten_patient_resource(resource: dict, col_to_idx: dict) -> list:
     """
     Helper method that flattens an incoming patient resource into a list whose
     elements are the keys of the FHIR dictionary, reformatted and ordered
@@ -1378,7 +1375,7 @@ def _flatten_patient_field_helper(resource: dict, field: str) -> any:
         return val if val is not None else ""
 
 
-def _group_patient_block_by_person(data_block: List[list]) -> dict[str, List]:
+def _group_patient_block_by_person(data_block: list[list]) -> dict[str, list]:
     """
     Helper method that partitions the block of patient data returned from the MPI
     into clusters of records according to their linked Person ID.
@@ -1393,8 +1390,8 @@ def _group_patient_block_by_person(data_block: List[list]) -> dict[str, List]:
 
 
 def _map_matches_to_record_ids(
-    match_list: Union[List[tuple], List[set]], data_block, cluster_mode: bool = False
-) -> List[tuple]:
+    match_list: Union[list[tuple], list[set]], data_block, cluster_mode: bool = False
+) -> list[tuple]:
     """
     Helper function to turn a list of tuples of row indices in a block
     of data into a list of tuples of the IDs of the records within
@@ -1418,13 +1415,13 @@ def _map_matches_to_record_ids(
 
 
 def _match_within_block_cluster_ratio(
-    block: List[List],
+    block: list[list],
     cluster_ratio: float,
     feature_funcs: dict[str, Callable],
     col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
-) -> List[set]:
+) -> list[set]:
     """
     A matching function for statistically testing the impact of membership
     ratio to the quality of clusters formed. This function behaves similarly
@@ -1558,8 +1555,8 @@ def _convert_given_name_to_first_name(data: list[list]) -> list[list]:
     list of given names) to a first_name column (which is a space-delimited string
     of given names).
 
-    :param data: List of lists block data.
-    :return: List of lists with first_name column.
+    :param data: list of lists block data.
+    :return: list of lists with first_name column.
     """
     result = []
     if not data:

--- a/phdi/linkage/mpi.py
+++ b/phdi/linkage/mpi.py
@@ -2,16 +2,10 @@ import datetime
 import logging
 import uuid
 from functools import cache
-from typing import Dict
-from typing import List
 from typing import Literal
 
-from sqlalchemy import and_
-from sqlalchemy import Select
-from sqlalchemy import select
-from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import aggregate_order_by
-from sqlalchemy.dialects.postgresql import array_agg
+from sqlalchemy import Select, and_, select, text
+from sqlalchemy.dialects.postgresql import aggregate_order_by, array_agg
 
 from phdi.fhir.utils import extract_value_with_resource_path
 from phdi.linkage.core import BaseMPIConnectorClient
@@ -116,7 +110,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
             },
         }
 
-    def get_block_data(self, block_criteria: Dict) -> List[list]:
+    def get_block_data(self, block_criteria: dict) -> list[list]:
         """
         Returns a list of lists containing records from the MPI database that
         match on the incoming record's block criteria and values. If blocking
@@ -184,7 +178,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
 
     def insert_matched_patient(
         self,
-        patient_resource: Dict,
+        patient_resource: dict,
         person_id=None,
         external_person_id=None,
     ) -> str:
@@ -236,12 +230,12 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
             if external_person_id is not None:
                 logging.info(
                     f"""external_person_id was not None;
-                      starting _insert_external_person_id at:{datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                      starting _insert_external_person_id at:{datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                 )
                 self._insert_external_person_id(person_id, external_person_id)
                 logging.info(
                     f"""external_person_id was not None;
-                      done with _insert_external_person_id at:{datetime.datetime.now().strftime('%m-%d-%yT%H:%M:%S.%f')}"""  # noqa
+                      done with _insert_external_person_id at:{datetime.datetime.now().strftime("%m-%d-%yT%H:%M:%S.%f")}"""  # noqa
                 )
         except Exception as error:  # pragma: no cover
             raise ValueError(f"{error}")
@@ -662,8 +656,8 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
         return external_source_id
 
     def _generate_dict_record_from_results(
-        self, results_list: List[list]
-    ) -> List[dict]:
+        self, results_list: list[list]
+    ) -> list[dict]:
         """
         Converts a list of list of records into a
         dictionary using the column name header, in the

--- a/phdi/linkage/seed.py
+++ b/phdi/linkage/seed.py
@@ -1,11 +1,9 @@
 # This script converts patient data from parquet to patient FHIR resources.
 import uuid
 from datetime import datetime
-from typing import Dict
-from typing import Tuple
 
 
-def extract_given_name(data: Dict):
+def extract_given_name(data: dict):
     first_name = data.get("first_name", None)
     middle_name = data.get("middle_name", None)
 
@@ -22,7 +20,7 @@ def extract_given_name(data: Dict):
         return None
 
 
-def adjust_birthdate(data: Dict):
+def adjust_birthdate(data: dict):
     # TODO: remove this function and pass in the `format` parameter to dob
     # standardization in ReadSourceData for LAC
     format = "%d%b%Y:00:00:00.000"
@@ -33,7 +31,7 @@ def adjust_birthdate(data: Dict):
     return dob
 
 
-def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
+def convert_to_patient_fhir_resources(data: dict) -> tuple:
     """
     Converts and returns a row of patient data into patient resource in a FHIR-formatted
     patient resouce with a newly generated patient id as well as the

--- a/phdi/linkage/utils.py
+++ b/phdi/linkage/utils.py
@@ -1,5 +1,4 @@
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 from typing import Union
 
 from phdi.linkage.config import get_settings

--- a/phdi/tabulation/__init__.py
+++ b/phdi/tabulation/__init__.py
@@ -1,5 +1,3 @@
-from phdi.tabulation.tables import load_schema
-from phdi.tabulation.tables import validate_schema
-from phdi.tabulation.tables import write_data
+from phdi.tabulation.tables import load_schema, validate_schema, write_data
 
 __all__ = ("load_schema", "validate_schema", write_data)

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -4,9 +4,7 @@ import json
 import os
 import pathlib
 import sqlite3 as sql
-from typing import List
-from typing import Literal
-from typing import Union
+from typing import Literal, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -27,7 +25,7 @@ def load_schema(path: pathlib.Path) -> dict:
     :return: A dict representing a schema read from the given path.
     """
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             if path.suffix == ".yaml":
                 schema = yaml.safe_load(file)
             elif path.suffix == ".json":
@@ -67,7 +65,7 @@ def validate_schema(schema: dict):
 
 
 def write_data(
-    tabulated_data: List[List],
+    tabulated_data: list[list],
     directory: str,
     output_type: Literal["csv", "parquet", "sql"],
     filename: str = None,
@@ -176,9 +174,7 @@ def write_data(
         # Have to do a format string this way to avoid an empty f-string error
         print(tuple_data)
         cursor.executemany(
-            "INSERT INTO {} {} VALUES {};".format(
-                db_tablename, headers, hdr_placeholder
-            ),
+            f"INSERT INTO {db_tablename} {headers} VALUES {hdr_placeholder};",
             tuple_data,
         )
 
@@ -205,7 +201,7 @@ def _convert_list_to_string(val: list) -> str:
 
 
 def _create_pa_schema_from_table_schema(
-    schema: dict, col_names: List, table_name: str
+    schema: dict, col_names: list, table_name: str
 ) -> pa.Schema:
     """
     Returns a parquet schema based on the schema definition file provided to the
@@ -244,7 +240,7 @@ def _create_pa_schema_from_table_schema(
     return pa_schema
 
 
-def _create_from_arrays_data(row_data: List) -> List:
+def _create_from_arrays_data(row_data: list) -> list:
     """
     Returns a list that is one array per column. Accepts list that is one
       array per row.
@@ -262,7 +258,7 @@ def _create_from_arrays_data(row_data: List) -> List:
     return col_data
 
 
-def _create_parquet_data(data: List[List], pq_schema: pa.Schema) -> List[List]:
+def _create_parquet_data(data: list[list], pq_schema: pa.Schema) -> list[list]:
     """
     Returns a list with the data being modified to the data types specified by the
       pyarrow schema.

--- a/phdi/transport/http.py
+++ b/phdi/transport/http.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Literal
 
 import requests
@@ -10,7 +9,7 @@ def http_request_with_retry(
     url: str,
     retry_count: int,
     request_type: Literal["GET", "POST"],
-    allowed_methods: List[str],
+    allowed_methods: list[str],
     headers: dict,
     data: dict = None,
 ) -> requests.Response:

--- a/phdi/validation/__init__.py
+++ b/phdi/validation/__init__.py
@@ -1,23 +1,27 @@
-from phdi.validation.validation import _add_message_ids
-from phdi.validation.validation import _append_error_message
-from phdi.validation.validation import _clear_all_errors_and_ids
-from phdi.validation.validation import _organize_error_messages
-from phdi.validation.validation import _response_builder
-from phdi.validation.validation import validate_ecr
-from phdi.validation.xml_utils import _check_xml_names_and_attribs_exist
-from phdi.validation.xml_utils import _get_ecr_custom_message
-from phdi.validation.xml_utils import _get_xml_attributes
-from phdi.validation.xml_utils import _get_xml_message_id
-from phdi.validation.xml_utils import _get_xml_relative_iterator
-from phdi.validation.xml_utils import _get_xml_relatives_details
-from phdi.validation.xml_utils import _validate_xml_related_element
-from phdi.validation.xml_utils import _validate_xml_relatives
-from phdi.validation.xml_utils import ECR_NAMESPACES
-from phdi.validation.xml_utils import get_ecr_message_ids
-from phdi.validation.xml_utils import get_xml_element_details
-from phdi.validation.xml_utils import validate_xml_attributes
-from phdi.validation.xml_utils import validate_xml_elements
-from phdi.validation.xml_utils import validate_xml_value
+from phdi.validation.validation import (
+    _add_message_ids,
+    _append_error_message,
+    _clear_all_errors_and_ids,
+    _organize_error_messages,
+    _response_builder,
+    validate_ecr,
+)
+from phdi.validation.xml_utils import (
+    ECR_NAMESPACES,
+    _check_xml_names_and_attribs_exist,
+    _get_ecr_custom_message,
+    _get_xml_attributes,
+    _get_xml_message_id,
+    _get_xml_relative_iterator,
+    _get_xml_relatives_details,
+    _validate_xml_related_element,
+    _validate_xml_relatives,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 
 __all__ = [
     "validate_ecr",

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -1,11 +1,13 @@
 from lxml import etree
 
-from .xml_utils import ECR_NAMESPACES
-from .xml_utils import get_ecr_message_ids
-from .xml_utils import get_xml_element_details
-from .xml_utils import validate_xml_attributes
-from .xml_utils import validate_xml_elements
-from .xml_utils import validate_xml_value
+from .xml_utils import (
+    ECR_NAMESPACES,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 
 ERROR_MESSAGES = {
     "fatal": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+
 [tool.poetry]
 name = "phdi"
 version = "v1.7.6"
@@ -24,6 +25,7 @@ homepage = "https://github.com/CDCgov/phdi"
 repository = "https://github.com/CDCgov/phdi"
 documentation = "https://cdcgov.github.io/phdi"
 readme = "README.md"
+require-python = ">=3.10"
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -73,23 +75,31 @@ minversion = 6.0
 addopts = "--doctest-modules"
 
 [tool.ruff]
-exclude = [".git", ".pytest_cache", "__pycache__", "docs"]
+exclude = [".git", ".pytest_cache", "__pycache__", "docs", "examples/"]
 line-length = 88
 indent-width = 4
-target-version = "py310"
 show-fixes = true
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "D102", "D103", "D104", "D105", "D106"] # Defaults
+select = [
+  "F",    # Pyflakes
+  "E4",   # Pydocstyle errors
+  "E7",
+  "E9",
+  "W",    # Pydocstyle warnings
+  "D102", # Pydocstyle undocumented-public-method
+  "D103", # Pydocstyle undocumented-public-function
+  "D104", # Pydocstyle undocumented-public-package
+  "D105", # Pydocstyle undocumented-magic-method
+  "D106", # Pydocstyle undocumented-public-nested-class
+  "I",    # isort
+  "UP",   # pyupgrade
+  "FAST", # FastAPI
+  "FURB", # refrub
+]
 
 [tool.ruff.lint.per-file-ignores]
-"**/tests/*" = ["D"]
+"**/tests/*" = ["D", "S"]
 "**/__init__.py" = ["D"]
 "**/phdi/**/*" = ["D"]
 "**/utils/zip-search/**/*" = ["D"]
-
-[tool.ruff.lint.isort]
-# The following settings reduce the number of changes from reorder-python-imports
-force-single-line = true
-# lines-after-imports = 1
-order-by-type = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ select = [
   "D106", # Pydocstyle undocumented-public-nested-class
   "I",    # isort
   "UP",   # pyupgrade
-  "FAST", # FastAPI
   "FURB", # refrub
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ select = [
   "D106", # Pydocstyle undocumented-public-nested-class
   "I",    # isort
   "UP",   # pyupgrade
-  "FURB", # refrub
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -1,17 +1,14 @@
 import io
 import json
 import pathlib
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
 from azure.storage.blob import ContainerClient
 
-from phdi.cloud.azure import AzureCloudContainerConnection
-from phdi.cloud.azure import AzureCredentialManager
-from phdi.cloud.gcp import GcpCloudStorageConnection
-from phdi.cloud.gcp import GcpCredentialManager
+from phdi.cloud.azure import AzureCloudContainerConnection, AzureCredentialManager
+from phdi.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
 
 
 @mock.patch("phdi.cloud.azure.DefaultAzureCredential")

--- a/tests/containers/test_base_service.py
+++ b/tests/containers/test_base_service.py
@@ -3,9 +3,7 @@ from pathlib import Path
 import toml
 from fastapi.testclient import TestClient
 
-from phdi.containers.base_service import BaseService
-from phdi.containers.base_service import DIBBS_CONTACT
-from phdi.containers.base_service import LICENSES
+from phdi.containers.base_service import DIBBS_CONTACT, LICENSES, BaseService
 
 with open(Path(__file__).parent.parent / "pyproject.toml") as project_config_file:
     project_config = toml.load(project_config_file)

--- a/tests/fhir/conversion/test_conversion.py
+++ b/tests/fhir/conversion/test_conversion.py
@@ -5,9 +5,11 @@ import pytest
 from lxml import etree
 
 from phdi.fhir.conversion import convert_to_fhir
-from phdi.fhir.conversion.convert import _get_fhir_conversion_settings
-from phdi.fhir.conversion.convert import add_rr_data_to_eicr
-from phdi.fhir.conversion.convert import ConversionError
+from phdi.fhir.conversion.convert import (
+    ConversionError,
+    _get_fhir_conversion_settings,
+    add_rr_data_to_eicr,
+)
 from phdi.harmonization import standardize_hl7_datetimes
 
 

--- a/tests/fhir/harmonization/test_fhir_harmonization.py
+++ b/tests/fhir/harmonization/test_fhir_harmonization.py
@@ -2,11 +2,13 @@ import copy
 import json
 import pathlib
 
-from phdi.fhir.harmonization import double_metaphone_bundle
-from phdi.fhir.harmonization import double_metaphone_patient
-from phdi.fhir.harmonization import standardize_dob
-from phdi.fhir.harmonization import standardize_names
-from phdi.fhir.harmonization import standardize_phones
+from phdi.fhir.harmonization import (
+    double_metaphone_bundle,
+    double_metaphone_patient,
+    standardize_dob,
+    standardize_names,
+    standardize_phones,
+)
 from phdi.harmonization import DoubleMetaphone
 
 

--- a/tests/fhir/harmonization/test_standardization_helpers.py
+++ b/tests/fhir/harmonization/test_standardization_helpers.py
@@ -2,10 +2,12 @@ import copy
 import json
 import pathlib
 
-from phdi.fhir.harmonization.standardization import _extract_countries_from_resource
-from phdi.fhir.harmonization.standardization import _standardize_dob_in_resource
-from phdi.fhir.harmonization.standardization import _standardize_names_in_resource
-from phdi.fhir.harmonization.standardization import _standardize_phones_in_resource
+from phdi.fhir.harmonization.standardization import (
+    _extract_countries_from_resource,
+    _standardize_dob_in_resource,
+    _standardize_names_in_resource,
+    _standardize_phones_in_resource,
+)
 
 
 def test_standardize_names_in_resource():

--- a/tests/fhir/linkage/test_fhir_link.py
+++ b/tests/fhir/linkage/test_fhir_link.py
@@ -1,8 +1,10 @@
 import json
 import pathlib
 
-from phdi.fhir.linkage.link import add_patient_identifier
-from phdi.fhir.linkage.link import add_patient_identifier_in_bundle
+from phdi.fhir.linkage.link import (
+    add_patient_identifier,
+    add_patient_identifier_in_bundle,
+)
 from phdi.linkage.link import generate_hash_str
 
 

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -9,18 +9,20 @@ import pytest
 import yaml
 from requests.models import Response
 
-from phdi.fhir.tabulation.tables import _build_reference_dicts
-from phdi.fhir.tabulation.tables import _dereference_included_resource
-from phdi.fhir.tabulation.tables import _generate_search_url
-from phdi.fhir.tabulation.tables import _generate_search_urls
-from phdi.fhir.tabulation.tables import _get_reference_directions
-from phdi.fhir.tabulation.tables import _merge_include_query_params_for_location
-from phdi.fhir.tabulation.tables import drop_invalid
-from phdi.fhir.tabulation.tables import extract_data_from_fhir_search
-from phdi.fhir.tabulation.tables import extract_data_from_fhir_search_incremental
-from phdi.fhir.tabulation.tables import extract_data_from_schema
-from phdi.fhir.tabulation.tables import generate_tables
-from phdi.fhir.tabulation.tables import tabulate_data
+from phdi.fhir.tabulation.tables import (
+    _build_reference_dicts,
+    _dereference_included_resource,
+    _generate_search_url,
+    _generate_search_urls,
+    _get_reference_directions,
+    _merge_include_query_params_for_location,
+    drop_invalid,
+    extract_data_from_fhir_search,
+    extract_data_from_fhir_search_incremental,
+    extract_data_from_schema,
+    generate_tables,
+    tabulate_data,
+)
 
 
 def test_tabulate_data_invalid_table_name():
@@ -832,12 +834,11 @@ def test_generate_tables(patch_search_incremental):
             / "tabulation"
             / "tabulated_patients.csv"
         ),
-        "r",
     ) as e:
         csvreader = csv.reader(e)
         expected_content = [row for row in csvreader]
 
-    with open(patients_path, "r") as csv_file:
+    with open(patients_path) as csv_file:
         reader = csv.reader(csv_file, dialect="excel")
         line = 0
         for row in reader:
@@ -865,12 +866,11 @@ def test_generate_tables(patch_search_incremental):
             / "tabulation"
             / "tabulated_physical_exam.csv"
         ),
-        "r",
     ) as e:
         csvreader = csv.reader(e)
         expected_content = [row for row in csvreader]
 
-    with open(physical_exams_path, "r") as csv_file:
+    with open(physical_exams_path) as csv_file:
         reader = csv.reader(csv_file, dialect="excel")
         line = 0
         for row in reader:

--- a/tests/fhir/test_fhir_utils.py
+++ b/tests/fhir/test_fhir_utils.py
@@ -3,10 +3,12 @@ import pathlib
 
 import pytest
 
-from phdi.fhir.utils import apply_selection_criteria
-from phdi.fhir.utils import find_entries_by_resource_type
-from phdi.fhir.utils import get_field
-from phdi.fhir.utils import get_one_line_address
+from phdi.fhir.utils import (
+    apply_selection_criteria,
+    find_entries_by_resource_type,
+    get_field,
+    get_one_line_address,
+)
 
 
 def test_apply_selection_criteria():

--- a/tests/fhir/transport/test_fhir_transport.py
+++ b/tests/fhir/transport/test_fhir_transport.py
@@ -7,13 +7,14 @@ import polling
 import pytest
 import requests
 
-from phdi.fhir.transport import export_from_fhir_server
-from phdi.fhir.transport import http_request_with_reauth
+from phdi.fhir.transport import export_from_fhir_server, http_request_with_reauth
 from phdi.fhir.transport.export import _compose_export_url
-from phdi.fhir.transport.http import _log_fhir_server_error
-from phdi.fhir.transport.http import _split_bundle_resources
-from phdi.fhir.transport.http import fhir_server_get
-from phdi.fhir.transport.http import upload_bundle_to_fhir_server
+from phdi.fhir.transport.http import (
+    _log_fhir_server_error,
+    _split_bundle_resources,
+    fhir_server_get,
+    upload_bundle_to_fhir_server,
+)
 
 
 @mock.patch("requests.Session")

--- a/tests/harmonization/test_date_helpers.py
+++ b/tests/harmonization/test_date_helpers.py
@@ -1,7 +1,6 @@
 import pytest
 
-from phdi.harmonization.standardization import _standardize_date
-from phdi.harmonization.standardization import _validate_date
+from phdi.harmonization.standardization import _standardize_date, _validate_date
 
 
 def test_standardize_date():

--- a/tests/harmonization/test_harmonization.py
+++ b/tests/harmonization/test_harmonization.py
@@ -3,17 +3,19 @@ import pathlib
 import hl7
 import pytest
 
-from phdi.harmonization import convert_hl7_batch_messages_to_list
-from phdi.harmonization import default_hl7_value
-from phdi.harmonization import double_metaphone_string
-from phdi.harmonization import DoubleMetaphone
-from phdi.harmonization import normalize_hl7_datetime
-from phdi.harmonization import normalize_hl7_datetime_segment
-from phdi.harmonization import standardize_birth_date
-from phdi.harmonization import standardize_country_code
-from phdi.harmonization import standardize_hl7_datetimes
-from phdi.harmonization import standardize_name
-from phdi.harmonization import standardize_phone
+from phdi.harmonization import (
+    DoubleMetaphone,
+    convert_hl7_batch_messages_to_list,
+    default_hl7_value,
+    double_metaphone_string,
+    normalize_hl7_datetime,
+    normalize_hl7_datetime_segment,
+    standardize_birth_date,
+    standardize_country_code,
+    standardize_hl7_datetimes,
+    standardize_name,
+    standardize_phone,
+)
 from phdi.harmonization.utils import compare_strings
 
 

--- a/tests/linkage/test_dal.py
+++ b/tests/linkage/test_dal.py
@@ -2,10 +2,7 @@ import datetime
 import os
 import pathlib
 
-from sqlalchemy import Engine
-from sqlalchemy import select
-from sqlalchemy import Table
-from sqlalchemy import text
+from sqlalchemy import Engine, Table, select, text
 
 from phdi.linkage.dal import DataAccessLayer
 from phdi.linkage.mpi import DIBBsMPIConnectorClient

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -3,47 +3,49 @@ import json
 import os
 import pathlib
 import uuid
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 from json.decoder import JSONDecodeError
 from math import log
 from random import seed
 
 import pandas as pd
 import pytest
-from sqlalchemy import select
-from sqlalchemy import text
+from sqlalchemy import select, text
 
-from phdi.linkage import add_person_resource
-from phdi.linkage import calculate_log_odds
-from phdi.linkage import calculate_m_probs
-from phdi.linkage import calculate_u_probs
-from phdi.linkage import compile_match_lists
-from phdi.linkage import DIBBS_BASIC
-from phdi.linkage import DIBBS_ENHANCED
-from phdi.linkage import eval_log_odds_cutoff
-from phdi.linkage import eval_perfect_match
-from phdi.linkage import extract_blocking_values_from_record
-from phdi.linkage import feature_match_exact
-from phdi.linkage import feature_match_four_char
-from phdi.linkage import feature_match_fuzzy_string
-from phdi.linkage import feature_match_log_odds_exact
-from phdi.linkage import feature_match_log_odds_fuzzy_compare
-from phdi.linkage import generate_hash_str
-from phdi.linkage import link_record_against_mpi
-from phdi.linkage import load_json_probs
-from phdi.linkage import match_within_block
-from phdi.linkage import perform_linkage_pass
-from phdi.linkage import read_linkage_config
-from phdi.linkage import score_linkage_vs_truth
-from phdi.linkage import write_linkage_config
+from phdi.linkage import (
+    DIBBS_BASIC,
+    DIBBS_ENHANCED,
+    add_person_resource,
+    calculate_log_odds,
+    calculate_m_probs,
+    calculate_u_probs,
+    compile_match_lists,
+    eval_log_odds_cutoff,
+    eval_perfect_match,
+    extract_blocking_values_from_record,
+    feature_match_exact,
+    feature_match_four_char,
+    feature_match_fuzzy_string,
+    feature_match_log_odds_exact,
+    feature_match_log_odds_fuzzy_compare,
+    generate_hash_str,
+    link_record_against_mpi,
+    load_json_probs,
+    match_within_block,
+    perform_linkage_pass,
+    read_linkage_config,
+    score_linkage_vs_truth,
+    write_linkage_config,
+)
 from phdi.linkage.dal import DataAccessLayer
-from phdi.linkage.link import _compare_address_elements
-from phdi.linkage.link import _compare_name_elements
-from phdi.linkage.link import _condense_extract_address_from_resource
-from phdi.linkage.link import _convert_given_name_to_first_name
-from phdi.linkage.link import _flatten_patient_resource
-from phdi.linkage.link import _match_within_block_cluster_ratio
+from phdi.linkage.link import (
+    _compare_address_elements,
+    _compare_name_elements,
+    _condense_extract_address_from_resource,
+    _convert_given_name_to_first_name,
+    _flatten_patient_resource,
+    _match_within_block_cluster_ratio,
+)
 from phdi.linkage.mpi import DIBBsMPIConnectorClient
 from tests.test_data_generator import generate_list_patients_contact
 
@@ -1355,14 +1357,14 @@ def test_link_match_missing_address_record():
 
 
 def test_convert_given_name_to_first_name():
-    assert (
-        _convert_given_name_to_first_name([]) == []
-    ), "Empty data should return empty data"
+    assert _convert_given_name_to_first_name([]) == [], (
+        "Empty data should return empty data"
+    )
 
     data = [["last_name"], ["LENNON"], ["MCCARTNEY"], ["HARRISON"], ["STARKLEY"]]
-    assert (
-        _convert_given_name_to_first_name(data) == data
-    ), "Data without given names should return the same data"
+    assert _convert_given_name_to_first_name(data) == data, (
+        "Data without given names should return the same data"
+    )
 
     data = [
         [

--- a/tests/linkage/test_linkage_utils.py
+++ b/tests/linkage/test_linkage_utils.py
@@ -1,5 +1,4 @@
-from datetime import date
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
 

--- a/tests/linkage/test_mpi.py
+++ b/tests/linkage/test_mpi.py
@@ -6,9 +6,7 @@ import re
 import uuid
 
 import pytest
-from sqlalchemy import Select
-from sqlalchemy import select
-from sqlalchemy import text
+from sqlalchemy import Select, select, text
 
 from phdi.linkage.dal import DataAccessLayer
 from phdi.linkage.mpi import DIBBsMPIConnectorClient

--- a/tests/linkage/test_seed.py
+++ b/tests/linkage/test_seed.py
@@ -2,9 +2,11 @@ import pathlib
 
 import pyarrow.parquet as pq
 
-from phdi.linkage.seed import adjust_birthdate
-from phdi.linkage.seed import convert_to_patient_fhir_resources
-from phdi.linkage.seed import extract_given_name
+from phdi.linkage.seed import (
+    adjust_birthdate,
+    convert_to_patient_fhir_resources,
+    extract_given_name,
+)
 
 mpi_test_file_path = (
     pathlib.Path(__file__).parent.parent.parent

--- a/tests/tabulation/test_tables.py
+++ b/tests/tabulation/test_tables.py
@@ -13,13 +13,13 @@ import pytest
 import yaml
 
 from phdi.fhir.tabulation import tabulate_data
-from phdi.tabulation import load_schema
-from phdi.tabulation import validate_schema
-from phdi.tabulation import write_data
-from phdi.tabulation.tables import _convert_list_to_string
-from phdi.tabulation.tables import _create_from_arrays_data
-from phdi.tabulation.tables import _create_pa_schema_from_table_schema
-from phdi.tabulation.tables import _create_parquet_data
+from phdi.tabulation import load_schema, validate_schema, write_data
+from phdi.tabulation.tables import (
+    _convert_list_to_string,
+    _create_from_arrays_data,
+    _create_pa_schema_from_table_schema,
+    _create_parquet_data,
+)
 
 
 def test_load_schema():
@@ -106,7 +106,7 @@ def test_write_data_csv():
     # Batch 1 tests writing and creating brand new file
     # Only one row actually written in first batch
     write_data(batch_1, file_location, file_format, filename=output_file_name)
-    with open(file_location + output_file_name, "r") as csv_file:
+    with open(file_location + output_file_name) as csv_file:
         reader = csv.reader(csv_file, dialect="excel")
         line = 0
         for row in reader:
@@ -118,7 +118,7 @@ def test_write_data_csv():
     # Batch 2 tests appending to existing csv
     # Two more rows written here, make sure no duplicate header row
     write_data(batch_2, file_location, file_format, filename=output_file_name)
-    with open(file_location + output_file_name, "r") as csv_file:
+    with open(file_location + output_file_name) as csv_file:
         reader = csv.reader(csv_file, dialect="excel")
         line = 0
         for row in reader:

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -45,7 +45,6 @@ with open(
     / "assets"
     / "validation"
     / "sample_ecr_config_custom_messages.yaml",
-    "r",
 ) as file2:
     config_with_custom_errors = yaml.safe_load(file2)
 
@@ -55,7 +54,6 @@ with open(
     / "assets"
     / "validation"
     / "sample_ecr_config.yaml",
-    "r",
 ) as file:
     config = yaml.safe_load(file)
 
@@ -65,7 +63,6 @@ with open(
     / "assets"
     / "validation"
     / "sample_ecr_config_with_rr.yaml",
-    "r",
 ) as file:
     config_rr = yaml.safe_load(file)
 

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -1,11 +1,13 @@
 import pathlib
 
-from phdi.validation.validation import _add_message_ids
-from phdi.validation.validation import _append_error_message
-from phdi.validation.validation import _clear_all_errors_and_ids
-from phdi.validation.validation import _organize_error_messages
-from phdi.validation.validation import _response_builder
-from phdi.validation.validation import ERROR_MESSAGES
+from phdi.validation.validation import (
+    ERROR_MESSAGES,
+    _add_message_ids,
+    _append_error_message,
+    _clear_all_errors_and_ids,
+    _organize_error_messages,
+    _response_builder,
+)
 from tests.test_data_generator import generate_ecr_msg_ids
 
 test_include_errors = ["fatal", "errors", "warnings", "information"]

--- a/tests/validation/test_xml_utils.py
+++ b/tests/validation/test_xml_utils.py
@@ -2,22 +2,24 @@ import pathlib
 
 from lxml import etree
 
-from phdi.validation.xml_utils import _check_xml_names_and_attribs_exist
-from phdi.validation.xml_utils import _get_ecr_custom_message
-from phdi.validation.xml_utils import _get_xml_attributes
-from phdi.validation.xml_utils import _get_xml_message_id
-from phdi.validation.xml_utils import _get_xml_relative_iterator
-from phdi.validation.xml_utils import _get_xml_relatives_details
-from phdi.validation.xml_utils import _validate_xml_related_element
-from phdi.validation.xml_utils import _validate_xml_relatives
-from phdi.validation.xml_utils import ECR_NAMESPACES
-from phdi.validation.xml_utils import EICR_MSG_ID_XPATH
-from phdi.validation.xml_utils import get_ecr_message_ids
-from phdi.validation.xml_utils import get_xml_element_details
-from phdi.validation.xml_utils import RR_MSG_ID_XPATH
-from phdi.validation.xml_utils import validate_xml_attributes
-from phdi.validation.xml_utils import validate_xml_elements
-from phdi.validation.xml_utils import validate_xml_value
+from phdi.validation.xml_utils import (
+    ECR_NAMESPACES,
+    EICR_MSG_ID_XPATH,
+    RR_MSG_ID_XPATH,
+    _check_xml_names_and_attribs_exist,
+    _get_ecr_custom_message,
+    _get_xml_attributes,
+    _get_xml_message_id,
+    _get_xml_relative_iterator,
+    _get_xml_relatives_details,
+    _validate_xml_related_element,
+    _validate_xml_relatives,
+    get_ecr_message_ids,
+    get_xml_element_details,
+    validate_xml_attributes,
+    validate_xml_elements,
+    validate_xml_value,
+)
 
 test_include_errors = ["fatal", "errors", "warnings", "information"]
 

--- a/tutorials/geospatial-tutorial.md
+++ b/tutorials/geospatial-tutorial.md
@@ -37,7 +37,7 @@ Because the abstract base classes define these methods, all vendor-specific Geoc
 A `GeocodeResult` has the following attributes:
 
 ```
-line: List[str]
+line: list[str]
 city: str
 state: str
 postal_code: str


### PR DESCRIPTION
# PULL REQUEST

## Summary

Added the following rules:

"W" - Pydocstyle warnings
"UP" - Pyupgrade
Removed our isort configurations to enforce sorting of imports.

TLDR of Changes:
Including "W" caught a couple of trailing whitespaces. "UP" mostly moves away from using the deprecated typing library. 

Also, this should resolve #93 by aligning Ruff versions.

## Related Issue

Fixes #93 
