### PR TITLE
chore: Update design review script to use new repo

### DIFF
--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -69,8 +69,8 @@ while ! docker system info > /dev/null 2>&1; do
 done
 
 # Clone the repository if it doesn't exist, otherwise pull the latest changes
-REPO_URL="https://github.com/CDCgov/phdi.git"
-REPO_DIR="phdi"
+REPO_URL="https://github.com/CDCgov/dibbs-ecr-viewer.git"
+REPO_DIR="dibbs-ecr-viewer"
 
 if [ ! -d "$REPO_DIR" ]; then
     git clone $REPO_URL

--- a/containers/ecr-viewer/e2e/integrated/auth.spec.ts
+++ b/containers/ecr-viewer/e2e/integrated/auth.spec.ts
@@ -18,6 +18,8 @@ test.describe("integrated - nbs auth", () => {
   test("should grant access when a valid token is provided", async ({
     page,
   }) => {
+    test.setTimeout(30_000);
+
     await page.goto(
       "/ecr-viewer/view-data?id=1234&auth=eyJhbGciOiJSUzI1NiIsImlkIjoiYmxhaCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.hXmX6wu9ThiSqNEl6Y3pBETppiIt0j4RKSVPO_AAYZJZsngSFiu8GuGDtA13kJ-texfUHshqcy4euoVwfmN-naDi2Ly6p6lPjY6xzmTuQ1DtiKLZDNBsDupjoLAuIJQ3K8uWRnCdRGG1ZlTkZa-SG8b4jfDLRrl1fPiJCWM62XV7_gIvqCvRAPdP9kMrOV1LtLEuXgoXZGifVNnPQhtT7fQ7kDmbM-HDG4MquZy89CIRy2q22xIclePOAoe0Ifz6q7-NG3I9CzKOAa_Vx6Oy5ZYBYphfV1n46gp4OC0Cb_w-wFLfRDuDPJZvcS5ed2HxdyZrU_GeD4WSN5IQpEn_45CZifBzmv9-jweEUD2or3sp1DReORLZG2CvBqtixC0p3gIeGnY4HROduafmDfyI0gcv7pDM-fcreMCBG-7uqUPkk9rqhCPw9n6fhWvNMSGrtW9tx6hAPNxjKJ2AsyTh7cJyR0teVpijhXZz0dGJOtYY1-nlR7_BnJH2lC9tLiIJcVl1JKfGRu18MV1bHs7y25Wp1HxVDUXllShXa7_oD7ljnE3stmpO5GPMbxvWC_RKO_bu_e2mAgJ3yiPImFpLVYZZgBqClctciZMQeV1lZTAy-7Xlzgdx-IvFc9VuigKw6hfk4on98BxMUENeh20KIgVv8cMr4ZjAGV3MjnFnHWw",
     );


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Updates design review script to use the new repo
- Increases timeout for integrated auth e2e test to 30 seconds.

## Related Issue

#411 

## Acceptance Criteria

- [ ] Running design review script downloads CDCgov/dibbs-ecr-viewer

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
