### PR TITLE
ci: pass ref_name during create release job

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/run-container-workflow.yaml
     with:
       container: ${{ matrix.container }}
-      ref_name: ${{ github.ref_name	}}
+      ref_name: ${{ github.ref_name }}
     secrets: inherit
 
   # Rebuild all containers for the new release

--- a/.github/workflows/run-container-workflow.yaml
+++ b/.github/workflows/run-container-workflow.yaml
@@ -42,5 +42,5 @@ jobs:
         run: |
           echo "Waiting for workflow run ID: $RUN_ID to complete..."
           echo "https://github.com/CDCgov/dibbs-ecr-viewer/actions/runs/$RUN_ID"
-          
-          gh run watch $RUN_ID -i 30 --exit-status 
+
+          gh run watch $RUN_ID -i 30 --exit-status


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Improve release process by passing ref_name rather than just using the default (main)
- Use `gh run watch` to report status and add logs to workflow
  - Example run: https://github.com/BobanL/dibbs-ecr-viewer/actions/runs/14067677447/job/39394141741
 
## Related Issue

- run-container-workflow would create jobs that were cancallable by merges on main since it was using the `main` ref