### PR TITLE
fix: change ecr_viewer_url to use host.docker.internal

### DIFF
--- a/containers/ecr-viewer/seed-scripts/docker-compose-seed.yaml
+++ b/containers/ecr-viewer/seed-scripts/docker-compose-seed.yaml
@@ -58,7 +58,7 @@ services:
     environment:
       - OTEL_TRACES_EXPORTER=none
       - OTEL_METRICS_EXPORTER=none
-      - ECR_VIEWER_URL=http://localhost:3000/ecr-viewer
+      - ECR_VIEWER_URL=http://host.docker.internal:3000/ecr-viewer
     healthcheck:
       test: ["CMD", "curl", "-f", "http://orchestration-service:8080/"]
       interval: 10s


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Update ecr_viewer_url to host.docker.internal since ecr-viewer now runs on host network mode

