### PR TITLE
refactor: tighten types with applyToValue

### DIFF
--- a/containers/ecr-viewer/src/app/services/socialHistoryService.tsx
+++ b/containers/ecr-viewer/src/app/services/socialHistoryService.tsx
@@ -1,17 +1,20 @@
 import { Bundle, Observation } from "fhir/r4";
 
 import { noData } from "@/app/utils/data-utils";
-import { evaluateAll, evaluateValue } from "@/app/utils/evaluate";
-import fhirPathMappings, {
-  FhirPathKeys,
-} from "@/app/utils/evaluate/fhir-paths";
-import { ColumnInfoInput } from "@/app/view-data/components/EvaluateTable";
+import { evaluateAll } from "@/app/utils/evaluate";
+import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
+import {
+  ColumnInfoInput,
+  evaluateTableRowCell,
+} from "@/app/view-data/components/EvaluateTable";
 import { JsonTable } from "@/app/view-data/components/JsonTable";
 
 import { formatDate } from "./formatDateService";
 import { HtmlTableJsonRow } from "./htmlTableService";
 
-type TravelHistoryColumn = ColumnInfoInput & { infoPath: FhirPathKeys };
+type TravelHistoryColumn = Omit<ColumnInfoInput, "applyToValue"> & {
+  applyToValue?: (val: string) => string | undefined;
+};
 
 /**
  * Extracts travel history information from the provided FHIR bundle based on the FHIR path mappings.
@@ -66,16 +69,13 @@ const createTravelHistoryTables = (
       const row: HtmlTableJsonRow = {};
 
       // Populate the row by iterating over the columns
-      columns.forEach(({ columnName, infoPath, applyToValue }) => {
-        let value = evaluateValue(activity, fhirPathMappings[infoPath]);
-
-        // Apply transformation if needed
-        if (applyToValue) {
-          value = applyToValue(value) ?? "";
-        }
+      columns.forEach((column) => {
+        const value = evaluateTableRowCell(column, activity, fhirPathMappings);
+        // casting is fine because of constrained applyToValue type
+        const data = value.data as string | undefined;
 
         // Assign the value to the row
-        row[columnName] = { value: value || noData };
+        row[column.columnName] = { value: data || noData };
       });
 
       return row;

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/ActiveProblems.test.tsx.snap
@@ -40,22 +40,22 @@ exports[`Active Problems Table should match snapshot 1`] = `
     <tbody>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           Malignant neoplasm of lower-inner quadrant of left breast in female, estrogen receptor positive
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           12/14/2022
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           123 years
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <button
             aria-controls="hidden-comment-r:id"
@@ -84,12 +84,12 @@ exports[`Active Problems Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           Headache
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -98,12 +98,12 @@ exports[`Active Problems Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           152 years
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -114,22 +114,22 @@ exports[`Active Problems Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           Backache
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           08/19/2018 1:00 PM
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           141 years
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -140,12 +140,12 @@ exports[`Active Problems Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           Headache
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -154,12 +154,12 @@ exports[`Active Problems Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           1 year
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -170,22 +170,22 @@ exports[`Active Problems Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           Backache
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           06/28/1877
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           1 month, 3 days
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
@@ -227,35 +227,35 @@ exports[`Snapshot test for Procedures (Treatment Details) should match snapshot 
                     <tbody>
                       <tr>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           HC INFECTIOUS DISEASE PATHOGEN SPECIFIC RNA SARS-COV-2/INF A&B/RSV UPPER RESP SPEC DETECTED OR NOT
                         </td>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           06/24/2022
 12:50 PM EDT
                         </td>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           Struck by nonvenomous lizards, sequela
                         </td>
                       </tr>
                       <tr>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           LOINC codes are better
                         </td>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           06/16/2022
                         </td>
                         <td
-                          class="text-top"
+                          class="text-top text-pre-line"
                         >
                           Routine general medical examination at a health care facility
                         </td>

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Immunizations.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Immunizations.test.tsx.snap
@@ -46,17 +46,17 @@ exports[`Immunizations Table should match snapshot 1`] = `
     <tbody>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           MENINGOCOCCAL CONJUGATE,MENACTRA                                        (PED/ADOL/ADULT)
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           11/16/2020
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -65,7 +65,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -74,7 +74,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -85,22 +85,22 @@ exports[`Immunizations Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           TDAP, (ADOL/ADULT)
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           11/10/2020 6:20 AM EST
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           1
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -109,24 +109,24 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           369258741
         </td>
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           HEP A (ADULT) 2 DOSE
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           11/11/2011
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -135,7 +135,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -144,7 +144,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -155,17 +155,17 @@ exports[`Immunizations Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           DTAP-HIB-IPV (PENTACEL)
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           04/16/2010
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -174,7 +174,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -183,7 +183,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -194,17 +194,17 @@ exports[`Immunizations Table should match snapshot 1`] = `
       </tr>
       <tr>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           HEP B (PED,ADOLESCENT) 3 DOSE
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           03/21/1974
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -213,7 +213,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"
@@ -222,7 +222,7 @@ exports[`Immunizations Table should match snapshot 1`] = `
           </span>
         </td>
         <td
-          class="text-top"
+          class="text-top text-pre-line"
         >
           <span
             class="no-data text-italic text-base"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LabInfo.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LabInfo.test.tsx.snap
@@ -294,27 +294,27 @@ Mos Eisley, CO
                   <tbody>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Campylobacter, NAAT
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Abnormal (Abnormal)
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -325,27 +325,27 @@ Mos Eisley, CO
                     </tr>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Plesiomonas shigelloides, NAAT
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -619,27 +619,27 @@ Mos Eisley, CO
                   <tbody>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Campylobacter, NAAT
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -650,27 +650,27 @@ Mos Eisley, CO
                     </tr>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Plesiomonas shigelloides, NAAT
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Not Detected
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -1051,17 +1051,17 @@ Coruscant, MA
                   <tbody>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Organism ID
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Acinetobacter baumannii
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -1070,7 +1070,7 @@ Coruscant, MA
                         </span>
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -1079,7 +1079,7 @@ Coruscant, MA
                         </span>
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <button
                           aria-controls="hidden-comment-r:id"
@@ -1110,22 +1110,22 @@ Coruscant, MA
                     </tr>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Sodium
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         139 mmol/L
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         138 mmol/L - 145 mmol/L
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -1134,7 +1134,7 @@ Coruscant, MA
                         </span>
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         <span
                           class="no-data text-italic text-base"
@@ -1180,66 +1180,66 @@ Coruscant, MA
                   <tbody>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Acinetobacter baumannii
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Amikacin
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         MIC
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         0.25: Susceptible
                       </td>
                     </tr>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Acinetobacter baumannii
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Avycaz (Ceftazidime/Avibactam)
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         MIC
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         0.05: Intermediate
                       </td>
                     </tr>
                     <tr>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Acinetobacter baumannii
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         Levofloxacin
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         MIC
                       </td>
                       <td
-                        class="text-top"
+                        class="text-top text-pre-line"
                       >
                         0.75: Resistant
                       </td>

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
@@ -19,7 +19,7 @@ export interface ColumnInfoInput {
   value?: string;
   className?: string;
   hiddenBaseText?: string;
-  applyToValue?: (value: string) => React.ReactNode;
+  applyToValue?: (value: string) => ReactNode;
 }
 
 interface TableProps {

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
@@ -19,10 +19,7 @@ export interface ColumnInfoInput {
   value?: string;
   className?: string;
   hiddenBaseText?: string;
-  // Generics could be used here instead but we don't want to have to provide it
-  // when this property is optional. Using `any` avoids that issue.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  applyToValue?: (value: any) => any;
+  applyToValue?: (value: string) => React.ReactNode;
 }
 
 interface TableProps {
@@ -157,33 +154,11 @@ const evaluateTableRowData = (
   mappings: Mapping,
   entry: Element,
 ) => {
-  let hiddenRow: ReactNode = null;
-  const rowCellsData = columns.map((column) => {
-    let data: ReactNode;
-    let hidden = false;
-    if (column?.value) {
-      data = column.value;
-    }
-
-    if (!column?.value && column?.infoPath) {
-      data = splitStringWith(
-        evaluateValue(entry, mappings[column.infoPath]),
-        "<br/>",
-      );
-    }
-
-    if (data && column.applyToValue) {
-      data = column.applyToValue(data);
-    }
-
-    if (data && column.hiddenBaseText) {
-      hiddenRow = data;
-      hidden = true;
-      data = column.hiddenBaseText;
-    }
-
-    return { data, hidden };
-  });
+  const rowCellsData = columns.map((column) =>
+    evaluateTableRowCell(column, entry, mappings),
+  );
+  const hiddenRow = rowCellsData.find(({ hiddenRow }) => !!hiddenRow)
+    ?.hiddenRow;
 
   // This row is entirely empty, skip it
   if (rowCellsData.every(({ data }) => !data))
@@ -192,25 +167,48 @@ const evaluateTableRowData = (
   return { rowCellsData, hiddenRow };
 };
 
-const splitStringWith = (
-  input: string,
-  splitter: string,
-): (string | JSX.Element)[] | string => {
-  // Split the input string by <br/> tag
-  const parts = input.split(splitter);
-
-  // If there is no <br/> in the input string, return the string as a single element array
-  if (parts.length === 1) {
-    return input;
+/**
+ * Evaluate data for a column and entry
+ * @param column column descriptor
+ * @param entry fhir data to extract value from
+ * @param mappings mappings to use in evaluating data
+ * @returns data, hidden status, and hiddenRow
+ */
+export const evaluateTableRowCell = (
+  column: ColumnInfoInput,
+  entry: Element,
+  mappings: Mapping,
+) => {
+  let strData: string;
+  let hiddenRow: ReactNode = null;
+  let hidden = false;
+  if (column?.value) {
+    strData = column.value;
+  } else if (column?.infoPath) {
+    strData = evaluateValue(entry, mappings[column.infoPath]).replaceAll(
+      "<br/>",
+      "\n",
+    );
+  } else {
+    throw new Error(
+      `No value or infoPath provided to EvaluateTable column: ${JSON.stringify(
+        column,
+      )}`,
+    );
   }
 
-  // Create an array with strings and JSX <br /> elements
-  const result: (string | JSX.Element)[] = [];
-  parts.forEach((part, index) => {
-    result.push(<p key={`${part}-${index}`}>{part}</p>);
-  });
+  let data: ReactNode = strData;
+  if (strData && column.applyToValue) {
+    data = column.applyToValue(strData);
+  }
 
-  return result;
+  if (data && column.hiddenBaseText) {
+    hiddenRow = data;
+    hidden = true;
+    data = column.hiddenBaseText;
+  }
+
+  return { data, hidden, hiddenRow };
 };
 
 export default EvaluateTable;

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTableRow.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTableRow.tsx
@@ -38,7 +38,7 @@ export const EvaluateTableRow = ({
     <>
       <tr>
         {rowCellsData.map(({ data, hidden }, index) => (
-          <td key={`row-data-${index}`} className="text-top">
+          <td key={`row-data-${index}`} className="text-top text-pre-line">
             {data ? (
               hidden ? (
                 <Button


### PR DESCRIPTION
# PULL REQUEST

## Summary

Constrain the type of `applyToValue` to `(string) => ReactNode` instead of `(any) => any`.

This required some light refactoring to use pre-formatted lines in the table cells instead of creating paragraphs if `<br/>` existed in the raw value, and also to tighten the type used for travel history even further so it would play nice with the `HtmlTable` interface.

## Related Issue

Fixes #428

## Acceptance Criteria

- [ ] applyToValue no longer makes use of the any type
- [ ] Application functions as it did previously