### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,3 @@
 
 # ecr viewer team
 *       @akasper @angelathe @austin-hall-skylight @gordonfarrell @JNygaard-Skylight @mcmcgrath13 
-
-# refiner team
-/containers/message-refiner/ @jakewheeler @lina-roth @robertmitchellv
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-
-# ecr viewer team
 *       @akasper @angelathe @austin-hall-skylight @gordonfarrell @JNygaard-Skylight @mcmcgrath13 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,10 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @akasper @angelathe @austin-hall-skylight @BobanL @gordonfarrell @jakewheeler @JNygaard-Skylight @lina-roth @mcmcgrath13 @robertmitchellv
+
+# ecr viewer team
+*       @akasper @angelathe @austin-hall-skylight @gordonfarrell @JNygaard-Skylight @mcmcgrath13 
+
+# refiner team
+/containers/message-refiner/ @jakewheeler @lina-roth @robertmitchellv
+


### PR DESCRIPTION
# PULL REQUEST

## Summary

Update code owners per recent team changes.

Not 100% sure on the refiner piece, but it seems maybe better than removing entirely?