### PR TITLE
fix: remove unnecessary key on filter condition div

### DIFF
--- a/containers/ecr-viewer/src/app/components/Filters.tsx
+++ b/containers/ecr-viewer/src/app/components/Filters.tsx
@@ -225,10 +225,7 @@ const FilterReportableConditions = ({ conditions }: FilterProps) => {
     >
       {/* Select All checkbox */}
       <div className="display-flex flex-column">
-        <div
-          className="checkbox-color usa-checkbox padding-bottom-1 padding-x-105"
-          key="all"
-        >
+        <div className="checkbox-color usa-checkbox padding-bottom-1 padding-x-105">
           <input
             id="condition-all"
             className="usa-checkbox__input"


### PR DESCRIPTION
# PULL REQUEST

## Summary

Remove the key "all" on a div in filter condition code. It's unnecessary.

## Related Issue

Fixes #24
