### PR TITLE
feat: make AZURE_CONTAINER_NAME optional in favor of ECR_BUCKET_NAME

### DIFF
--- a/containers/ecr-viewer/environment.d.ts
+++ b/containers/ecr-viewer/environment.d.ts
@@ -6,12 +6,12 @@ namespace NodeJS {
     AUTH_CLIENT_SECRET?: string;
     AUTH_ISSUER?: string;
     AUTH_PROVIDER?: "keycloak" | "ad";
-    AWS_ACCESS_KEY_ID: string;
-    AWS_CUSTOM_ENDPOINT: string;
-    AWS_REGION: string;
-    AWS_SECRET_ACCESS_KEY: string;
-    AZURE_CONTAINER_NAME: string;
-    AZURE_STORAGE_CONNECTION_STRING: string;
+    AWS_ACCESS_KEY_ID?: string;
+    AWS_CUSTOM_ENDPOINT?: string;
+    AWS_REGION?: string;
+    AWS_SECRET_ACCESS_KEY?: string;
+    AZURE_CONTAINER_NAME?: string;
+    AZURE_STORAGE_CONNECTION_STRING?: string;
     BASE_PATH: string;
     CONFIG_NAME:
       | "AWS_INTEGRATED"

--- a/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
@@ -87,36 +87,8 @@ export const get_azure = async (
 ): Promise<FhirDataResponse> => {
   const containerClient = azureBlobContainerClient();
   const blobName = `${ecr_id}.json`;
-  if (containerClient) {
-    try {
-      const blockBlobClient: BlobClient =
-        containerClient.getBlobClient(blobName);
 
-      const downloadResponse: BlobDownloadResponseParsed =
-        await blockBlobClient.download();
-      const fhirBundle = await streamToJson(
-        downloadResponse.readableStreamBody,
-      );
-
-      return {
-        payload: { fhirBundle },
-        status: 200,
-      };
-
-      // The Azure SDK doesn't export its exception types
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      console.error(
-        "Failed to download the FHIR data from Azure Blob Storage:",
-        error,
-      );
-      if (error?.statusCode === 404) {
-        return { payload: { message: UNKNOWN_ECR_ID }, status: 404 };
-      } else {
-        return { payload: { message: error.message }, status: 500 };
-      }
-    }
-  } else {
+  if (!containerClient) {
     return {
       payload: {
         message:
@@ -124,6 +96,31 @@ export const get_azure = async (
       },
       status: 500,
     };
+  }
+  try {
+    const blockBlobClient: BlobClient = containerClient.getBlobClient(blobName);
+
+    const downloadResponse: BlobDownloadResponseParsed =
+      await blockBlobClient.download();
+    const fhirBundle = await streamToJson(downloadResponse.readableStreamBody);
+
+    return {
+      payload: { fhirBundle },
+      status: 200,
+    };
+
+    // The Azure SDK doesn't export its exception types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    console.error(
+      "Failed to download the FHIR data from Azure Blob Storage:",
+      error,
+    );
+    if (error?.statusCode === 404) {
+      return { payload: { message: UNKNOWN_ECR_ID }, status: 404 };
+    } else {
+      return { payload: { message: error.message }, status: 500 };
+    }
   }
 };
 

--- a/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
@@ -78,30 +78,40 @@ export const get_azure = async (
 ): Promise<FhirDataResponse> => {
   const containerClient = azureBlobContainerClient();
   const blobName = `${ecr_id}.json`;
+  if (containerClient) {
+    try {
+      const blockBlobClient: BlobClient =
+        containerClient.getBlobClient(blobName);
 
-  try {
-    const blockBlobClient: BlobClient = containerClient.getBlobClient(blobName);
+      const downloadResponse: BlobDownloadResponseParsed =
+        await blockBlobClient.download();
+      const content = await streamToJson(downloadResponse.readableStreamBody);
 
-    const downloadResponse: BlobDownloadResponseParsed =
-      await blockBlobClient.download();
-    const content = await streamToJson(downloadResponse.readableStreamBody);
+      return {
+        payload: { fhirBundle: content },
+        status: 200,
+      };
 
-    return {
-      payload: { fhirBundle: content },
-      status: 200,
-    };
-
-    // The Azure SDK doesn't export its exception types
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    console.error(
-      "Failed to download the FHIR data from Azure Blob Storage:",
-      error,
-    );
-    if (error?.statusCode === 404) {
-      return { payload: { message: UNKNOWN_ECR_ID }, status: 404 };
-    } else {
-      return { payload: { message: error.message }, status: 500 };
+      // The Azure SDK doesn't export its exception types
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      console.error(
+        "Failed to download the FHIR data from Azure Blob Storage:",
+        error,
+      );
+      if (error?.statusCode === 404) {
+        return { payload: { message: UNKNOWN_ECR_ID }, status: 404 };
+      } else {
+        return { payload: { message: error.message }, status: 500 };
+      }
     }
+  } else {
+    return {
+      payload: {
+        message:
+          "Failed to download the FHIR data due to misconfiguration of client.",
+      },
+      status: 500,
+    };
   }
 };

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -78,6 +78,13 @@ export const saveToAzure = async (
   const blobName = `${ecrId}.json`;
   const body = JSON.stringify(fhirBundle);
 
+  if (!containerClient) {
+    return {
+      message: "Failed to save FHIR bundle due to misconfiguration of client.",
+      status: 500,
+    };
+  }
+
   try {
     const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 

--- a/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
@@ -9,7 +9,7 @@ export const azureBlobContainerClient = () => {
     process.env.AZURE_STORAGE_CONNECTION_STRING,
   );
   const containerClient = blobClient.getContainerClient(
-    process.env.AZURE_CONTAINER_NAME,
+    process.env.AZURE_CONTAINER_NAME || process.env.ECR_BUCKET_NAME,
   );
 
   return containerClient;
@@ -22,7 +22,7 @@ export const azureBlobContainerClient = () => {
 export const azureBlobStorageHealthCheck = async () => {
   if (
     !process.env.AZURE_STORAGE_CONNECTION_STRING ||
-    !process.env.AZURE_CONTAINER_NAME
+    !(process.env.AZURE_CONTAINER_NAME || process.env.ECR_BUCKET_NAME)
   ) {
     return undefined;
   }

--- a/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
@@ -20,10 +20,7 @@ export const azureBlobContainerClient = () => {
  * @returns The status of the azure blob connection or undefined if missing environment values.
  */
 export const azureBlobStorageHealthCheck = async () => {
-  if (
-    !process.env.AZURE_STORAGE_CONNECTION_STRING ||
-    !(process.env.AZURE_CONTAINER_NAME || process.env.ECR_BUCKET_NAME)
-  ) {
+  if (process.env.SOURCE !== "azure") {
     return undefined;
   }
   try {

--- a/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
@@ -1,5 +1,7 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 
+import { AZURE_SOURCE } from "@/app/api/utils";
+
 /**
  * Connect to the Azure blob container.
  * @returns A promise resolving to a azure blob container client.
@@ -23,7 +25,7 @@ export const azureBlobContainerClient = () => {
  * @returns The status of the azure blob connection or undefined if missing environment values.
  */
 export const azureBlobStorageHealthCheck = async () => {
-  if (process.env.SOURCE !== "azure") {
+  if (process.env.SOURCE !== AZURE_SOURCE) {
     return undefined;
   }
   try {

--- a/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
@@ -5,14 +5,17 @@ import { BlobServiceClient } from "@azure/storage-blob";
  * @returns A promise resolving to a azure blob container client.
  */
 export const azureBlobContainerClient = () => {
-  const blobClient = BlobServiceClient.fromConnectionString(
-    process.env.AZURE_STORAGE_CONNECTION_STRING,
-  );
-  const containerClient = blobClient.getContainerClient(
-    process.env.AZURE_CONTAINER_NAME || process.env.ECR_BUCKET_NAME,
-  );
+  if (process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    const blobClient = BlobServiceClient.fromConnectionString(
+      process.env.AZURE_STORAGE_CONNECTION_STRING,
+    );
+    const containerClient = blobClient.getContainerClient(
+      process.env.AZURE_CONTAINER_NAME || process.env.ECR_BUCKET_NAME,
+    );
 
-  return containerClient;
+    return containerClient;
+  }
+  return undefined;
 };
 
 /**
@@ -26,6 +29,9 @@ export const azureBlobStorageHealthCheck = async () => {
   try {
     const containerClient = azureBlobContainerClient();
 
+    if (!containerClient) {
+      return "DOWN";
+    }
     if (await containerClient.exists()) {
       return "UP";
     }

--- a/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
@@ -1,5 +1,6 @@
-import { S3_SOURCE } from "@/app/api/utils";
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+
+import { S3_SOURCE } from "@/app/api/utils";
 
 export const s3Client = new S3Client({
   region: process.env.AWS_REGION,

--- a/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
@@ -1,3 +1,4 @@
+import { S3_SOURCE } from "@/app/api/utils";
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
 
 export const s3Client = new S3Client({
@@ -11,7 +12,7 @@ export const s3Client = new S3Client({
  * @returns The status of the AWS S3 connection or undefined if missing environment values.
  */
 export const s3HealthCheck = async () => {
-  if (process.env.SOURCE !== "s3") {
+  if (process.env.SOURCE !== S3_SOURCE) {
     return undefined;
   }
   try {

--- a/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
@@ -11,7 +11,7 @@ export const s3Client = new S3Client({
  * @returns The status of the AWS S3 connection or undefined if missing environment values.
  */
 export const s3HealthCheck = async () => {
-  if (!process.env.ECR_BUCKET_NAME) {
+  if (process.env.SOURCE !== "s3") {
     return undefined;
   }
   try {

--- a/containers/ecr-viewer/src/app/tests/api/fhir-data.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/api/fhir-data.test.tsx
@@ -61,6 +61,10 @@ const mockBlobServiceClient = {
 };
 
 describe("GET API Route", () => {
+  afterAll(() => {
+    process.env.SOURCE = "s3";
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+  });
   it("fetches data from S3 and returns a JSON response", async () => {
     const fakeId = "test-id";
     process.env.SOURCE = "s3";
@@ -84,6 +88,7 @@ describe("GET API Route", () => {
   it("fetches data from Azure Blob Storage and returns a JSON response", async () => {
     const fakeId = "test-id";
     process.env.SOURCE = "azure";
+    process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
     const request = new NextRequest(`http://localhost?id=${fakeId}`);
 
     const response = await GET(request);

--- a/containers/ecr-viewer/src/app/tests/api/fhir-data/service.test.ts
+++ b/containers/ecr-viewer/src/app/tests/api/fhir-data/service.test.ts
@@ -136,6 +136,7 @@ describe("get_azure", () => {
   };
 
   beforeEach(() => {
+    process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
     const containerClient = {
       getBlobClient: jest.fn().mockReturnValue(blockBlobClient),
     };
@@ -151,6 +152,7 @@ describe("get_azure", () => {
 
   afterEach(() => {
     process.env.SOURCE = S3_SOURCE;
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING;
     jest.resetAllMocks();
   });
 
@@ -179,7 +181,7 @@ describe("get_azure", () => {
     expect(blockBlobClient.download).toHaveBeenCalledTimes(1);
   });
 
-  it("should return an 404 error response when id unknown", async () => {
+  it("should return a 404 error response when id unknown", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
 
     blockBlobClient.download = jest.fn().mockImplementation(async () => {
@@ -191,7 +193,7 @@ describe("get_azure", () => {
     expect(blockBlobClient.download).toHaveBeenCalledTimes(1);
   });
 
-  it("should return an 500 error response when database query fails", async () => {
+  it("should return a 500 error response when database query fails", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
 
     blockBlobClient.download = jest.fn().mockImplementation(async () => {
@@ -201,5 +203,29 @@ describe("get_azure", () => {
     expect(response.status).toEqual(500);
     expect(response.payload).toEqual({ message: "Oh no!" });
     expect(blockBlobClient.download).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return a 500 error response when azure is not setup", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    blockBlobClient.download = jest.fn().mockImplementation(async () => {
+      throw { statusCode: 409, message: "Oh no!" };
+    });
+    const response = await get_azure("123");
+    expect(response.status).toEqual(500);
+    expect(response.payload).toEqual({ message: "Oh no!" });
+    expect(blockBlobClient.download).toHaveBeenCalledTimes(1);
+  });
+  it("should return a 500 error response when AZURE_STORAGE_CONNECTION_STRING is missing", async () => {
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+    blockBlobClient.download = jest.fn().mockImplementation(async () => {
+      throw { statusCode: 409, message: "Oh no!" };
+    });
+    const response = await get_azure("123");
+    expect(response.status).toEqual(500);
+    expect(response.payload).toEqual({
+      message:
+        "Failed to download the FHIR data due to misconfiguration of client.",
+    });
   });
 });

--- a/containers/ecr-viewer/src/app/tests/api/save-fhir-data.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/api/save-fhir-data.test.tsx
@@ -209,6 +209,11 @@ describe("POST Save FHIR Data API Route - Azure", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
+  });
+
+  afterAll(() => {
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING;
   });
 
   it("sends data to Azure Blob Storage and returns a success response", async () => {

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -65,30 +65,16 @@ describe("azure blob container", () => {
       process.env.AZURE_STORAGE_CONNECTION_STRING = "";
       process.env.AZURE_CONTAINER_NAME = "";
       process.env.ECR_BUCKET_NAME = "";
+      process.env.SOURCE = "s3";
     });
-    it("should return UNDEFINED if missing connection string", async () => {
+    it("should return UNDEFINED if SOURCE is not azure", async () => {
+      process.env.SOURCE = "s3";
       process.env.AZURE_STORAGE_CONNECTION_STRING = "";
       process.env.AZURE_CONTAINER_NAME = "container";
       expect(await azureBlobStorageHealthCheck()).toBeUndefined();
     });
-    it("should return UNDEFINED if missing container name", async () => {
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "";
-      process.env.ECR_BUCKET_NAME = "";
-      expect(await azureBlobStorageHealthCheck()).toBeUndefined();
-    });
-    it("should return UP when provided ECR_BUCKET_NAME and not AZURE_CONTAINER_NAME", async () => {
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "";
-      process.env.ECR_BUCKET_NAME = "container";
-      mockExists.mockResolvedValue(true);
-
-      const result = await azureBlobStorageHealthCheck();
-      expect(result).toEqual("UP");
-    });
-    it("should return UP when the container exists", async () => {
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "container";
+    it("should return UP when SOURCE is azure and client exists", async () => {
+      process.env.SOURCE = "azure";
       mockExists.mockResolvedValue(true);
 
       const result = await azureBlobStorageHealthCheck();
@@ -96,8 +82,7 @@ describe("azure blob container", () => {
     });
     it("should return DOWN when the container does not exist", async () => {
       jest.spyOn(console, "error").mockImplementation();
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "??";
+      process.env.SOURCE = "azure";
       mockExists.mockResolvedValue(false);
 
       const result = await azureBlobStorageHealthCheck();
@@ -105,8 +90,7 @@ describe("azure blob container", () => {
     });
     it("should return DOWN when the container throws an error", async () => {
       jest.spyOn(console, "error").mockImplementation();
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "??";
-      process.env.AZURE_CONTAINER_NAME = "container";
+      process.env.SOURCE = "azure";
       mockExists.mockRejectedValue(new Error("Connection error"));
 
       const result = await azureBlobStorageHealthCheck();

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -3,6 +3,7 @@
  */
 import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 
+import { AZURE_SOURCE, S3_SOURCE } from "@/app/api/utils";
 import {
   azureBlobContainerClient,
   azureBlobStorageHealthCheck,
@@ -67,11 +68,11 @@ describe("azure blob container", () => {
     });
 
     it("should return UNDEFINED if SOURCE is not azure", async () => {
-      process.env.SOURCE = "s3";
+      process.env.SOURCE = S3_SOURCE;
       expect(await azureBlobStorageHealthCheck()).toBeUndefined();
     });
     it("should return UP when the container exists", async () => {
-      process.env.SOURCE = "azure";
+      process.env.SOURCE = AZURE_SOURCE;
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
       process.env.AZURE_CONTAINER_NAME = "container";
       mockExists.mockResolvedValue(true);
@@ -80,7 +81,7 @@ describe("azure blob container", () => {
       expect(result).toEqual("UP");
     });
     it("should return DOWN when the container is not initialized", async () => {
-      process.env.SOURCE = "azure";
+      process.env.SOURCE = AZURE_SOURCE;
       delete process.env.AZURE_STORAGE_CONNECTION_STRING;
       mockExists.mockResolvedValue(false);
 
@@ -89,7 +90,7 @@ describe("azure blob container", () => {
     });
     it("should return DOWN when the container does not exist", async () => {
       jest.spyOn(console, "error").mockImplementation();
-      process.env.SOURCE = "azure";
+      process.env.SOURCE = AZURE_SOURCE;
       mockExists.mockResolvedValue(false);
 
       const result = await azureBlobStorageHealthCheck();
@@ -97,7 +98,7 @@ describe("azure blob container", () => {
     });
     it("should return DOWN when the container throws an error", async () => {
       jest.spyOn(console, "error").mockImplementation();
-      process.env.SOURCE = "azure";
+      process.env.SOURCE = AZURE_SOURCE;
       mockExists.mockRejectedValue(new Error("Connection error"));
 
       const result = await azureBlobStorageHealthCheck();

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -12,6 +12,12 @@ jest.mock("@azure/storage-blob");
 
 describe("azure blob container", () => {
   describe("client", () => {
+    it("should return undefined when AZURE_STORAGE_CONNECTION_STRING is not provided", () => {
+      delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+      expect(azureBlobContainerClient()).toBeUndefined();
+    });
+
     it("should create container client with AZURE_CONTAINER_NAME", () => {
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
       process.env.AZURE_CONTAINER_NAME = "container";
@@ -62,11 +68,12 @@ describe("azure blob container", () => {
     });
     afterEach(() => {
       jest.resetAllMocks();
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "";
-      process.env.AZURE_CONTAINER_NAME = "";
+      delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+      delete process.env.AZURE_CONTAINER_NAME;
       process.env.ECR_BUCKET_NAME = "";
       process.env.SOURCE = "s3";
     });
+
     it("should return UNDEFINED if SOURCE is not azure", async () => {
       process.env.SOURCE = "s3";
       process.env.AZURE_STORAGE_CONNECTION_STRING = "";
@@ -75,10 +82,19 @@ describe("azure blob container", () => {
     });
     it("should return UP when SOURCE is azure and client exists", async () => {
       process.env.SOURCE = "azure";
+      process.env.AZURE_STORAGE_CONNECTION_STRING = "something";
       mockExists.mockResolvedValue(true);
 
       const result = await azureBlobStorageHealthCheck();
       expect(result).toEqual("UP");
+    });
+    it("should return DOWN when the container is not initialized", async () => {
+      process.env.SOURCE = "azure";
+      delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+      mockExists.mockResolvedValue(false);
+
+      const result = await azureBlobStorageHealthCheck();
+      expect(result).toEqual("DOWN");
     });
     it("should return DOWN when the container does not exist", async () => {
       jest.spyOn(console, "error").mockImplementation();

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -32,7 +32,7 @@ describe("azure blob container", () => {
 
     it("should create container client with ECR_BUCKET_NAME", () => {
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "";
+      delete process.env.AZURE_CONTAINER_NAME;
       process.env.ECR_BUCKET_NAME = "container2";
       const mockGetContainerClient = jest
         .fn()
@@ -62,20 +62,16 @@ describe("azure blob container", () => {
     });
     afterEach(() => {
       jest.resetAllMocks();
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "";
-      process.env.AZURE_CONTAINER_NAME = "";
+      delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+      delete process.env.AZURE_CONTAINER_NAME;
     });
-    it("should return UNDEFINED if missing connection string", async () => {
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "";
-      process.env.AZURE_CONTAINER_NAME = "container";
-      expect(await azureBlobStorageHealthCheck()).toBeUndefined();
-    });
-    it("should return UNDEFINED if missing container name", async () => {
-      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
-      process.env.AZURE_CONTAINER_NAME = "";
+
+    it("should return UNDEFINED if SOURCE is not azure", async () => {
+      process.env.SOURCE = "s3";
       expect(await azureBlobStorageHealthCheck()).toBeUndefined();
     });
     it("should return UP when the container exists", async () => {
+      process.env.SOURCE = "azure";
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
       process.env.AZURE_CONTAINER_NAME = "container";
       mockExists.mockResolvedValue(true);

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
@@ -21,14 +21,15 @@ describe("s3 health check", () => {
   afterEach(() => {
     jest.resetAllMocks();
     process.env.ECR_BUCKET_NAME = "";
+    process.env.SOURCE = "s3";
   });
 
-  it("should return UNDEFINED if missing bucket name", async () => {
-    process.env.ECR_BUCKET_NAME = "";
+  it("should return UNDEFINED if SOURCE is not s3", async () => {
+    process.env.SOURCE = "azure";
     expect(await s3HealthCheck()).toBeUndefined();
   });
   it("should return UP when health command succeeds", async () => {
-    process.env.ECR_BUCKET_NAME = "bucket";
+    process.env.SOURCE = "s3";
     mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
 
     const result = await s3HealthCheck();
@@ -36,7 +37,7 @@ describe("s3 health check", () => {
   });
   it("should return DOWN when health command fails", async () => {
     jest.spyOn(console, "error").mockImplementation();
-    process.env.ECR_BUCKET_NAME = "bucket";
+    process.env.SOURCE = "s3";
     mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 404 } });
 
     const result = await s3HealthCheck();
@@ -44,7 +45,7 @@ describe("s3 health check", () => {
   });
   it("should return DOWN when s3 throws an error", async () => {
     jest.spyOn(console, "error").mockImplementation();
-    process.env.ECR_BUCKET_NAME = "bucket";
+    process.env.SOURCE = "s3";
     mockSend.mockRejectedValue(new Error("Connection failed"));
 
     const result = await s3HealthCheck();


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Update AWS and Azure related variables to be optional since they won't be available in every setup
- Use `ECR_BUCKET_NAME` as backup when creating azure blob.

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
