### PR TITLE
refactor: remove dummy health check endpoint from eCR Viewer API

### DIFF
--- a/containers/ecr-viewer/src/app/api/route.ts
+++ b/containers/ecr-viewer/src/app/api/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-
-/**
- * Health check for ECR Viewer
- * @returns Response with status OK.
- */
-export async function GET() {
-  return NextResponse.json({ status: "OK" }, { status: 200 });
-}


### PR DESCRIPTION
# PULL REQUEST

## Summary

Removes an endpoint at `/api`. This is acting like a health-check endpoint, but we explicitly have one: `api/health-check`.

## Related Issue

Fixes #618 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Removing the `/api/save-fhir-data` endpoint was split off from this PR because it is a much heavier lift that will involving changing the orchestration service.
