### PR TITLE
fix: update back button image to be aria hidden

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/BackButton.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/BackButton.test.tsx
@@ -33,6 +33,8 @@ describe("Back button", () => {
 
     render(<BackButton iconClassName="some-icon-class" />);
 
-    expect(screen.getByRole("img").classList).toContain("some-icon-class");
+    expect(screen.getByRole("link").children[0].classList).toContain(
+      "some-icon-class",
+    );
   });
 });

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
                 href="/"
               >
                 <svg
-                  aria-label="Back Arrow"
+                  aria-hidden="true"
                   class="usa-icon usa-icon--size-3 text-middle margin-right-1 text-base"
                   focusable="false"
                   height="1em"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SectionConfig should match the snapshot 1`] = `
       href="/"
     >
       <svg
-        aria-label="Back Arrow"
+        aria-hidden="true"
         class="usa-icon usa-icon--size-3 text-middle margin-right-1 text-base"
         focusable="false"
         height="1em"

--- a/containers/ecr-viewer/src/app/view-data/components/BackButton.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/BackButton.tsx
@@ -34,7 +34,7 @@ export const BackButton = ({ className, iconClassName }: BackButtonProps) => {
         className={classNames("display-inline-block", className)}
       >
         <ArrowBack
-          aria-label={"Back Arrow"}
+          aria-hidden
           size={3}
           className={classNames("text-middle margin-right-1", iconClassName)}
         />


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Remove aria label and apply aria-hidden to the back button based on [uswds docs](https://designsystem.digital.gov/components/icon/#:~:text=Hide%20decorative%20icons%20from%20screen%20readers).

## Related Issue

Fixes #294 

## Acceptance Criteria

- [ ] Back arrow has no aria text

