### PR TITLE
test: add e2e library sorting tests

### DIFF
--- a/containers/ecr-viewer/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-library.spec.ts
@@ -160,7 +160,7 @@ test.describe("ecr library page", () => {
     });
   });
 
-  test.only("eCR sorting", async ({ page }) => {
+  test("eCR sorting", async ({ page }) => {
     await page.goto("/ecr-viewer");
 
     for (const [header, colIndex] of [

--- a/containers/ecr-viewer/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/ecr-library.spec.ts
@@ -160,6 +160,49 @@ test.describe("ecr library page", () => {
     });
   });
 
+  test.only("eCR sorting", async ({ page }) => {
+    await page.goto("/ecr-viewer");
+
+    for (const [header, colIndex] of [
+      ["Patient", "1"],
+      ["Received Date", "2"],
+      ["Encounter Date", "3"],
+    ]) {
+      const headerButton = page.getByRole("button", {
+        name: header,
+        exact: true,
+      });
+
+      await headerButton.click();
+      await expect(page.getByTestId("loading-table")).toBeVisible();
+      await expect(page.getByText("Yoda")).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: header }),
+      ).toHaveAttribute("aria-sort", "ascending");
+      const ascContents = await Promise.all(
+        (await page.locator(`tr > td:nth-child(${colIndex})`).all()).map((td) =>
+          td.innerText(),
+        ),
+      );
+
+      await headerButton.click();
+      await expect(page.getByTestId("loading-table")).toBeVisible();
+      await expect(page.getByText("Yoda")).toBeVisible();
+      await expect(
+        page.getByRole("columnheader", { name: header }),
+      ).toHaveAttribute("aria-sort", "descending");
+      const descContents = await Promise.all(
+        (await page.locator(`tr > td:nth-child(${colIndex})`).all()).map((td) =>
+          td.innerText(),
+        ),
+      );
+
+      ascContents.forEach((ascContent, i) => {
+        expect(ascContent).toBe(descContents.at(-1 * (i + 1)));
+      });
+    }
+  });
+
   test.describe("eCR grouping", () => {
     test("expanding group", async ({ page }) => {
       await page.goto("/ecr-viewer");
@@ -170,6 +213,12 @@ test.describe("ecr library page", () => {
       await expect(
         (await page.getByRole("row", { level: 2 }).all()).length,
       ).toEqual(2);
+
+      // collapse it back down
+      await page.getByRole("button", { name: "Hide Related eCRs" }).click();
+      await expect(
+        (await page.getByRole("row", { level: 2 }).all()).length,
+      ).toEqual(0);
     });
   });
 });

--- a/containers/ecr-viewer/src/app/components/EcrTableLoading.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrTableLoading.tsx
@@ -6,7 +6,7 @@ import { range } from "@/app/utils/data-utils";
  */
 export const EcrTableLoading = () => {
   return (
-    <tbody>
+    <tbody data-testid="loading-table">
       {range(10).map((i) => {
         return (
           <BlobRow key={i} themeColor={i % 2 === 0 ? "gray" : "dark-gray"} />

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTableLoading.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrTableLoading.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`EcrTableLoading Snapshot test should match snapshot 1`] = `
 <div>
-  <tbody>
+  <tbody
+    data-testid="loading-table"
+  >
     <tr>
       <td>
         <div


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add e2e tests to ensure library sorting is working.

## Related Issue

Fixes #580

## Acceptance Criteria

Sorting tests for each column in the eCR Library

## Additional Information

This PR tests that the order of the columns did reverse when switched from ascending to descending? Is this enough? or should it more strictly check a sort order?