### PR TITLE
fix: restore ecr library table stickiness

### DIFF
--- a/containers/ecr-viewer/src/app/components/EcrTableHeader.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrTableHeader.tsx
@@ -44,7 +44,7 @@ export const EcrTableHeader = ({
   };
 
   return (
-    <thead>
+    <thead className="position-sticky top-0">
       <tr>
         {headers.map((column) => (
           <Header

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTableHeader.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTableHeader.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`EcrTableHeader disabled should match snapshot 1`] = `
 <table>
-  <thead>
+  <thead
+    class="position-sticky top-0"
+  >
     <tr>
       <th
         class="library-patient-column"
@@ -145,7 +147,9 @@ exports[`EcrTableHeader disabled should match snapshot 1`] = `
 
 exports[`EcrTableHeader enabled should match snapshot 1`] = `
 <table>
-  <thead>
+  <thead
+    class="position-sticky top-0"
+  >
     <tr>
       <th
         class="library-patient-column"


### PR DESCRIPTION
# PULL REQUEST

## Summary

In #337 a couple classnames got lost. This adds them back.