### PR TITLE
fix: remove unnecessary key on `Header`

### DIFF
--- a/containers/ecr-viewer/src/app/components/EcrTableClientBase.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrTableClientBase.tsx
@@ -143,7 +143,6 @@ const Header = ({
   return (
     <th
       id={`${column.id}-header`}
-      key={`${column.value}`}
       scope="col"
       role="columnheader"
       className={column.className}


### PR DESCRIPTION
# PULL REQUEST

## Summary

Remove the `key` on the jsx returned from `Header`. It's unneccessary.

## Related Issue

Fixes #25