### PR TITLE
fix: handle more phone number formats and fail more gracefully

### DIFF
--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -165,9 +165,9 @@ export const formatCurrentAddress = (
   return formatAddress(address);
 };
 
-const VALID_PHONE_NUMBER_REGEX = /^\d{3}-\d{3}-\d{4}$/;
+const VALID_PHONE_NUMBER_REGEX = /^\d{3}-\d{3}-\d{4}( \D\w*)?$/;
 /**
- * Formats a phone number into a standard format of XXX-XXX-XXXX.
+ * Formats a phone number into a standard format of XXX-XXX-XXXX x123.
  * @param phoneNumber - The phone number to format.
  * @returns The formatted phone number or "Invalid Number" if the input is invalid or undefined if the input is empty.
  */
@@ -178,13 +178,14 @@ export const formatPhoneNumber = (
 
   const formatted = phoneNumber
     .replace("+1", "")
-    .replace(/\D/g, "")
-    .replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3");
+    .replace(/\W/g, "")
+    .replace(/(\d{3})(\d{3})(\d{4})(.*)/, "$1-$2-$3 $4")
+    .trim();
 
   if (VALID_PHONE_NUMBER_REGEX.test(formatted)) {
     return formatted;
   } else {
-    return "Invalid Number";
+    return `Invalid Number: ${phoneNumber}`;
   }
 };
 

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -169,7 +169,7 @@ const VALID_PHONE_NUMBER_REGEX = /^\d{3}-\d{3}-\d{4}( \D\w*)?$/;
 /**
  * Formats a phone number into a standard format of XXX-XXX-XXXX x123.
  * @param phoneNumber - The phone number to format.
- * @returns The formatted phone number or "Invalid Number" if the input is invalid or undefined if the input is empty.
+ * @returns The formatted phone number or "Invalid Number: <unformatted phone number>" if the input is invalid or undefined if the input is empty.
  */
 export const formatPhoneNumber = (
   phoneNumber: string | undefined,

--- a/containers/ecr-viewer/src/app/tests/services/formatService.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/services/formatService.test.tsx
@@ -217,7 +217,10 @@ describe("FormatService tests", () => {
     });
 
     it("should return 'Invalid Number' when junk things passed", () => {
-      expect(formatPhoneNumber("+11111111")).toBe("Invalid Number");
+      expect(formatPhoneNumber("+11111111")).toBe("Invalid Number: +11111111");
+      expect(formatPhoneNumber("+11111111111111111")).toBe(
+        "Invalid Number: +11111111111111111",
+      );
     });
 
     it("should format a valid phone number", () => {
@@ -226,6 +229,22 @@ describe("FormatService tests", () => {
       expect(formatPhoneNumber("1111111111")).toBe("111-111-1111");
       expect(formatPhoneNumber("111-111-1111")).toBe("111-111-1111");
       expect(formatPhoneNumber("(111) 111-1111")).toBe("111-111-1111");
+      expect(formatPhoneNumber("(111) 111-1111x123")).toBe("111-111-1111 x123");
+      expect(formatPhoneNumber("(111) 111-1111-x123")).toBe(
+        "111-111-1111 x123",
+      );
+      expect(formatPhoneNumber("(111) 111-1111 x123")).toBe(
+        "111-111-1111 x123",
+      );
+      expect(formatPhoneNumber("(111) 111-1111 ext123")).toBe(
+        "111-111-1111 ext123",
+      );
+      expect(formatPhoneNumber("(111) 111-1111 ext 123")).toBe(
+        "111-111-1111 ext123",
+      );
+      expect(formatPhoneNumber("(111) 111-1111 ext. 123")).toBe(
+        "111-111-1111 ext123",
+      );
     });
   });
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Handle phone number with extensions (or extension like formatting). When we can't format a number instead of only showing `Invalid Number`, show `Invalid Number: <unformatted phone number>`

## Related Issue

Fixes #497