### PR TITLE
fix: eCR Library wrapper is inaccessible when no eCRs are found

### DIFF
--- a/containers/ecr-viewer/src/app/page.tsx
+++ b/containers/ecr-viewer/src/app/page.tsx
@@ -140,9 +140,9 @@ const EcrTableNoData = () => (
   <tbody>
     <tr>
       <td colSpan={999} className="text-middle text-center height-card">
-        <span className="text-bold font-body-lg">
+        <span className="text-bold font-body-lg" tabIndex={0}>
           No eCRs found. We couldn't find any eCRs matching your filter or
-          search critera.
+          search criteria.
         </span>
       </td>
     </tr>


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR addresses an issue in which keyboard users are unable to navigate within the scrollable `.ecr-library-wrapper` element when no eCRs are found. I've run the automated Axe scan again after implementing this change and it is no longer reporting the original issue. I've also attempted to access the region via keyboard while using VoiceOver and was able to confirm that VO did seem to correctly read the "No eCRs found" message within the table.

I also fixed a small typo 🙂

## Related Issue

Fixes #397 

## Acceptance Criteria

- [ ] Automated Axe test no longer reports an issue when running a scan
- [ ] "No eCRs found" message within the table is accessible by keyboard and read by the screen reader