### PR TITLE
fix: add revalidate on /health-check to force refresh

### DIFF
--- a/containers/ecr-viewer/src/app/api/health-check/route.ts
+++ b/containers/ecr-viewer/src/app/api/health-check/route.ts
@@ -5,6 +5,8 @@ import { s3HealthCheck } from "@/app/data/blobStorage/s3Client";
 import { postgresHealthCheck } from "@/app/data/db/postgres_db";
 import { sqlServerHealthCheck } from "@/app/data/db/sqlserver_db";
 
+export const revalidate = 10;
+
 /**
  * Health check for ECR Viwer
  * @returns Response with status OK.


### PR DESCRIPTION
# PULL REQUEST

## Summary

- [Add `revalidate` variable](https://nextjs.org/docs/14/app/api-reference/file-conventions/route-segment-config#revalidate) to ensure /health-check will be re-rendered 

## Additional Information

- The /health-check endpoint will never update the values after build time without this change. This issue does not occur when running in dev mode.