### PR TITLE
fix: use onset age if available, only calculate if date present

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/ActiveProblems.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/ActiveProblems.test.tsx
@@ -51,6 +51,7 @@ describe("Active Problems Table", () => {
         ],
         resourceType: "Condition",
         onsetDateTime: "12/14/2022",
+        onsetAge: { value: 123 },
         clinicalStatus: {
           coding: [
             {
@@ -95,7 +96,7 @@ describe("Active Problems Table", () => {
           },
         ],
         resourceType: "Condition",
-        onsetDateTime: "08/19/2021",
+        onsetAge: { value: 152 },
         clinicalStatus: {
           coding: [
             {
@@ -165,9 +166,9 @@ describe("Active Problems Table", () => {
   it("should pass accessibility test", async () => {
     expect(await axe(container)).toHaveNoViolations();
   });
-  it("should calculate onset age", () => {
-    expect(screen.getByText("145")).toBeInTheDocument();
-    expect(screen.getByText("144")).toBeInTheDocument();
+  it("should use or calculate onset age", () => {
+    expect(screen.getByText("123")).toBeInTheDocument();
+    expect(screen.getByText("152")).toBeInTheDocument();
     expect(screen.getByText("141")).toBeInTheDocument();
   });
 });

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Active Problems Table should match snapshot 1`] = `
         <td
           class="text-top"
         >
-          145
+          123
         </td>
         <td
           class="text-top"
@@ -91,12 +91,16 @@ exports[`Active Problems Table should match snapshot 1`] = `
         <td
           class="text-top"
         >
-          08/19/2021
+          <span
+            class="no-data text-italic text-base"
+          >
+            No data
+          </span>
         </td>
         <td
           class="text-top"
         >
-          144
+          152
         </td>
         <td
           class="text-top"

--- a/containers/ecr-viewer/src/app/view-data/components/common.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/common.tsx
@@ -107,9 +107,11 @@ export const returnProblemsTable = (
 
   problemsArray.forEach((entry) => {
     entry.onsetDateTime = formatDateTime(entry.onsetDateTime);
-    entry.onsetAge = {
-      value: calculatePatientAge(fhirBundle, mappings, entry.onsetDateTime),
-    };
+    entry.onsetAge ||= entry.onsetDateTime
+      ? {
+          value: calculatePatientAge(fhirBundle, mappings, entry.onsetDateTime),
+        }
+      : undefined;
   });
 
   if (problemsArray.length === 0) {


### PR DESCRIPTION
# PULL REQUEST

## Summary

Fix onset age handling so it follows the following logic:
1. If onset age is available, use it as is
2. If it isn't available, but onset date is, calculate the age
3. If age and date aren't available, don't calculate anything

## Related Issue

Fixes #164