### PR TITLE
refactor: break up `.scss` files into more clear scopes

### DIFF
--- a/containers/ecr-viewer/src/app/components/EcrPaginationWrapper.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrPaginationWrapper.tsx
@@ -68,7 +68,7 @@ const EcrPaginationWrapper = ({
   );
 
   return (
-    <div className="main-container height-ecrLibrary flex-column flex-align-center">
+    <div className="main-container height-ecr-library flex-column flex-align-center">
       {children}
       <div className="pagination-bar width-full padding-x-3 padding-y-105 flex-align-self-stretch display-flex flex-align-center">
         <div className={"flex-1"}>

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
@@ -12,25 +12,25 @@ exports[`Active Problems Table should match snapshot 1`] = `
     <thead>
       <tr>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Active Problem
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Onset Date/Time
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Onset Age
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Comments

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
@@ -117,13 +117,13 @@ exports[`Snapshot test for Clinical Notes should match snapshot for table notes 
                     <thead>
                       <tr>
                         <th
-                          class="tableHeader bg-gray-5 minw-10"
+                          class="table-header bg-gray-5 minw-10"
                           scope="col"
                         >
                           Active Problems
                         </th>
                         <th
-                          class="tableHeader bg-gray-5 minw-10"
+                          class="table-header bg-gray-5 minw-10"
                           scope="col"
                         >
                           Noted Date
@@ -205,19 +205,19 @@ exports[`Snapshot test for Procedures (Treatment Details) should match snapshot 
                     <thead>
                       <tr>
                         <th
-                          class="tableHeader"
+                          class="table-header"
                           scope="col"
                         >
                           Name
                         </th>
                         <th
-                          class="tableHeader"
+                          class="table-header"
                           scope="col"
                         >
                           Date/Time Performed
                         </th>
                         <th
-                          class="tableHeader"
+                          class="table-header"
                           scope="col"
                         >
                           Reason

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrPaginationWrapper.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrPaginationWrapper.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EcrPaginationWrapper should match snapshot 1`] = `
 <div>
   <div
-    class="main-container height-ecrLibrary flex-column flex-align-center"
+    class="main-container height-ecr-library flex-column flex-align-center"
   >
     <br />
     <div

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Immunizations.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Immunizations.test.tsx.snap
@@ -12,31 +12,31 @@ exports[`Immunizations Table should match snapshot 1`] = `
     <thead>
       <tr>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Name
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Administration Dates
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Dose Number
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Manufacturer
         </th>
         <th
-          class="tableHeader"
+          class="table-header"
           scope="col"
         >
           Lot Number

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LabInfo.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LabInfo.test.tsx.snap
@@ -62,19 +62,19 @@ exports[`LabInfo when labResults is DisplayDataProps[] should match snapshot tes
                         <thead>
                           <tr>
                             <th
-                              class="tableHeader bg-gray-5 minw-10"
+                              class="table-header bg-gray-5 minw-10"
                               scope="col"
                             >
                               Lab Test Name
                             </th>
                             <th
-                              class="tableHeader bg-gray-5 minw-10"
+                              class="table-header bg-gray-5 minw-10"
                               scope="col"
                             >
                               Lab Test Result Value
                             </th>
                             <th
-                              class="tableHeader bg-gray-5 minw-10"
+                              class="table-header bg-gray-5 minw-10"
                               scope="col"
                             >
                               Lab Test Result Date
@@ -258,31 +258,31 @@ Mos Eisley, CO
                   <thead>
                     <tr>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Component
                       </th>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Value
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Ref Range
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Test Method
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Lab Comment
@@ -588,31 +588,31 @@ Mos Eisley, CO
                   <thead>
                     <tr>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Component
                       </th>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Value
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Ref Range
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Test Method
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Lab Comment
@@ -1019,31 +1019,31 @@ Coruscant, MA
                   <thead>
                     <tr>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Component
                       </th>
                       <th
-                        class="tableHeader minw-10 width-40"
+                        class="table-header minw-10 width-40"
                         scope="col"
                       >
                         Value
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Ref Range
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Test Method
                       </th>
                       <th
-                        class="tableHeader minw-10 width-20"
+                        class="table-header minw-10 width-20"
                         scope="col"
                       >
                         Lab Comment
@@ -1154,25 +1154,25 @@ Coruscant, MA
                   <thead>
                     <tr>
                       <th
-                        class="tableHeader"
+                        class="table-header"
                         scope="col"
                       >
                         Organism
                       </th>
                       <th
-                        class="tableHeader"
+                        class="table-header"
                         scope="col"
                       >
                         Antibiotic
                       </th>
                       <th
-                        class="tableHeader"
+                        class="table-header"
                         scope="col"
                       >
                         Method
                       </th>
                       <th
-                        class="tableHeader"
+                        class="table-header"
                         scope="col"
                       >
                         Susceptibility

--- a/containers/ecr-viewer/src/app/tests/services/__snapshots__/socialHistoryService.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/services/__snapshots__/socialHistoryService.test.tsx.snap
@@ -12,25 +12,25 @@ exports[`Travel History should display a table  1`] = `
     <thead>
       <tr>
         <th
-          class="tableHeader bg-gray-5 minw-10"
+          class="table-header bg-gray-5 minw-10"
           scope="col"
         >
           Location
         </th>
         <th
-          class="tableHeader bg-gray-5 minw-10"
+          class="table-header bg-gray-5 minw-10"
           scope="col"
         >
           Start Date
         </th>
         <th
-          class="tableHeader bg-gray-5 minw-10"
+          class="table-header bg-gray-5 minw-10"
           scope="col"
         >
           End Date
         </th>
         <th
-          class="tableHeader bg-gray-5 minw-10"
+          class="table-header bg-gray-5 minw-10"
           scope="col"
         >
           Purpose

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
@@ -126,7 +126,7 @@ const BaseTableHeaders = ({
         <th
           key={`${column.columnName}${index}`}
           scope="col"
-          className={classNames("tableHeader", column.className)}
+          className={classNames("table-header", column.className)}
         >
           {column.columnName}
         </th>

--- a/containers/ecr-viewer/src/styles/common.scss
+++ b/containers/ecr-viewer/src/styles/common.scss
@@ -1,0 +1,68 @@
+// This file contains declarations which are used in high level components or which style
+// elements without a modifier to scope them to a specific component
+
+@keyframes shimmer {
+  to {
+    background-position-x: 0%;
+  }
+}
+
+.loading-blob {
+  border-radius: 8px;
+  animation: shimmer 0.75s infinite linear;
+
+  background-size: 300%;
+  background-position-x: 100%;
+
+  &-blue {
+    background-image: linear-gradient(
+      -90deg,
+      #99deea 40%,
+      #71d5e6 50%,
+      #99deea 60%
+    );
+  }
+
+  &-gray {
+    background-image: linear-gradient(
+      -90deg,
+      #f0f0f0 40%,
+      #e4e4e4 50%,
+      #f0f0f0 60%
+    );
+  }
+
+  &-dark-gray {
+    background-image: linear-gradient(
+      -90deg,
+      #dfe1e2 40%,
+      #cfcfcf 50%,
+      #dfe1e2 60%
+    );
+  }
+}
+
+h2 {
+  font-size: 2.5rem;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+h3 {
+  font-size: 1.375rem;
+}
+
+h4 {
+  font-size: 16px;
+  margin: 0;
+}
+
+td {
+  vertical-align: top;
+}
+
+.main-container {
+  display: flex;
+  justify-content: center;
+  overflow: visible;
+}

--- a/containers/ecr-viewer/src/styles/common.scss
+++ b/containers/ecr-viewer/src/styles/common.scss
@@ -1,6 +1,35 @@
 // This file contains declarations which are used in high level components or which style
 // elements without a modifier to scope them to a specific component
 
+// ==== Base element styles ===== //
+
+h2 {
+  font-size: 2.5rem;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+h3 {
+  font-size: 1.375rem;
+}
+
+h4 {
+  font-size: 16px;
+  margin: 0;
+}
+
+td {
+  vertical-align: top;
+}
+
+// ==== Common component classes ===== //
+
+.main-container {
+  display: flex;
+  justify-content: center;
+  overflow: visible;
+}
+
 @keyframes shimmer {
   to {
     background-position-x: 0%;
@@ -40,29 +69,4 @@
       #dfe1e2 60%
     );
   }
-}
-
-h2 {
-  font-size: 2.5rem;
-  margin-top: 0;
-  margin-bottom: 20px;
-}
-
-h3 {
-  font-size: 1.375rem;
-}
-
-h4 {
-  font-size: 16px;
-  margin: 0;
-}
-
-td {
-  vertical-align: top;
-}
-
-.main-container {
-  display: flex;
-  justify-content: center;
-  overflow: visible;
 }

--- a/containers/ecr-viewer/src/styles/custom-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-styles.scss
@@ -17,38 +17,6 @@ html {
   scroll-margin-top: calc(var(--patient-banner-buffer) + 0.75em);
 }
 
-.ecr-table-list {
-  @include unstyled-list;
-  li:not(:first-child) {
-    margin-top: 1rem;
-  }
-}
-
-.library-patient-column {
-  min-width: 16.3rem;
-  width: 18%;
-}
-
-.library-received-date-column {
-  width: 8.3rem;
-  min-width: 8.3rem;
-}
-
-.library-encounter-date-column {
-  width: 10%;
-  min-width: 8.3rem;
-}
-
-.library-condition-column {
-  min-width: 23rem;
-  width: 25%;
-}
-
-.library-rule-column {
-  min-width: 35.5rem;
-  width: auto;
-}
-
 .vertical-line {
   border-left: 1px solid #005ea2;
   margin-left: 0.5rem;
@@ -80,10 +48,6 @@ h2 {
 h4 {
   font-size: 16px;
   margin: 0;
-}
-
-.maxw7 {
-  max-width: 68%;
 }
 
 .page-title {
@@ -192,177 +156,6 @@ h4 {
   }
 }
 
-.filter-button {
-  background-color: color("base-lightest");
-  box-shadow: inset 0 0 0 2px color("base-light");
-  font-weight: normal;
-
-  span svg {
-    fill: color("base-light");
-  }
-
-  &:hover {
-    background-color: color("base-lighter");
-    box-shadow: inset 0 0 0 2px color("base");
-
-    span svg {
-      fill: color("base");
-    }
-  }
-
-  &:active {
-    background-color: color("base-lightest");
-    box-shadow: inset 0 0 0 2px color("base-light");
-
-    span svg {
-      fill: color("base-light");
-    }
-  }
-}
-
-.filters-applied {
-  box-shadow: inset 0 0 0 2px color("primary");
-  background-color: color("primary-lighter");
-  font-weight: bold;
-
-  span svg {
-    fill: color("primary");
-  }
-
-  &:hover {
-    box-shadow: inset 0 0 0 2px color("primary-dark");
-    background-color: color("primary-light");
-
-    span svg {
-      fill: color("primary-dark");
-    }
-  }
-
-  &:active {
-    box-shadow: inset 0 0 0 2px color("primary");
-    background-color: color("primary-lighter");
-
-    span svg {
-      fill: color("primary");
-    }
-  }
-}
-
-.sort-button {
-  border: none;
-  transition: none;
-  margin-left: auto;
-  background-color: transparent;
-  &:hover {
-    background-color: transparent; /* Removes the hover background */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-  &:active {
-    background-color: transparent; /* Keeps the original background color */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-  &:focus {
-    background-color: transparent; /* Removes fill after click */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-}
-
-.sortable-column,
-.sortable-desc-column,
-.sortable-asc-column {
-  &.usa-button {
-    margin-left: auto;
-    justify-content: flex-end;
-    padding: 12px;
-  }
-}
-
-.sortable-column {
-  @include add-background-svg("usa-icons/sort_arrow");
-}
-
-.sortable-desc-column {
-  @include add-background-svg("usa-icons/arrow_downward");
-}
-
-.sortable-asc-column {
-  @include add-background-svg("usa-icons/arrow_upward");
-}
-
-.sort-div {
-  width: 100%;
-  display: flex;
-}
-
-.ecr-library-wrapper {
-  height: calc(100% - 4rem);
-}
-
-.table-ecr-library {
-  font-size: 1rem;
-  border-collapse: separate;
-  font-family: "Source Sans Pro Web";
-
-  // Hide highlight color by matching th color on sorted column - per design
-  &.usa-table th {
-    &[aria-sort="descending"] {
-      background-color: #dfe1e2;
-    }
-    &[aria-sort="ascending"] {
-      background-color: #dfe1e2;
-    }
-  }
-
-  a {
-    color: var(--Primary-primary, #005ea2);
-    font-size: 1rem;
-    font-style: normal;
-    font-weight: 700;
-  }
-
-  a,
-  u {
-    text-decoration: none;
-  }
-
-  tbody tr td div {
-    font-size: 1rem;
-    font-style: normal;
-    font-weight: 400;
-  }
-
-  &.usa-table--striped tbody tr:nth-child(odd) td {
-    background-color: white;
-  }
-
-  &.usa-table--striped tbody tr:nth-child(even) td {
-    background-color: color("base-lightest");
-  }
-
-  thead {
-    box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
-
-    th {
-      background-color: color("base-lighter");
-      border-bottom: 1px solid var(--Base-base, #71767a);
-    }
-  }
-
-  thead tr th:first-child,
-  tbody tr td:first-child {
-    padding-left: 1.5rem;
-  }
-
-  tbody td {
-    border-top: 0;
-    border-bottom: 1px solid var(--ink, #111);
-  }
-
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-}
-
 .table-clinical-problems {
   tbody td:nth-child(2) {
     min-width: 130px;
@@ -446,14 +239,6 @@ td {
 
 .usa-sidenav__item a:not(.usa-sidenav__sublist a) {
   font-weight: bold;
-}
-
-.pagination-bar {
-  .usa-pagination {
-    margin: 0;
-  }
-
-  box-shadow: 0 -0.25rem 0.25rem rgba(0, 0, 0, 0.1);
 }
 
 .main-container {
@@ -694,10 +479,6 @@ ul.usa-sidenav
   color: #111111;
 }
 
-.checkbox-color .usa-checkbox__label::before {
-  box-shadow: 0 0 0 0.125rem color("base");
-}
-
 .patient-banner {
   display: flex;
   padding: 0.5rem 1.5rem;
@@ -759,12 +540,4 @@ h3 {
   .usa-accordion__button {
     padding: 0.88rem 0.75rem;
   }
-}
-
-.width-21-9375 {
-  width: 21.9375rem;
-}
-
-.height-ecrLibrary {
-  height: calc(100% - 2.45rem - 1.5rem - 4.45rem);
 }

--- a/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
@@ -1,36 +1,8 @@
 // This file contains customizations of USWDS classes without a modifier
 // which scopes it to a specific component.
 
-.usa-table {
-  overflow-wrap: break-word;
-
-  thead th {
-    background-color: #f0f0f0;
-    vertical-align: top;
-  }
-
-  th,
-  td {
-    padding: 0.75rem;
-  }
-}
-
 .usa-accordion__content {
   overflow: visible;
-}
-
-.usa-tooltip__body {
-  max-width: 700px;
-  min-width: min(450px, 0.25 * (100vw - 16rem));
-  white-space: normal;
-  text-align: left;
-  font-weight: normal;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-.short-tooltip + .usa-tooltip__body {
-  min-width: min(350px, 0.25 * (100vw - 16rem));
 }
 
 .usa-header {
@@ -83,4 +55,32 @@
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+}
+
+.usa-table {
+  overflow-wrap: break-word;
+
+  thead th {
+    background-color: #f0f0f0;
+    vertical-align: top;
+  }
+
+  th,
+  td {
+    padding: 0.75rem;
+  }
+}
+
+.usa-tooltip__body {
+  max-width: 700px;
+  min-width: min(450px, 0.25 * (100vw - 16rem));
+  white-space: normal;
+  text-align: left;
+  font-weight: normal;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.short-tooltip + .usa-tooltip__body {
+  min-width: min(350px, 0.25 * (100vw - 16rem));
 }

--- a/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
@@ -1,0 +1,86 @@
+// This file contains customizations of USWDS classes without a modifier
+// which scopes it to a specific component.
+
+.usa-table {
+  overflow-wrap: break-word;
+
+  thead th {
+    background-color: #f0f0f0;
+    vertical-align: top;
+  }
+
+  th,
+  td {
+    padding: 0.75rem;
+  }
+}
+
+.usa-accordion__content {
+  overflow: visible;
+}
+
+.usa-tooltip__body {
+  max-width: 700px;
+  min-width: min(450px, 0.25 * (100vw - 16rem));
+  white-space: normal;
+  text-align: left;
+  font-weight: normal;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.short-tooltip + .usa-tooltip__body {
+  min-width: min(350px, 0.25 * (100vw - 16rem));
+}
+
+.usa-header {
+  background-color: #172e51;
+  color: white;
+
+  .usa-logo {
+    margin-left: 0px;
+
+    a {
+      color: white;
+    }
+  }
+
+  .usa-navbar {
+    border-bottom: none;
+  }
+
+  @media (min-width: 64em) {
+    .usa-logo {
+      margin-bottom: 1.5rem;
+      margin-top: 1.5rem;
+    }
+
+    .usa-nav-container {
+      max-width: 65rem;
+      margin-left: 0px;
+      padding: 0.5rem 1.5rem;
+    }
+  }
+
+  .usa-nav-container {
+    max-width: 65rem;
+    margin-left: 0px;
+    padding: 0.5rem 1.5rem;
+  }
+
+  h1 {
+    font-style: normal;
+    font-weight: bold;
+    font-size: 2rem;
+  }
+}
+
+.usa-summary-box {
+  padding: 0.75rem 1.5rem 1.5rem 1.5rem;
+
+  h3:not(.usa-accordion__heading) {
+    margin: 0px;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}

--- a/containers/ecr-viewer/src/styles/ecr-library.scss
+++ b/containers/ecr-viewer/src/styles/ecr-library.scss
@@ -1,3 +1,5 @@
+// This file contains declarations used in the styling of the ecr library (root) page
+
 @use "uswds-core" as *;
 
 .ecr-table-list {

--- a/containers/ecr-viewer/src/styles/ecr-library.scss
+++ b/containers/ecr-viewer/src/styles/ecr-library.scss
@@ -1,0 +1,220 @@
+@use "uswds-core" as *;
+
+.ecr-table-list {
+  @include unstyled-list;
+  li:not(:first-child) {
+    margin-top: 1rem;
+  }
+}
+
+.library-patient-column {
+  min-width: 16.3rem;
+  width: 18%;
+}
+
+.library-received-date-column {
+  width: 8.3rem;
+  min-width: 8.3rem;
+}
+
+.library-encounter-date-column {
+  width: 10%;
+  min-width: 8.3rem;
+}
+
+.library-condition-column {
+  min-width: 23rem;
+  width: 25%;
+}
+
+.library-rule-column {
+  min-width: 35.5rem;
+  width: auto;
+}
+
+.filter-button {
+  background-color: color("base-lightest");
+  box-shadow: inset 0 0 0 2px color("base-light");
+  font-weight: normal;
+
+  span svg {
+    fill: color("base-light");
+  }
+
+  &:hover {
+    background-color: color("base-lighter");
+    box-shadow: inset 0 0 0 2px color("base");
+
+    span svg {
+      fill: color("base");
+    }
+  }
+
+  &:active {
+    background-color: color("base-lightest");
+    box-shadow: inset 0 0 0 2px color("base-light");
+
+    span svg {
+      fill: color("base-light");
+    }
+  }
+}
+
+.filters-applied {
+  box-shadow: inset 0 0 0 2px color("primary");
+  background-color: color("primary-lighter");
+  font-weight: bold;
+
+  span svg {
+    fill: color("primary");
+  }
+
+  &:hover {
+    box-shadow: inset 0 0 0 2px color("primary-dark");
+    background-color: color("primary-light");
+
+    span svg {
+      fill: color("primary-dark");
+    }
+  }
+
+  &:active {
+    box-shadow: inset 0 0 0 2px color("primary");
+    background-color: color("primary-lighter");
+
+    span svg {
+      fill: color("primary");
+    }
+  }
+}
+
+.sort-button {
+  border: none;
+  transition: none;
+  margin-left: auto;
+  background-color: transparent;
+  &:hover {
+    background-color: transparent; /* Removes the hover background */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+  &:active {
+    background-color: transparent; /* Keeps the original background color */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+  &:focus {
+    background-color: transparent; /* Removes fill after click */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+}
+
+.sortable-column,
+.sortable-desc-column,
+.sortable-asc-column {
+  &.usa-button {
+    margin-left: auto;
+    justify-content: flex-end;
+    padding: 12px;
+  }
+}
+
+.sortable-column {
+  @include add-background-svg("usa-icons/sort_arrow");
+}
+
+.sortable-desc-column {
+  @include add-background-svg("usa-icons/arrow_downward");
+}
+
+.sortable-asc-column {
+  @include add-background-svg("usa-icons/arrow_upward");
+}
+
+.sort-div {
+  width: 100%;
+  display: flex;
+}
+
+.ecr-library-wrapper {
+  height: calc(100% - 4rem);
+}
+
+.table-ecr-library {
+  font-size: 1rem;
+  border-collapse: separate;
+  font-family: "Source Sans Pro Web";
+
+  // Hide highlight color by matching th color on sorted column - per design
+  &.usa-table th {
+    &[aria-sort="descending"] {
+      background-color: #dfe1e2;
+    }
+    &[aria-sort="ascending"] {
+      background-color: #dfe1e2;
+    }
+  }
+
+  a {
+    color: var(--Primary-primary, #005ea2);
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  a,
+  u {
+    text-decoration: none;
+  }
+
+  tbody tr td div {
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 400;
+  }
+
+  &.usa-table--striped tbody tr:nth-child(odd) td {
+    background-color: white;
+  }
+
+  &.usa-table--striped tbody tr:nth-child(even) td {
+    background-color: color("base-lightest");
+  }
+
+  thead {
+    box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
+
+    th {
+      background-color: color("base-lighter");
+      border-bottom: 1px solid var(--Base-base, #71767a);
+    }
+  }
+
+  thead tr th:first-child,
+  tbody tr td:first-child {
+    padding-left: 1.5rem;
+  }
+
+  tbody td {
+    border-top: 0;
+    border-bottom: 1px solid var(--ink, #111);
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.pagination-bar {
+  .usa-pagination {
+    margin: 0;
+  }
+
+  box-shadow: 0 -0.25rem 0.25rem rgba(0, 0, 0, 0.1);
+}
+
+.checkbox-color .usa-checkbox__label::before {
+  box-shadow: 0 0 0 0.125rem color("base");
+}
+
+.height-ecr-library {
+  height: calc(100% - 2.45rem - 1.5rem - 4.45rem);
+}

--- a/containers/ecr-viewer/src/styles/ecr-library.scss
+++ b/containers/ecr-viewer/src/styles/ecr-library.scss
@@ -2,12 +2,7 @@
 
 @use "uswds-core" as *;
 
-.ecr-table-list {
-  @include unstyled-list;
-  li:not(:first-child) {
-    margin-top: 1rem;
-  }
-}
+// ==== Table styling ===== //
 
 .library-patient-column {
   min-width: 16.3rem;
@@ -34,110 +29,11 @@
   width: auto;
 }
 
-.filter-button {
-  background-color: color("base-lightest");
-  box-shadow: inset 0 0 0 2px color("base-light");
-  font-weight: normal;
-
-  span svg {
-    fill: color("base-light");
+.ecr-table-list {
+  @include unstyled-list;
+  li:not(:first-child) {
+    margin-top: 1rem;
   }
-
-  &:hover {
-    background-color: color("base-lighter");
-    box-shadow: inset 0 0 0 2px color("base");
-
-    span svg {
-      fill: color("base");
-    }
-  }
-
-  &:active {
-    background-color: color("base-lightest");
-    box-shadow: inset 0 0 0 2px color("base-light");
-
-    span svg {
-      fill: color("base-light");
-    }
-  }
-}
-
-.filters-applied {
-  box-shadow: inset 0 0 0 2px color("primary");
-  background-color: color("primary-lighter");
-  font-weight: bold;
-
-  span svg {
-    fill: color("primary");
-  }
-
-  &:hover {
-    box-shadow: inset 0 0 0 2px color("primary-dark");
-    background-color: color("primary-light");
-
-    span svg {
-      fill: color("primary-dark");
-    }
-  }
-
-  &:active {
-    box-shadow: inset 0 0 0 2px color("primary");
-    background-color: color("primary-lighter");
-
-    span svg {
-      fill: color("primary");
-    }
-  }
-}
-
-.sort-button {
-  border: none;
-  transition: none;
-  margin-left: auto;
-  background-color: transparent;
-  &:hover {
-    background-color: transparent; /* Removes the hover background */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-  &:active {
-    background-color: transparent; /* Keeps the original background color */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-  &:focus {
-    background-color: transparent; /* Removes fill after click */
-    color: inherit; /* Keeps the text color unchanged */
-  }
-}
-
-.sortable-column,
-.sortable-desc-column,
-.sortable-asc-column {
-  &.usa-button {
-    margin-left: auto;
-    justify-content: flex-end;
-    padding: 12px;
-  }
-}
-
-.sortable-column {
-  @include add-background-svg("usa-icons/sort_arrow");
-}
-
-.sortable-desc-column {
-  @include add-background-svg("usa-icons/arrow_downward");
-}
-
-.sortable-asc-column {
-  @include add-background-svg("usa-icons/arrow_upward");
-}
-
-.sort-div {
-  width: 100%;
-  display: flex;
-}
-
-.ecr-library-wrapper {
-  height: calc(100% - 4rem);
 }
 
 .table-ecr-library {
@@ -205,6 +101,16 @@
   }
 }
 
+// ==== Page styling ===== //
+
+.ecr-library-wrapper {
+  height: calc(100% - 4rem);
+}
+
+.height-ecr-library {
+  height: calc(100% - 2.45rem - 1.5rem - 4.45rem);
+}
+
 .pagination-bar {
   .usa-pagination {
     margin: 0;
@@ -213,10 +119,112 @@
   box-shadow: 0 -0.25rem 0.25rem rgba(0, 0, 0, 0.1);
 }
 
+// ==== Filter styling ===== //
+
+.filter-button {
+  background-color: color("base-lightest");
+  box-shadow: inset 0 0 0 2px color("base-light");
+  font-weight: normal;
+
+  span svg {
+    fill: color("base-light");
+  }
+
+  &:hover {
+    background-color: color("base-lighter");
+    box-shadow: inset 0 0 0 2px color("base");
+
+    span svg {
+      fill: color("base");
+    }
+  }
+
+  &:active {
+    background-color: color("base-lightest");
+    box-shadow: inset 0 0 0 2px color("base-light");
+
+    span svg {
+      fill: color("base-light");
+    }
+  }
+}
+
+.filters-applied {
+  box-shadow: inset 0 0 0 2px color("primary");
+  background-color: color("primary-lighter");
+  font-weight: bold;
+
+  span svg {
+    fill: color("primary");
+  }
+
+  &:hover {
+    box-shadow: inset 0 0 0 2px color("primary-dark");
+    background-color: color("primary-light");
+
+    span svg {
+      fill: color("primary-dark");
+    }
+  }
+
+  &:active {
+    box-shadow: inset 0 0 0 2px color("primary");
+    background-color: color("primary-lighter");
+
+    span svg {
+      fill: color("primary");
+    }
+  }
+}
+
 .checkbox-color .usa-checkbox__label::before {
   box-shadow: 0 0 0 0.125rem color("base");
 }
 
-.height-ecr-library {
-  height: calc(100% - 2.45rem - 1.5rem - 4.45rem);
+// ==== Sorting styling ===== //
+
+.sort-button {
+  border: none;
+  transition: none;
+  margin-left: auto;
+  background-color: transparent;
+  &:hover {
+    background-color: transparent; /* Removes the hover background */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+  &:active {
+    background-color: transparent; /* Keeps the original background color */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+  &:focus {
+    background-color: transparent; /* Removes fill after click */
+    color: inherit; /* Keeps the text color unchanged */
+  }
+}
+
+.sortable-column,
+.sortable-desc-column,
+.sortable-asc-column {
+  &.usa-button {
+    margin-left: auto;
+    justify-content: flex-end;
+    padding: 12px;
+  }
+}
+
+.sortable-column {
+  @include add-background-svg("usa-icons/sort_arrow");
+}
+
+.sortable-desc-column {
+  @include add-background-svg("usa-icons/arrow_downward");
+}
+
+.sortable-asc-column {
+  @include add-background-svg("usa-icons/arrow_upward");
+}
+
+.sort-div {
+  width: 100%;
+  display: flex;
 }

--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -2,6 +2,8 @@
 
 @use "uswds-core" as *;
 
+// ===== Variables ===== //
+
 $ecr-viewer-container-max-width: 80rem;
 $ecr-viewer-container-min-width: 40rem;
 $ecr-viewer-gap: 3rem;
@@ -14,10 +16,42 @@ html {
   --patient-banner-buffer: 0;
 }
 
-// Make sure items we link to don't get stuck behind patient banner
-.ecr-viewer-container *[id] {
-  scroll-margin-top: calc(var(--patient-banner-buffer) + 0.75em);
+// ===== Page styling ===== //
+
+.ecr-viewer-container {
+  width: 100%;
+  max-width: $ecr-viewer-container-max-width;
+  min-width: $ecr-viewer-container-min-width;
+
+  // Make sure items we link to don't get stuck behind patient banner
+  *[id] {
+    scroll-margin-top: calc(var(--patient-banner-buffer) + 0.75em);
+  }
 }
+
+.content-wrapper {
+  display: flex;
+  gap: $ecr-viewer-gap;
+  overflow: visible;
+}
+
+.minw-main {
+  min-width: $main-min-width;
+}
+
+.width-main {
+  max-width: $main-min-width + $ecr-viewer-container-max-width -
+    $ecr-viewer-container-min-width;
+  min-width: $main-min-width;
+  width: 100%;
+}
+
+.padding-main {
+  padding-left: $main-container-padding;
+  padding-right: $main-container-padding;
+}
+
+// ===== Line styling helpers ===== //
 
 .vertical-line {
   border-left: 1px solid #005ea2;
@@ -37,11 +71,80 @@ html {
   margin-bottom: 0.5rem;
 }
 
+// ===== Element styling ===== //
+
 .data-title {
   flex: 0 1 auto;
   width: 190px;
   font-weight: bold;
 }
+.table-header {
+  background-color: #f0f0f0 !important;
+}
+
+.fixed-table {
+  table-layout: fixed;
+}
+
+.table-caption-margin {
+  caption {
+    margin-bottom: 8px;
+  }
+}
+
+.caption-normal-weight {
+  caption {
+    font-weight: normal;
+  }
+}
+
+.caption-data-title {
+  caption {
+    flex: 0 1 auto;
+    width: 190px;
+    font-weight: bold;
+    font-size: 1rem; // from .usa-prose
+  }
+}
+
+.caption-width-full {
+  caption {
+    width: 100%;
+  }
+}
+
+.p-list {
+  p {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.header-with-tag {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tag-info {
+  display: flex;
+  padding: 0.25rem 0.5rem;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 0.125rem;
+  background-color: #99deea;
+  font-weight: normal;
+  font-size: 0.875rem;
+  line-height: 100%;
+  color: #111111;
+}
+
+// ===== Section styling ===== //
 
 .ecr-summary-title-long {
   font-weight: bold;
@@ -113,12 +216,6 @@ html {
   }
 }
 
-.caption-normal-weight {
-  caption {
-    font-weight: normal;
-  }
-}
-
 .table-clinical-problems {
   tbody td:nth-child(2) {
     min-width: 130px;
@@ -129,62 +226,51 @@ html {
   }
 }
 
-.table-header {
-  background-color: #f0f0f0 !important;
-}
-
-.fixed-table {
-  table-layout: fixed;
-}
-
-.table-caption-margin {
-  caption {
-    margin-bottom: 8px;
-  }
-}
-
-.caption-data-title {
-  caption {
-    flex: 0 1 auto;
-    width: 190px;
-    font-weight: bold;
-    font-size: 1rem; // from .usa-prose
-  }
-}
-
-.caption-width-full {
-  caption {
+.clinical_info_container {
+  table {
+    @include usa-table;
+    @include usa-table--borderless;
     width: 100%;
+    border: 1px solid;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    thead tr th {
+      background-color: #f0f0f0;
+      min-width: 120px;
+    }
   }
 }
 
-.minw-main {
-  min-width: $main-min-width;
+.immunization_table {
+  tr {
+    td:nth-child(1) {
+      word-break: break-word;
+    }
+  }
 }
 
-.width-main {
-  max-width: $main-min-width + $ecr-viewer-container-max-width -
-    $ecr-viewer-container-min-width;
-  min-width: $main-min-width;
-  width: 100%;
+.condition-details-accordion {
+  .usa-accordion__heading.border-accent-cool-darker {
+    &:not(:first-child) {
+      margin-top: 1.12rem;
+    }
+  }
+
+  .usa-accordion__content.border-accent-cool-darker {
+    padding: 0.5rem 0.75rem 0 0.75rem;
+  }
+
+  .usa-accordion.accordion-rr {
+    margin: 0.5rem 0 0.75rem 0;
+  }
+
+  .usa-accordion__button {
+    padding: 0.88rem 0.75rem;
+  }
 }
 
-.padding-main {
-  padding-left: $main-container-padding;
-  padding-right: $main-container-padding;
-}
-
-.content-wrapper {
-  display: flex;
-  gap: $ecr-viewer-gap;
-  overflow: visible;
-}
-
-.ecr-viewer-container {
-  width: 100%;
-  max-width: $ecr-viewer-container-max-width;
-  min-width: $ecr-viewer-container-min-width;
-}
+// ===== SideNav styling ===== //
 
 .nav-wrapper {
   padding-top: 2rem;
@@ -236,60 +322,7 @@ html {
   }
 }
 
-.clinical_info_container {
-  table {
-    @include usa-table;
-    @include usa-table--borderless;
-    width: 100%;
-    border: 1px solid;
-    margin-top: 0;
-    margin-bottom: 0;
-
-    thead tr th {
-      background-color: #f0f0f0;
-      min-width: 120px;
-    }
-  }
-}
-
-.immunization_table {
-  tr {
-    td:nth-child(1) {
-      word-break: break-word;
-    }
-  }
-}
-
-.p-list {
-  p {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-  }
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.header-with-tag {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.tag-info {
-  display: flex;
-  padding: 0.25rem 0.5rem;
-  justify-content: center;
-  align-items: center;
-
-  border-radius: 0.125rem;
-  background-color: #99deea;
-  font-weight: normal;
-  font-size: 0.875rem;
-  line-height: 100%;
-  color: #111111;
-}
+// ===== PatientBanner styling ===== //
 
 .patient-banner {
   display: flex;
@@ -318,24 +351,4 @@ html {
 
 .patient-banner-dob {
   font-weight: normal;
-}
-
-.condition-details-accordion {
-  .usa-accordion__heading.border-accent-cool-darker {
-    &:not(:first-child) {
-      margin-top: 1.12rem;
-    }
-  }
-
-  .usa-accordion__content.border-accent-cool-darker {
-    padding: 0.5rem 0.75rem 0 0.75rem;
-  }
-
-  .usa-accordion.accordion-rr {
-    margin: 0.5rem 0 0.75rem 0;
-  }
-
-  .usa-accordion__button {
-    padding: 0.88rem 0.75rem;
-  }
 }

--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -1,3 +1,5 @@
+// This file contains declarations used in the styling of the ecr-viewer page
+
 @use "uswds-core" as *;
 
 $ecr-viewer-container-max-width: 80rem;
@@ -33,31 +35,6 @@ html {
   border-top: 1px solid #99deea;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
-}
-
-.card__line {
-  border-top: 8px solid #edeff0;
-}
-
-h2 {
-  font-size: 2.5rem;
-  margin-top: 0;
-  margin-bottom: 20px;
-}
-
-h4 {
-  font-size: 16px;
-  margin: 0;
-}
-
-.page-title {
-  font-size: 32px;
-  color: white;
-  background-color: #162e51;
-  padding-top: 28px;
-  padding-bottom: 28px;
-  padding-left: 32px;
-  margin-top: 0px;
 }
 
 .data-title {
@@ -142,20 +119,6 @@ h4 {
   }
 }
 
-.usa-table {
-  overflow-wrap: break-word;
-
-  thead th {
-    background-color: #f0f0f0;
-    vertical-align: top;
-  }
-
-  th,
-  td {
-    padding: 0.75rem;
-  }
-}
-
 .table-clinical-problems {
   tbody td:nth-child(2) {
     min-width: 130px;
@@ -166,54 +129,12 @@ h4 {
   }
 }
 
-.minimize-container {
-  position: absolute;
-  right: 12px;
-}
-
-.list-style-none {
-  list-style: none;
-}
-
-.tableHeader {
+.table-header {
   background-color: #f0f0f0 !important;
-}
-
-.ecrTable {
-  table-layout: fixed;
-  margin-bottom: 0;
-  width: 100%;
-
-  td:first-child,
-  th:first-child {
-    padding-left: 24px;
-  }
-
-  td:last-child,
-  th:last-child {
-    padding-right: 24px;
-  }
-
-  td {
-    padding-top: 14px;
-    padding-bottom: 14px;
-  }
-
-  thead th {
-    border-bottom-color: #a9aeb1;
-  }
-
-  tr td {
-    border-bottom: none;
-  }
 }
 
 .fixed-table {
   table-layout: fixed;
-}
-
-td {
-  vertical-align: top;
 }
 
 .table-caption-margin {
@@ -235,16 +156,6 @@ td {
   caption {
     width: 100%;
   }
-}
-
-.usa-sidenav__item a:not(.usa-sidenav__sublist a) {
-  font-weight: bold;
-}
-
-.main-container {
-  display: flex;
-  justify-content: center;
-  overflow: visible;
 }
 
 .minw-main {
@@ -269,6 +180,12 @@ td {
   overflow: visible;
 }
 
+.ecr-viewer-container {
+  width: 100%;
+  max-width: $ecr-viewer-container-max-width;
+  min-width: $ecr-viewer-container-min-width;
+}
+
 .nav-wrapper {
   padding-top: 2rem;
   width: $nav-wrapper-width;
@@ -276,67 +193,63 @@ td {
   position: sticky;
   height: 100vh;
   top: var(--patient-banner-buffer);
-}
 
-.ecr-viewer-container {
-  width: 100%;
-  max-width: $ecr-viewer-container-max-width;
-  min-width: $ecr-viewer-container-min-width;
-}
+  .usa-sidenav__item a:not(.usa-sidenav__sublist a) {
+    font-weight: bold;
+  }
 
-.lh-18 {
-  line-height: 18px;
-}
+  ul.usa-sidenav
+    > li.usa-sidenav__item
+    > ul.usa-sidenav__sublist
+    > li.usa-sidenav__item
+    > a {
+    font-weight: bold;
+  }
 
-ul.usa-sidenav
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > a {
-  font-weight: bold;
-}
+  ul.usa-sidenav
+    > li.usa-sidenav__item
+    > ul.usa-sidenav__sublist
+    > li.usa-sidenav__item
+    > a.usa-current,
+  ul.usa-sidenav
+    > li.usa-sidenav__item
+    > ul.usa-sidenav__sublist
+    > li.usa-sidenav__item
+    > ul.usa-sidenav__sublist
+    > li.usa-sidenav__item
+    > a.usa-current {
+    &::after {
+      background-color: rgb(0, 94, 162);
+      content: "";
+      display: block;
+      position: absolute;
+      bottom: 0.25rem;
+      top: 0.25rem;
+      width: 0.25rem;
+      left: 0rem;
+      border-radius: 99rem;
+    }
+  }
 
-ul.usa-sidenav
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > a.usa-current,
-ul.usa-sidenav
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > a.usa-current {
-  &::after {
-    background-color: rgb(0, 94, 162);
-    content: "";
-    display: block;
-    position: absolute;
-    bottom: 0.25rem;
-    top: 0.25rem;
-    width: 0.25rem;
-    left: 0rem;
-    border-radius: 99rem;
+  .usa-sidenav__sublist li.usa-sidenav__item:first-child {
+    border-top: none !important;
   }
 }
 
-.usa-sidenav__sublist li.usa-sidenav__item:first-child {
-  border-top: none !important;
-}
+.clinical_info_container {
+  table {
+    @include usa-table;
+    @include usa-table--borderless;
+    width: 100%;
+    border: 1px solid;
+    margin-top: 0;
+    margin-bottom: 0;
 
-.clinical_info_container table {
-  @include usa-table;
-  @include usa-table--borderless;
-  width: 100%;
-  border: 1px solid;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.clinical_info_container table thead tr th {
-  background-color: #f0f0f0;
-  min-width: 120px;
+    thead tr th {
+      background-color: #f0f0f0;
+      min-width: 120px;
+    }
+  }
 }
 
 .immunization_table {
@@ -344,107 +257,6 @@ ul.usa-sidenav
     td:nth-child(1) {
       word-break: break-word;
     }
-  }
-}
-
-.usa-accordion__content {
-  overflow: visible;
-}
-
-.usa-tooltip__body {
-  max-width: 700px;
-  min-width: min(450px, 0.25 * (100vw - $nav-wrapper-width));
-  white-space: normal;
-  text-align: left;
-  font-weight: normal;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-.short-tooltip + .usa-tooltip__body {
-  min-width: min(350px, 0.25 * (100vw - $nav-wrapper-width));
-}
-
-@keyframes shimmer {
-  to {
-    background-position-x: 0%;
-  }
-}
-
-.loading-blob {
-  border-radius: 8px;
-  animation: shimmer 0.75s infinite linear;
-
-  background-size: 300%;
-  background-position-x: 100%;
-
-  &-blue {
-    background-image: linear-gradient(
-      -90deg,
-      #99deea 40%,
-      #71d5e6 50%,
-      #99deea 60%
-    );
-  }
-
-  &-gray {
-    background-image: linear-gradient(
-      -90deg,
-      #f0f0f0 40%,
-      #e4e4e4 50%,
-      #f0f0f0 60%
-    );
-  }
-
-  &-dark-gray {
-    background-image: linear-gradient(
-      -90deg,
-      #dfe1e2 40%,
-      #cfcfcf 50%,
-      #dfe1e2 60%
-    );
-  }
-}
-
-.usa-header {
-  background-color: #172e51;
-  color: white;
-
-  .usa-logo {
-    margin-left: 0px;
-
-    a {
-      color: white;
-    }
-  }
-
-  .usa-navbar {
-    border-bottom: none;
-  }
-
-  @media (min-width: 64em) {
-    .usa-logo {
-      margin-bottom: 1.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .usa-nav-container {
-      max-width: 65rem;
-      margin-left: 0px;
-      padding: 0.5rem 1.5rem;
-    }
-  }
-
-  .usa-nav-container {
-    max-width: 65rem;
-    margin-left: 0px;
-    padding: 0.5rem 1.5rem;
-  }
-
-  h1 {
-    font-style: normal;
-    font-weight: bold;
-    font-size: 2rem;
   }
 }
 
@@ -506,20 +318,6 @@ ul.usa-sidenav
 
 .patient-banner-dob {
   font-weight: normal;
-}
-
-h3 {
-  font-size: 1.375rem;
-}
-
-.usa-summary-box {
-  padding: 0.75rem 1.5rem 1.5rem 1.5rem;
-
-  h3:not(.usa-accordion__heading) {
-    margin: 0px;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-  }
 }
 
 .condition-details-accordion {

--- a/containers/ecr-viewer/src/styles/styles.scss
+++ b/containers/ecr-viewer/src/styles/styles.scss
@@ -2,6 +2,12 @@
 
 @forward "uswds";
 
-@forward "custom-styles";
+@forward "custom-uswds-styles";
+
+@forward "common";
+
+@forward "ecr-library";
+
+@forward "ecr-viewer";
 
 @forward "utilities";

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -1,3 +1,5 @@
+// This file contains helper utilities for setting (typically) one style property
+
 .top-550 {
   top: 2.75rem;
 }

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -1,12 +1,40 @@
 // This file contains helper utilities for setting (typically) one style property
+// Please keep this sorted alphabetically by util type, then smallest to largest
+// within utility.
+//
+// These typically expand the builtin set provided by uswds, so use
+// those first, then if needed add one following their naming conventions.
 
-.top-550 {
-  top: 2.75rem;
+// ==== gap ==== //
+
+.gap-05 {
+  gap: 0.25rem;
 }
+
+.gap-1 {
+  gap: 0.5rem;
+}
+
+.gap-105 {
+  gap: 0.75rem;
+}
+
+// ==== gutter ==== //
+
+.gutter-3:nth-child(1) {
+  margin-top: inherit;
+}
+.gutter-3 {
+  margin-top: 1.5rem;
+}
+
+// ==== margin ==== //
 
 .margin-right-1025 {
   margin-right: 0.625rem;
 }
+
+// ==== max[h/w] ==== //
 
 .maxh-38 {
   max-height: 19rem;
@@ -19,6 +47,8 @@
 .maxw7 {
   max-width: 68%;
 }
+
+// ==== min[h/w] ==== //
 
 .minw-1605 {
   min-width: 8.25rem;
@@ -47,6 +77,20 @@
 .minw-40 {
   min-width: 20rem;
 }
+
+// ==== padding ==== //
+
+.padding-top-1-25 {
+  padding-top: 0.625rem;
+}
+
+// ==== top ==== //
+
+.top-550 {
+  top: 2.75rem;
+}
+
+// ==== width ==== //
 
 .width-11075 {
   width: 5.875rem;
@@ -84,29 +128,8 @@
   width: 25%;
 }
 
-.padding-top-1-25 {
-  padding-top: 0.625rem;
-}
+// ==== visibility-hidden ==== //
 
 .visibility-hidden {
   visibility: hidden;
-}
-
-.gutter-3:nth-child(1) {
-  margin-top: inherit;
-}
-.gutter-3 {
-  margin-top: 1.5rem;
-}
-
-.gap-05 {
-  gap: 0.25rem;
-}
-
-.gap-1 {
-  gap: 0.5rem;
-}
-
-.gap-105 {
-  gap: 0.75rem;
 }

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -14,6 +14,10 @@
   max-height: 31.25rem;
 }
 
+.maxw7 {
+  max-width: 68%;
+}
+
 .minw-1605 {
   min-width: 8.25rem;
 }
@@ -64,6 +68,10 @@
 
 .width-4305 {
   width: 21.75rem;
+}
+
+.width-21-9375 {
+  width: 21.9375rem;
 }
 
 .width-62 {


### PR DESCRIPTION
# PULL REQUEST

## Summary

Split up our `custom-styles.scss` into
- `custom-uswds-styles`
- `common`
- `ecr-viewer`
- `ecr-library`
- and move some of the declartions into already existing `utilities`

## Related Issue

Fixes #169

## Acceptance Criteria

- [ ] Break up the custom-styles.scss file into 3 new files. One for shared styling, one for eCR library page styling, and one for the eCR Viewer page
- [ ] Organize the code in each file
