### PR TITLE
test: add side nav e2e

### DIFF
--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -89,10 +89,10 @@ test.describe("viewer page", () => {
       let lastY = "-1";
       while (navIndex < numLinks) {
         const y: string = await page.evaluate("window.scrollY");
-        if (y === lastY) break;
+        if (y === lastY) break; // we've hit the bottom of the page
         lastY = y;
         await page.mouse.wheel(0, 15);
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await new Promise((resolve) => setTimeout(resolve, 8));
 
         const className = await navLinks.nth(navIndex)?.getAttribute("class");
         if (className === "usa-current") {

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -85,7 +85,7 @@ test.describe("viewer page", () => {
 
       const navLinks = await nav.getByRole("link");
       const numLinks = (await navLinks.all()).length;
-      let navIndex = 1; // skip back to library link
+      let navIndex = 1; // skip "back to library" link
       while (navIndex < numLinks) {
         await page.mouse.wheel(0, 10);
 

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -92,7 +92,7 @@ test.describe("viewer page", () => {
         // if (y === lastY) break; // we've hit the bottom of the page
         // lastY = y;
         await page.mouse.wheel(0, 10);
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        // await new Promise((resolve) => setTimeout(resolve, 5));
 
         const className = await navLinks.nth(navIndex)?.getAttribute("class");
         if (className === "usa-current") {

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -41,18 +41,12 @@ test.describe("viewer page", () => {
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test.describe.only("side nav", () => {
-    test("clicking each link scrolls and higlighlights", async ({ page }) => {
+  test.describe("side nav", () => {
+    test.beforeEach(async ({ page }) => {
       await page.goto(
         "/ecr-viewer/view-data?id=db734647-fc99-424c-a864-7e3cda82e703",
       );
       await page.getByText("Patient Name").first().waitFor();
-
-      const nav = await page.getByRole("navigation");
-      await expect(nav).toBeVisible();
-
-      const navLinks = await nav.getByRole("link").all();
-      expect(navLinks.length).toBe(22);
 
       // Make sure after collapsing and reopening, nav links still work
       await page.getByText("Collapse all sections").click();
@@ -60,6 +54,14 @@ test.describe("viewer page", () => {
 
       await page.getByText("Expand all sections").click();
       expect(page.getByText("Miscellaneous Notes")).toBeVisible();
+    });
+
+    test("clicking each link scrolls and higlighlights", async ({ page }) => {
+      const nav = await page.getByRole("navigation");
+      await expect(nav).toBeVisible();
+
+      const navLinks = await nav.getByRole("link").all();
+      expect(navLinks.length).toBe(22);
 
       // make sure clicking each link scrolls the heading and highlights the corresponding
       // side nav item
@@ -78,24 +80,10 @@ test.describe("viewer page", () => {
     test("scrolling through highlights links appropriately", async ({
       page,
     }) => {
-      await page.goto(
-        "/ecr-viewer/view-data?id=db734647-fc99-424c-a864-7e3cda82e703",
-      );
-      await page.getByText("Patient Name").first().waitFor();
-
       const nav = await page.getByRole("navigation");
       await expect(nav).toBeVisible();
 
       const navLinks = await nav.getByRole("link").all();
-      expect(navLinks.length).toBe(22);
-
-      // Make sure after collapsing and reopening, nav links still work
-      await page.getByText("Collapse all sections").click();
-      expect(page.getByText("Miscellaneous Notes")).not.toBeVisible();
-
-      await page.getByText("Expand all sections").click();
-      expect(page.getByText("Miscellaneous Notes")).toBeVisible();
-
       let navIndex = 1; // skip back to library link
       let lastY = "-1";
       while (true) {

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -86,13 +86,8 @@ test.describe("viewer page", () => {
       const navLinks = await nav.getByRole("link");
       const numLinks = (await navLinks.all()).length;
       let navIndex = 1; // skip back to library link
-      // let lastY = "-1";
       while (navIndex < numLinks) {
-        // const y: string = await page.evaluate("window.scrollY");
-        // if (y === lastY) break; // we've hit the bottom of the page
-        // lastY = y;
         await page.mouse.wheel(0, 10);
-        // await new Promise((resolve) => setTimeout(resolve, 5));
 
         const className = await navLinks.nth(navIndex)?.getAttribute("class");
         if (className === "usa-current") {

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -47,6 +47,14 @@ test.describe("viewer page", () => {
         "/ecr-viewer/view-data?id=db734647-fc99-424c-a864-7e3cda82e703",
       );
       await page.getByText("Patient Name").first().waitFor();
+    });
+
+    test("clicking each link scrolls and higlighlights", async ({ page }) => {
+      const nav = page.getByRole("navigation");
+      await expect(nav).toBeVisible();
+
+      const navLinks = await nav.getByRole("link").all();
+      expect(navLinks.length).toBe(22);
 
       // Make sure after collapsing and reopening, nav links still work
       await page.getByText("Collapse all sections").click();
@@ -54,14 +62,6 @@ test.describe("viewer page", () => {
 
       await page.getByText("Expand all sections").click();
       expect(page.getByText("Miscellaneous Notes")).toBeVisible();
-    });
-
-    test("clicking each link scrolls and higlighlights", async ({ page }) => {
-      const nav = await page.getByRole("navigation");
-      await expect(nav).toBeVisible();
-
-      const navLinks = await nav.getByRole("link").all();
-      expect(navLinks.length).toBe(22);
 
       // make sure clicking each link scrolls the heading and highlights the corresponding
       // side nav item
@@ -80,25 +80,27 @@ test.describe("viewer page", () => {
     test("scrolling through highlights links appropriately", async ({
       page,
     }) => {
-      const nav = await page.getByRole("navigation");
+      const nav = page.getByRole("navigation");
       await expect(nav).toBeVisible();
 
-      const navLinks = await nav.getByRole("link").all();
+      const navLinks = await nav.getByRole("link");
+      const numLinks = (await navLinks.all()).length;
       let navIndex = 1; // skip back to library link
       let lastY = "-1";
-      while (true) {
+      while (navIndex < numLinks) {
         const y: string = await page.evaluate("window.scrollY");
         if (y === lastY) break;
         lastY = y;
-        await page.mouse.wheel(0, 10);
+        await page.mouse.wheel(0, 15);
+        await new Promise((resolve) => setTimeout(resolve, 5));
 
-        const className = await navLinks.at(navIndex)?.getAttribute("class");
+        const className = await navLinks.nth(navIndex)?.getAttribute("class");
         if (className === "usa-current") {
           navIndex += 1;
         }
       }
 
-      expect(navIndex).toBe(navLinks.length);
+      expect(navIndex).toBe(numLinks);
     });
   });
 });

--- a/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-viewer.spec.ts
@@ -86,13 +86,13 @@ test.describe("viewer page", () => {
       const navLinks = await nav.getByRole("link");
       const numLinks = (await navLinks.all()).length;
       let navIndex = 1; // skip back to library link
-      let lastY = "-1";
+      // let lastY = "-1";
       while (navIndex < numLinks) {
-        const y: string = await page.evaluate("window.scrollY");
-        if (y === lastY) break; // we've hit the bottom of the page
-        lastY = y;
-        await page.mouse.wheel(0, 15);
-        await new Promise((resolve) => setTimeout(resolve, 8));
+        // const y: string = await page.evaluate("window.scrollY");
+        // if (y === lastY) break; // we've hit the bottom of the page
+        // lastY = y;
+        await page.mouse.wheel(0, 10);
+        await new Promise((resolve) => setTimeout(resolve, 5));
 
         const className = await navLinks.nth(navIndex)?.getAttribute("class");
         if (className === "usa-current") {

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -172,11 +172,15 @@ const SideNav: React.FC = () => {
 
     const options = {
       root: null,
-      rootMargin: `-${topOffset}px 0px -100% 0px`,
+      rootMargin: `-${topOffset}px 0px -${
+        window.innerHeight - topOffset - 1
+      }px 0px`,
       threshold: 0,
     };
+    console.log({ options });
 
     const observer = new IntersectionObserver((entries) => {
+      console.log({ entries });
       // get the top/first thing that intersected
       for (const entry of entries) {
         if (entry.isIntersecting) {

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -177,10 +177,8 @@ const SideNav: React.FC = () => {
       }px 0px`,
       threshold: 0,
     };
-    console.log({ options });
 
     const observer = new IntersectionObserver((entries) => {
-      console.log({ entries });
       // get the top/first thing that intersected
       for (const entry of entries) {
         if (entry.isIntersecting) {

--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -13,7 +13,7 @@ $main-min-width: $ecr-viewer-container-min-width + $ecr-viewer-gap +
   $nav-wrapper-width + $main-container-padding * 2;
 
 html {
-  --patient-banner-buffer: 2.75rem;
+  --patient-banner-buffer: 3.1rem;
 }
 
 // ===== Page styling ===== //
@@ -333,11 +333,9 @@ html {
 
 .patient-banner {
   display: flex;
-  padding: 0.5rem 1.5rem;
+  padding: 0.85rem 1.5rem;
   align-items: center;
   gap: 12px;
-  align-self: stretch;
-  min-height: 44px;
 
   background: var(--Info-info-darker, #2e6276);
 
@@ -345,7 +343,7 @@ html {
 
   font-size: 1.375rem;
   font-style: normal;
-  line-height: normal;
+  line-height: 1.15;
 
   position: sticky;
   top: 0;


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add tests to make sure the side nav links and scroll syncing work as designed

## Related Issue

Fixes #388

## Acceptance Criteria

- [ ] When each link is clicked, the corresponding header is at the top of the screen (not hidden behind banner)
- [ ] When scrolling through, each side nav item should become highlighted at the appropriate time
- [ ] When accordion is collapsed, side nav links still work
- [ ] when accordion is re-expanded, side nav scrolling still works