### PR TITLE
ci: limit dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,30 +4,43 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 2
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/containers/ecr-viewer"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "docker"
     directory: "/containers/ecr-viewer"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "pip"
     directory: "/containers/orchestration"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "docker"
     directory: "/containers/orchestration"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "pip"
     directory: "/containers/fhir-converter"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "docker"
     directory: "/containers/fhir-converter"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Dependabot should only run on sundays so it doesn't fill up the action queue while we are actively working
- Set a limit of 2 updates per week so we don't get spammed 
