### PR TITLE
Update DB schemas to use new ecr-viewer schema not dbo

### DIFF
--- a/containers/ecr-viewer/sql/core.sql
+++ b/containers/ecr-viewer/sql/core.sql
@@ -1,6 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE ecr_data (
+CREATE SCHEMA ecr_viewer;
+
+CREATE TABLE ecr_viewer.ecr_data (
   eICR_ID VARCHAR(200) PRIMARY KEY,
   set_id VARCHAR(255),
   eicr_version_number VARCHAR(50),
@@ -13,14 +15,14 @@ CREATE TABLE ecr_data (
   report_date DATE
 );
 
-CREATE TABLE ecr_rr_conditions (
+CREATE TABLE ecr_viewer.ecr_rr_conditions (
     uuid VARCHAR(200) PRIMARY KEY,
-    eICR_ID VARCHAR(200) NOT NULL REFERENCES ecr_data(eICR_ID),
+    eICR_ID VARCHAR(200) NOT NULL REFERENCES ecr_viewer.ecr_data(eICR_ID),
     condition VARCHAR
 );
 
-CREATE TABLE ecr_rr_rule_summaries (
+CREATE TABLE ecr_viewer.ecr_rr_rule_summaries (
     uuid VARCHAR(200) PRIMARY KEY,
-    ecr_rr_conditions_id VARCHAR(200) REFERENCES ecr_rr_conditions(uuid),
+    ecr_rr_conditions_id VARCHAR(200) REFERENCES ecr_viewer.ecr_rr_conditions(uuid),
     rule_summary VARCHAR
 );

--- a/containers/ecr-viewer/sql/extended.sql
+++ b/containers/ecr-viewer/sql/extended.sql
@@ -1,4 +1,6 @@
-CREATE TABLE ECR_DATA
+CREATE SCHEMA ecr_viewer;
+
+CREATE TABLE ecr_viewer.ECR_DATA
 (
     eICR_ID                  VARCHAR(200) PRIMARY KEY,
     set_id                   VARCHAR(255),
@@ -39,7 +41,7 @@ CREATE TABLE ECR_DATA
     date_created DATETIMEOFFSET NOT NULL DEFAULT SYSDATETIMEOFFSET(),
 );
 
-CREATE TABLE patient_address
+CREATE TABLE ecr_viewer.patient_address
 (
     UUID VARCHAR(200) PRIMARY KEY,
     [use]  VARCHAR(7), -- The valid values are: "home" | "work" | "temp" | "old" | "billing"
@@ -53,28 +55,28 @@ CREATE TABLE patient_address
     country VARCHAR(255),
     period_start DATETIMEOFFSET,
     period_end DATETIMEOFFSET,
-    eICR_ID VARCHAR(200) REFERENCES ECR_DATA (eICR_ID)
+    eICR_ID VARCHAR(200) REFERENCES ecr_viewer.ECR_DATA (eICR_ID)
 )
 
-CREATE TABLE ecr_rr_conditions
+CREATE TABLE ecr_viewer.ecr_rr_conditions
 (
     UUID      VARCHAR(200) PRIMARY KEY,
-    eICR_ID   VARCHAR(200) NOT NULL REFERENCES ECR_DATA (eICR_ID),
+    eICR_ID   VARCHAR(200) NOT NULL REFERENCES ecr_viewer.ECR_DATA (eICR_ID),
     condition VARCHAR(MAX)
 );
 
-CREATE TABLE ecr_rr_rule_summaries
+CREATE TABLE ecr_viewer.ecr_rr_rule_summaries
 (
     UUID                 VARCHAR(200) PRIMARY KEY,
-    ECR_RR_CONDITIONS_ID VARCHAR(200) REFERENCES ecr_rr_conditions (UUID),
+    ECR_RR_CONDITIONS_ID VARCHAR(200) REFERENCES ecr_viewer.ecr_rr_conditions (UUID),
     rule_summary         VARCHAR(MAX)
 );
 
 
-CREATE TABLE ecr_labs
+CREATE TABLE ecr_viewer.ecr_labs
 (
     UUID                                   VARCHAR(200),
-    eICR_ID                                VARCHAR(200) REFERENCES ECR_DATA (eICR_ID),
+    eICR_ID                                VARCHAR(200) REFERENCES ecr_viewer.ECR_DATA (eICR_ID),
     test_type                              VARCHAR(255),
     test_type_code                         VARCHAR(50),
     test_type_system                       VARCHAR(255),


### PR DESCRIPTION
# PULL REQUEST

## Summary

Creates a new ecr-viewer schema for our tables to live in per Philly's request rather than landing in dbo by default

## Related Issue

Fixes #41 

## Acceptance Criteria

- [ ] All tables, within both core and extended models, live in a custom `ecr-viewer` schema
- [ ] This new schema is created once on database initialization (run manually?)
