### PR TITLE
ci: add a 1 second sleep before getting RUN_ID

### DIFF
--- a/.github/workflows/run-container-workflow.yaml
+++ b/.github/workflows/run-container-workflow.yaml
@@ -1,5 +1,10 @@
 name: "Run Container Workflow"
 on:
+  workflow_dispatch:
+    inputs:
+      container:
+        required: true
+        type: string
   workflow_call:
     inputs:
       container:
@@ -20,6 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run .github/workflows/container-${{ inputs.container }}.yaml
+          sleep 1
           RUN_ID=$(gh run list --workflow=container-${{ inputs.container }}.yaml --event=workflow_dispatch --json databaseId --limit 1 --jq '.[0].databaseId')
           echo "RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Add a 1 second wait between getting the github run ID because it was fetching a previous value
