### PR TITLE
fix: process-zip saving metadata

### DIFF
--- a/containers/ecr-viewer/src/app/api/process-zip/service.ts
+++ b/containers/ecr-viewer/src/app/api/process-zip/service.ts
@@ -14,7 +14,11 @@ interface OrchestrationRawResponse {
   processed_values: {
     responses: [
       { stamped_ecr: { extended_bundle: Bundle } },
-      { metadata_values: BundleExtendedMetadata | BundleMetadata }?,
+      {
+        metadata_values: {
+          parsed_values: BundleExtendedMetadata | BundleMetadata;
+        };
+      }?,
     ];
   };
 }
@@ -65,7 +69,8 @@ const getOrchestrationResponse = async (file: File): Promise<BundleInfo> => {
     const resp: OrchestrationRawResponse = await response.json();
     return {
       ecr: resp.processed_values.responses[0].stamped_ecr.extended_bundle,
-      metadata: resp.processed_values.responses?.[1]?.metadata_values,
+      metadata:
+        resp.processed_values.responses?.[1]?.metadata_values.parsed_values,
     };
   }
 };

--- a/containers/ecr-viewer/src/app/tests/api/process-zip/service.test.ts
+++ b/containers/ecr-viewer/src/app/tests/api/process-zip/service.test.ts
@@ -27,7 +27,7 @@ describe("processZip", () => {
         processed_values: {
           responses: [
             { stamped_ecr: { extended_bundle: mockEcr } },
-            { metadata_values: mockMetadata },
+            { metadata_values: { parsed_values: mockMetadata } },
           ],
         },
       }),


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Update ecr-viewer's `/process-zip` endpoint to read the metadata response object properly
