### PR TITLE
fix: rename report_date to encounter_date in EcrTableClient

### DIFF
--- a/containers/ecr-viewer/src/app/components/EcrTableClient.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrTableClient.tsx
@@ -48,7 +48,7 @@ const initialHeaders = [
     sortDirection: "",
   },
   {
-    id: "report_date",
+    id: "encounter_date",
     value: "Encounter Date",
     className: "library-encounter-date-column",
     dataSortable: true,

--- a/containers/ecr-viewer/src/app/components/EcrTableClient.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrTableClient.tsx
@@ -183,7 +183,8 @@ const Header = ({
         {column.value}
         {(column.sortDirection || column.dataSortable) && (
           <SortButton
-            columnName={column.id}
+            columnId={column.id}
+            columnName={column.value}
             className={classNames({
               "sortable-asc-column": column.sortDirection === "ASC",
               "sortable-desc-column": column.sortDirection === "DESC",

--- a/containers/ecr-viewer/src/app/components/SortButton.tsx
+++ b/containers/ecr-viewer/src/app/components/SortButton.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Button } from "@trussworks/react-uswds";
 
 type SortButtonProps = {
+  columnId: string;
   columnName: string;
   className: string;
   handleSort: (columnName: string, direction: string) => void;
@@ -12,20 +13,22 @@ type SortButtonProps = {
 /**
  * Functional component for a sort button.
  * @param props - Props containing button configurations.
- * @param props.columnName - The name of the column to sort
+ * @param props.columnId - The ID of the column to sort
+ * @param props.columnName - The display name of the column to sort
  * @param props.className   - The class name of the button
  * @param props.handleSort - The function to handle the click event
  * @param props.direction - The direction to sort by
  * @returns The JSX element representing the sort button.
  */
 export const SortButton: React.FC<SortButtonProps> = ({
+  columnId,
   columnName,
   className,
   handleSort,
   direction,
 }) => {
-  const buttonSelector = `${columnName}-sort-button`;
-  const headerSelectorToSort = `${columnName}-header`;
+  const buttonSelector = `${columnId}-sort-button`;
+  const headerSelectorToSort = `${columnId}-header`;
 
   function resetArrowDirections() {
     const arrowsToReset = document.querySelectorAll(
@@ -74,12 +77,12 @@ export const SortButton: React.FC<SortButtonProps> = ({
 
   return (
     <Button
-      id={`${columnName}-sort-button`}
+      id={`${columnId}-sort-button`}
       aria-label={`Sort by ${columnName}`}
       className={`sort-button usa-button ${className}`}
       type="button"
       onClick={() => {
-        handleSort(columnName, direction);
+        handleSort(columnId, direction);
         resetArrowDirections();
         changeArrowDirection();
         resetHeaderMarker();

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTable.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTable.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`EcrTable Snapshot test for EcrTableLoading should match snapshot 1`] = 
             >
               Patient
               <button
-                aria-label="Sort by patient"
+                aria-label="Sort by Patient"
                 class="usa-button sort-button usa-button sortable-column"
                 data-testid="button"
                 id="patient-sort-button"
@@ -45,7 +45,7 @@ exports[`EcrTable Snapshot test for EcrTableLoading should match snapshot 1`] = 
             >
               Received Date
               <button
-                aria-label="Sort by date_created"
+                aria-label="Sort by Received Date"
                 class="usa-button sort-button usa-button sortable-column"
                 data-testid="button"
                 id="date_created-sort-button"
@@ -56,7 +56,7 @@ exports[`EcrTable Snapshot test for EcrTableLoading should match snapshot 1`] = 
           <th
             class="library-encounter-date-column"
             data-sortable="true"
-            id="report_date-header"
+            id="encounter_date-header"
             role="columnheader"
             scope="col"
           >
@@ -65,10 +65,10 @@ exports[`EcrTable Snapshot test for EcrTableLoading should match snapshot 1`] = 
             >
               Encounter Date
               <button
-                aria-label="Sort by report_date"
+                aria-label="Sort by Encounter Date"
                 class="usa-button sort-button usa-button sortable-column"
                 data-testid="button"
-                id="report_date-sort-button"
+                id="encounter_date-sort-button"
                 type="button"
               />
             </div>
@@ -903,7 +903,7 @@ exports[`EcrTable should match snapshot 1`] = `
             >
               Patient
               <button
-                aria-label="Sort by patient"
+                aria-label="Sort by Patient"
                 class="usa-button sort-button usa-button sortable-column"
                 data-testid="button"
                 id="patient-sort-button"
@@ -924,7 +924,7 @@ exports[`EcrTable should match snapshot 1`] = `
             >
               Received Date
               <button
-                aria-label="Sort by date_created"
+                aria-label="Sort by Received Date"
                 class="usa-button sort-button usa-button sortable-desc-column"
                 data-testid="button"
                 id="date_created-sort-button"
@@ -935,7 +935,7 @@ exports[`EcrTable should match snapshot 1`] = `
           <th
             class="library-encounter-date-column"
             data-sortable="true"
-            id="report_date-header"
+            id="encounter_date-header"
             role="columnheader"
             scope="col"
           >
@@ -944,10 +944,10 @@ exports[`EcrTable should match snapshot 1`] = `
             >
               Encounter Date
               <button
-                aria-label="Sort by report_date"
+                aria-label="Sort by Encounter Date"
                 class="usa-button sort-button usa-button sortable-column"
                 data-testid="button"
-                id="report_date-sort-button"
+                id="encounter_date-sort-button"
                 type="button"
               />
             </div>


### PR DESCRIPTION
# PULL REQUEST

## Summary

Renames the ID of the sort button for the Encounter Date column to `encounter_date`. In addition use the column value in the aria-label.

## Related Issue

Fixes #290 

## Acceptance Criteria

- [ ] Aria label and element name for sort button are updated to "encounter date" instead of "report date"

## Additional Information

### Previous
<img width="398" alt="image" src="https://github.com/user-attachments/assets/98e7e4ef-a44f-43f0-be9b-00e1496b900e" />

### New
<img width="387" alt="image" src="https://github.com/user-attachments/assets/336c3ea4-8d07-417d-8147-2b98641925b5" />

