### PR TITLE
fix: side nav scroll

### DIFF
--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -283,7 +283,7 @@ html {
   width: $nav-wrapper-width;
   min-width: $nav-wrapper-width;
   position: sticky;
-  height: 100vh;
+  height: calc(100vh - var(--patient-banner-buffer));
   top: var(--patient-banner-buffer);
   overflow-y: auto;
 

--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -285,6 +285,7 @@ html {
   position: sticky;
   height: 100vh;
   top: var(--patient-banner-buffer);
+  overflow-y: auto;
 
   .usa-sidenav__item a:not(.usa-sidenav__sublist a) {
     font-weight: bold;


### PR DESCRIPTION
# PULL REQUEST

## Summary

When the screen is too short to house all of the side nav, let it scroll.

## Related Issue

Fixes #490

## Acceptance Criteria

Side nav should always be navigable

## Additional Information

https://github.com/user-attachments/assets/9e84c0d9-32ad-4c55-90cf-b883d7a21f02

