### PR TITLE
fix: generify vital sign evaluation and display

### DIFF
--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/yoda-zika-v1-positive/CDA_eICR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/yoda-zika-v1-positive/CDA_eICR.xml
@@ -725,6 +725,194 @@
           </entry>
         </section>
       </component>
+
+      <!-- Vital Signs Section (entries required) (V3) -->
+      <component>
+        <section>
+          <!-- [C-CDA R2.1] Vital Signs Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+          <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Vital Signs" />
+          <title>Vital Signs (Last Filed)</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Blood Pressure</th>
+                  <th>Pulse</th>
+                  <th>Temperature</th>
+                  <th>Respiratory Rate</th>
+                  <th>Height</th>
+                  <th>Weight</th>
+                  <th>BMI</th>
+                  <th>SpO2</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>05/20/2014 7:36pm</td>
+                  <!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references-->
+                  <td>
+                    <content ID="SystolicBP_2">120</content>/<content ID="DiastolicBP_2">80</content>mm[Hg] </td>
+                  <td ID="Pulse_2">80 /min</td>
+                  <td ID="Temp_2">99.0 F</td>
+                  <td ID="RespRate_2">18 /min</td>
+                  <td ID="Height_2">3'7 (43 inches)</td>
+                  <td ID="Weight_2">39.9 lbs</td>
+                  <td ID="BMI_2">17.58 kg/m2</td>
+                  <td ID="SPO2_2">98%</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <!-- When a set of vital signs are recorded together, include them in single clustered organizer-->
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.26" extension="2015-08-01" />
+              <id root="e421f5c8-29c2-4798-9cb5-7988c236e49d" />
+              <code code="46680005" displayName="Vital Signs" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                <translation code="74728-7" displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel " codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime value="20140520193605-0500" />
+              <!-- Each vital sign should be its own component. Note that systolic and diastolic BP must be separate components-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="2721acc5-0d05-4402-9e62-79943ea3901c" />
+                  <code code="8480-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="SYSTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <!-- This reference identifies content in human readable formatted text-->
+                    <reference value="#SystolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Example of Value with UCUM unit. Note that mixed metric and imperial units used in this example-->
+                  <value xsi:type="PQ" value="120" unit="mm[Hg]" />
+                  <!-- Additional information of interpretation and/or reference range may be included but are optional-->
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="88a01c83-a096-4705-a992-b5f59eca8c8c" />
+                  <code code="8462-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="DIASTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <reference value="#DiastolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="80" unit="mm[Hg]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="83bbffe1-54e5-4984-a32d-ad8f8d6896d8" />
+                  <code code="8867-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HEART RATE" />
+                  <text>
+                    <reference value="#Pulse_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="80" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="85f5784f-2958-4321-b7b6-3030d1577dc0" />
+                  <code code="8310-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BODY TEMPERATURE" />
+                  <text>
+                    <reference value="#Temp_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify degrees Farenheit-->
+                  <value xsi:type="PQ" value="99.0" unit="[degF]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="b618fa98-6596-4e19-a9e7-6bdb48012fc8" />
+                  <code code="9279-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="RESPIRATORY RATE" />
+                  <text>
+                    <reference value="#RespRate_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="18" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="1b1274a9-b45f-449a-8493-08eaeaeba7d6" />
+                  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HEIGHT" />
+                  <text>
+                    <reference value="#Height_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify inches-->
+                  <value xsi:type="PQ" value="43" unit="[in_us]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="1c1f89f1-8e93-4a46-b37f-9434f99727b8" />
+                  <code code="3141-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="WEIGHT" />
+                  <text>
+                    <reference value="#Weight_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify pounds-->
+                  <value xsi:type="PQ" value="39.9" unit="[lb_av]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="fd4ccd0b-c045-4587-8976-a17e2e064a1e" />
+                  <code code="39156-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BODY MASS INDEX" />
+                  <text>
+                    <reference value="#BMI_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="17.58" unit="kg/m2" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="0ef4afda-1638-4ad2-9978-7321bbceb0cb" />
+                  <code code="2710-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="OXYGEN SATURATION" />
+                  <text>
+                    <reference value="#SPO2_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="98" unit="%" />
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
     </structuredBody>
   </component>
 </ClinicalDocument>

--- a/containers/ecr-viewer/src/app/tests/components/Clinical.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/Clinical.test.tsx
@@ -303,7 +303,13 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
     expect(expectedTable[0]).toBeInTheDocument();
 
     // Check Vital Signs table contents
-    const expectedValues = ["60 in", "140 lb", "20 kg/m2"];
+    const expectedValues = [
+      "60 in",
+      "152.4 cm",
+      "140 lb",
+      "63.5 kg",
+      "20 kg/m2",
+    ];
     const expectedDate = "02/04/2025 12:48 PM EST";
 
     // Check if all expected values are present in the document
@@ -311,7 +317,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
       expect(screen.getByText(value)).toBeInTheDocument();
     });
     const numVitalSignsDate = screen.getAllByText(expectedDate);
-    expect(numVitalSignsDate.length).toBe(3);
+    expect(numVitalSignsDate.length).toBe(5);
   });
 
   it("eCR Viewer renders reason for visit given FHIR bundle with reason for visit info", () => {

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -89,12 +89,10 @@ export type PathTypes = {
   encounterParticipants: EncounterParticipant;
   rrDetails: Observation;
   clinicalReasonForVisit: ValueX;
-  patientHeight: ValueX;
-  patientHeightDate: string;
-  patientWeight: ValueX;
-  patientWeightDate: string;
-  patientBmi: ValueX;
-  patientBmiDate: string;
+  patientVitalSigns: Observation;
+  vitalSignType: CodeableConcept;
+  vitalSignValue: ValueX;
+  vitalSignDateTime: ValueX;
   resolve: unknown;
   activeProblems: Condition;
   activeProblemsDisplay: string;
@@ -388,30 +386,23 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
 
   // Vitals
-  patientHeight: {
+  patientVitalSigns: {
+    type: "Observation",
+    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(category.coding.code = 'vital-signs')",
+  },
+  vitalSignType: {
+    type: "CodeableConcept",
+    path: "code",
+  },
+  vitalSignValue: {
     type: "ValueX",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.code = '8302-2').first().value",
+    path: "value",
   },
-  patientHeightDate: {
-    type: "string",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.first().code = '8302-2').first().effectiveDateTime",
-  },
-  patientWeight: {
+  vitalSignDateTime: {
     type: "ValueX",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.first().code = '29463-7').first().value",
+    path: "effectiveDateTime",
   },
-  patientWeightDate: {
-    type: "string",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.first().code = '29463-7').first().effectiveDateTime",
-  },
-  patientBmi: {
-    type: "ValueX",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.first().code = '39156-5').value",
-  },
-  patientBmiDate: {
-    type: "string",
-    path: "Bundle.entry.resource.where(resourceType = 'Observation').where(code.coding.first().code = '39156-5').effectiveDateTime",
-  },
+
   resolve: {
     type: "unknown",
     path: "Bundle.entry.resource.where(resourceType = %resourceType).where(id = %id)",

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -202,6 +202,7 @@ export const evaluateOne = <K extends keyof PathTypes>(
 const UNIT_MAP = new Map([
   ["[lb_av]", "lb"],
   ["[in_i]", "in"],
+  ["[in_us]", "in"],
 ]);
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -407,6 +407,8 @@ export const returnProceduresTable = (
 export const returnVitalsTable = (fhirBundle: Bundle) => {
   const vitals = evaluateAll(fhirBundle, fhirPathMappings.patientVitalSigns);
 
+  if (vitals.length === 0) return;
+
   const columns = [
     {
       columnName: "Vital Reading",

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -409,6 +409,13 @@ export const returnVitalsTable = (fhirBundle: Bundle) => {
 
   if (vitals.length === 0) return;
 
+  // Sort by code to get consistent and reasonable order (e.g. blood pressures near each other)
+  vitals.sort((a, b) =>
+    (a?.code?.coding?.[0]?.code ?? 0) < (b?.code?.coding?.[0]?.code ?? 0)
+      ? -1
+      : 1,
+  );
+
   const columns = [
     {
       columnName: "Vital Reading",

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -20,10 +20,9 @@ import {
   formatName,
 } from "@/app/services/formatService";
 import { formatTablesToJSON } from "@/app/services/htmlTableService";
-import { evaluateData, noData, safeParse } from "@/app/utils/data-utils";
+import { evaluateData, safeParse } from "@/app/utils/data-utils";
 import {
   evaluateAll,
-  evaluateOne,
   evaluateReference,
   evaluateValue,
 } from "@/app/utils/evaluate";
@@ -35,7 +34,6 @@ import {
 } from "@/app/view-data/components/AdministeredMedication";
 import { DisplayDataProps } from "@/app/view-data/components/DataDisplay";
 import EvaluateTable, {
-  BaseTable,
   ColumnInfoInput,
 } from "@/app/view-data/components/EvaluateTable";
 import { JsonTable } from "@/app/view-data/components/JsonTable";
@@ -407,65 +405,29 @@ export const returnProceduresTable = (
  * @returns The JSX element representing the table, or undefined if no vital signs are found.
  */
 export const returnVitalsTable = (fhirBundle: Bundle) => {
-  const height = evaluateValue(fhirBundle, fhirPathMappings.patientHeight);
-  const heightDate: string | undefined = evaluateOne(
-    fhirBundle,
-    fhirPathMappings.patientHeightDate,
-  );
+  const vitals = evaluateAll(fhirBundle, fhirPathMappings.patientVitalSigns);
 
-  const weight = evaluateValue(fhirBundle, fhirPathMappings.patientWeight);
-  const weightDate: string | undefined = evaluateOne(
-    fhirBundle,
-    fhirPathMappings.patientWeightDate,
-  );
-
-  const bmi = evaluateValue(fhirBundle, fhirPathMappings.patientBmi);
-  const bmiDate: string | undefined = evaluateOne(
-    fhirBundle,
-    fhirPathMappings.patientBmiDate,
-  );
-
-  if (!height && !weight && !bmi) {
-    return undefined;
-  }
-
-  const vitalsData = [
-    {
-      vitalReading: "Height",
-      result: height || noData,
-      date: formatDateTime(heightDate) || noData,
-    },
-    {
-      vitalReading: "Weight",
-      result: weight || noData,
-      date: formatDateTime(weightDate) || noData,
-    },
-    {
-      vitalReading: "BMI",
-      result: bmi || noData,
-      date: formatDateTime(bmiDate) || noData,
-    },
-  ];
   const columns = [
-    { columnName: "Vital Reading" },
-    { columnName: "Result" },
-    { columnName: "Date/Time" },
+    {
+      columnName: "Vital Reading",
+      infoPath: "vitalSignType",
+      applyToValue: toSentenceCase,
+    },
+    { columnName: "Result", infoPath: "vitalSignValue" },
+    {
+      columnName: "Date/Time",
+      infoPath: "vitalSignDateTime",
+      applyToValue: formatDateTime,
+    },
   ];
 
   return (
-    <BaseTable
+    <EvaluateTable
+      resources={vitals}
       columns={columns}
       caption="Vital Signs"
       className="margin-y-0"
       fixed={false}
-    >
-      {vitalsData.map((entry, index: number) => (
-        <tr key={`table-row-${index}`}>
-          <td>{entry.vitalReading}</td>
-          <td>{entry.result}</td>
-          <td>{entry.date}</td>
-        </tr>
-      ))}
-    </BaseTable>
+    />
   );
 };


### PR DESCRIPTION
# PULL REQUEST

## Summary

Get and display all vital signs from the bundle and display in a consistent order instead of only getting height, weight, and BMI.

## Related Issue

Fixes #499

## Acceptance Criteria

All vital signs should be displayed

## Additional Information

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/591fb9d7-7106-438d-919b-d84b1d1ba837" />

After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/03a6b3c2-cc42-43a6-a0b7-5533065c6bba" />
