### PR TITLE
fix: Make patient age field dynamic

### DIFF
--- a/containers/ecr-viewer/src/app/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/services/ecrSummaryService.tsx
@@ -339,8 +339,7 @@ export const evaluateEcrSummaryRelevantLabResults = (
  */
 const evaluateEncounterDate = (fhirBundle: Bundle) => {
   return formatStartEndDateTime(
-    evaluateOne(fhirBundle, fhirPathMappings.encounterStartDate),
-    evaluateOne(fhirBundle, fhirPathMappings.encounterEndDate),
+    evaluateOne(fhirBundle, fhirPathMappings.encounterPeriod),
   );
 };
 

--- a/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
@@ -699,7 +699,7 @@ export const createPatientAgeDataProp = (
   );
   const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
 
-  let title = "Current Age";
+  let title = "Age at Encounter";
   let toolTip;
   let value;
 
@@ -723,7 +723,6 @@ export const createPatientAgeDataProp = (
 
   // Handle encounter start date
   if (encounterPeriod?.start) {
-    title = "Age at Encounter";
     value = formatAge(calculatePatientAge(fhirBundle, encounterPeriod.start));
     return { title, toolTip, value };
   }
@@ -733,15 +732,19 @@ export const createPatientAgeDataProp = (
     const encounterEnd = DateTime.fromJSDate(new Date(encounterPeriod.end));
 
     if (encounterEnd <= DateTime.now()) {
-      title = "Age at Encounter";
       toolTip =
         "Age at end date of encounter. Start date of encounter is not available.";
       value = formatAge(calculatePatientAge(fhirBundle, encounterPeriod.end));
     } else {
-      value = formatAge(calculatePatientAge(fhirBundle));
+      value = formatAge(
+        calculatePatientAge(
+          fhirBundle,
+          evaluateOne(fhirBundle, fhirPathMappings.dateTimeEcrCreated),
+        ),
+      );
       if (value) {
         toolTip =
-          "Using the date eCR was received as a proxy for date of encounter. No encounter start date and encounter end date is in the future.";
+          "Using the date eCR was created as a proxy for date of encounter. No encounter start date and encounter end date is in the future.";
       }
     }
     return { title, toolTip, value };

--- a/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
@@ -355,7 +355,7 @@ export const evaluateDemographicsData = (fhirBundle: Bundle) => {
       value: evaluatePatientDOB(fhirBundle),
     },
     {
-      title: "Current Age",
+      title: "Age at Encounter",
       value: formatAge(calculatePatientAge(fhirBundle)),
     },
     {

--- a/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
@@ -147,51 +147,42 @@ export interface Age {
 }
 
 /**
- * Calculates the age of a patient to a given date or today, unless DOD exists.
+ * Calculates the patient's age at a specific point in time or the current date.
  * @param fhirBundle - The FHIR bundle containing patient information.
- * @param [givenDate] - Optional. The target date to calculate the age. Defaults to the current date if not provided.
- * @returns - The exact age of the patient in years/months/days, or undefined if date of birth is not available or if date of death exists.
+ * @param [givenDate] - Optional date to calculate age at, overrides encounter dates
+ * @returns The patient's age in years, or undefined if:
+ *   - Patient has a recorded death date
+ *   - Patient has no birth date
  */
 export const calculatePatientAge = (
   fhirBundle: Bundle,
   givenDate?: string,
 ): Age | undefined => {
-  const deathDate = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
+  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
 
-  // if a death date is available, don't calculate patient age
+  // If no patient DOB is available, return undefined.
+  if (!patientDOBString) {
+    return undefined;
+  }
+
+  const patientDOB = DateTime.fromJSDate(new Date(patientDOBString));
+
+  // If date is provided by caller, use that.
+  if (givenDate) {
+    return calculateYearsFrom(
+      DateTime.fromJSDate(new Date(givenDate)),
+      patientDOB,
+    );
+  }
+
+  // If a death date is available, return undefined.
+  const deathDate = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
   if (deathDate) {
     return undefined;
   }
 
-  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
-
-  // date is provided by caller, use that
-  if (patientDOBString && givenDate) {
-    return getPatientAge(
-      DateTime.fromJSDate(new Date(givenDate)),
-      DateTime.fromJSDate(new Date(patientDOBString)),
-    );
-  }
-
-  // no date provided, use encounter or today's date
-  if (patientDOBString) {
-    const encounterStartDate = evaluateOne(
-      fhirBundle,
-      fhirPathMappings.encounterStartDate,
-    );
-
-    // use the encounter start date if one is available, otherwise we'll fall back to today's date
-    const laterDate = encounterStartDate
-      ? new Date(encounterStartDate)
-      : new Date();
-
-    return getPatientAge(
-      DateTime.fromJSDate(laterDate),
-      DateTime.fromJSDate(new Date(patientDOBString)),
-    );
-  }
-
-  return undefined;
+  // Default to current date if no encounter date is available
+  return calculateYearsFrom(DateTime.now(), patientDOB);
 };
 
 /**
@@ -210,7 +201,7 @@ export const calculatePatientAgeAtDeath = (
     const laterDate = DateTime.fromJSDate(new Date(patientDODString));
     const earlierDate = DateTime.fromJSDate(new Date(patientDOBString));
 
-    return getPatientAge(laterDate, earlierDate);
+    return calculateYearsFrom(laterDate, earlierDate);
   } else {
     return undefined;
   }
@@ -222,7 +213,10 @@ export const calculatePatientAgeAtDeath = (
  * @param earlierDate DateTime earlier in time
  * @returns An `Age`
  */
-const getPatientAge = (laterDate: DateTime, earlierDate: DateTime): Age => {
+const calculateYearsFrom = (
+  laterDate: DateTime,
+  earlierDate: DateTime,
+): Age => {
   const { years, months, days } = laterDate
     .diff(earlierDate, ["years", "months", "days"])
     .toObject();
@@ -354,10 +348,7 @@ export const evaluateDemographicsData = (fhirBundle: Bundle) => {
       title: "DOB",
       value: evaluatePatientDOB(fhirBundle),
     },
-    {
-      title: "Age at Encounter",
-      value: formatAge(calculatePatientAge(fhirBundle)),
-    },
+    createPatientAgeDataProp(fhirBundle),
     {
       title: "Age at Death",
       value: formatAge(calculatePatientAgeAtDeath(fhirBundle)),
@@ -445,8 +436,7 @@ export const evaluateEncounterData = (fhirBundle: Bundle) => {
     {
       title: "Encounter Date/Time",
       value: formatStartEndDateTime(
-        evaluateOne(fhirBundle, fhirPathMappings.encounterStartDate),
-        evaluateOne(fhirBundle, fhirPathMappings.encounterEndDate),
+        evaluateOne(fhirBundle, fhirPathMappings.encounterPeriod),
       ),
     },
     {
@@ -586,7 +576,6 @@ export const evaluateEncounterCareTeamTable = (fhirBundle: Bundle) => {
 
   const tables = participants.map((participant) => {
     const role = evaluateValue(participant, "type");
-    const { start, end } = participant.period ?? {};
     const participantRef = participant.individual?.reference;
 
     const { practitioner } = evaluatePractitionerRoleReference(
@@ -602,7 +591,7 @@ export const evaluateEncounterCareTeamTable = (fhirBundle: Bundle) => {
         value: role || noData,
       },
       Dates: {
-        value: formatStartEndDate(start, end) || noData,
+        value: formatStartEndDate(participant.period) || noData,
       },
     } as HtmlTableJsonRow;
   });
@@ -734,4 +723,65 @@ export const evaluatePatientLanguage = (fhirBundle: Bundle) => {
  */
 export const censorGender = (gender: string | undefined) => {
   return gender && ["Male", "Female"].includes(gender) ? gender : "";
+};
+
+/**
+ * Creates a DisplayDataProps object for patient age data based on the following:
+ * 1) If the patient has a death date, it returns an empty object.
+ * 2) If the encounter has a start date, it calculates the age at that date.
+ * 3) If the encounter has an end date and it is in the past, it calculates the age at that end date.
+ * 4) If there are no encounter dates, it calculates the current age.
+ * @param fhirBundle - The FHIR bundle containing patient data.
+ * @returns A DisplayDataProps object with title, tooltip, and value for patient age.
+ */
+export const createPatientAgeDataProp = (
+  fhirBundle: Bundle,
+): DisplayDataProps => {
+  const encounterPeriod = evaluateOne(
+    fhirBundle,
+    fhirPathMappings.encounterPeriod,
+  );
+  const hasDeathDate = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
+  let title = "Current Age";
+  let toolTip;
+  let value;
+
+  // If patient has death date, return empty object
+  if (hasDeathDate) {
+    return { title, toolTip, value };
+  }
+
+  // Handle encounter start date
+  if (encounterPeriod?.start) {
+    title = "Age at Encounter";
+    value = formatAge(calculatePatientAge(fhirBundle, encounterPeriod.start));
+    return { title, toolTip, value };
+  }
+
+  // Handle encounter end date
+  if (encounterPeriod?.end) {
+    const encounterEnd = DateTime.fromJSDate(new Date(encounterPeriod.end));
+
+    if (encounterEnd <= DateTime.now()) {
+      title = "Age at Encounter";
+      toolTip =
+        "Age at end date of encounter. Start date of encounter is not available.";
+      value = formatAge(calculatePatientAge(fhirBundle, encounterPeriod.end));
+    } else {
+      value = formatAge(calculatePatientAge(fhirBundle));
+      if (value) {
+        toolTip =
+          "Age at current date. No encounter start date and encounter end date is in the future.";
+      }
+    }
+    return { title, toolTip, value };
+  }
+
+  // Handle no encounter dates
+  value = formatAge(calculatePatientAge(fhirBundle));
+  if (value) {
+    toolTip = "Age at current date. No encounter date available.";
+  }
+
+  return { title, toolTip, value };
 };

--- a/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
@@ -149,10 +149,8 @@ export interface Age {
 /**
  * Calculates the patient's age at a specific point in time or the current date.
  * @param fhirBundle - The FHIR bundle containing patient information.
- * @param [givenDate] - Optional date to calculate age at, overrides encounter dates
- * @returns The patient's age in years, or undefined if:
- *   - Patient has a recorded death date
- *   - Patient has no birth date
+ * @param [givenDate] - Optional date to calculate age at.
+ * @returns The patient's age in years, or undefined if patient has no birth date.
  */
 export const calculatePatientAge = (
   fhirBundle: Bundle,
@@ -169,42 +167,11 @@ export const calculatePatientAge = (
 
   // If date is provided by caller, use that.
   if (givenDate) {
-    return calculateYearsFrom(
-      DateTime.fromJSDate(new Date(givenDate)),
-      patientDOB,
-    );
-  }
-
-  // If a death date is available, return undefined.
-  const deathDate = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
-  if (deathDate) {
-    return undefined;
+    return calcuateAge(DateTime.fromJSDate(new Date(givenDate)), patientDOB);
   }
 
   // Default to current date if no encounter date is available
-  return calculateYearsFrom(DateTime.now(), patientDOB);
-};
-
-/**
- * Calculates Patient Age at Death if DOB and DOD exist, otherwise returns undefined
- * @param fhirBundle - The FHIR bundle containing patient information.
- * @returns - The age of the patient at death in years/months/days, or undefined if date of birth or date of death is not available.
- */
-export const calculatePatientAgeAtDeath = (
-  fhirBundle: Bundle,
-): Age | undefined => {
-  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
-
-  const patientDODString = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
-
-  if (patientDOBString && patientDODString) {
-    const laterDate = DateTime.fromJSDate(new Date(patientDODString));
-    const earlierDate = DateTime.fromJSDate(new Date(patientDOBString));
-
-    return calculateYearsFrom(laterDate, earlierDate);
-  } else {
-    return undefined;
-  }
+  return calcuateAge(DateTime.now(), patientDOB);
 };
 
 /**
@@ -213,10 +180,7 @@ export const calculatePatientAgeAtDeath = (
  * @param earlierDate DateTime earlier in time
  * @returns An `Age`
  */
-const calculateYearsFrom = (
-  laterDate: DateTime,
-  earlierDate: DateTime,
-): Age => {
+const calcuateAge = (laterDate: DateTime, earlierDate: DateTime): Age => {
   const { years, months, days } = laterDate
     .diff(earlierDate, ["years", "months", "days"])
     .toObject();
@@ -234,16 +198,12 @@ const calculateYearsFrom = (
  * @returns The vital status of the patient, either `Alive`, `Deceased`, or `""` (if not found)
  */
 export const evaluatePatientVitalStatus = (fhirBundle: Bundle) => {
-  const isPatientDeceased = evaluateOne(
-    fhirBundle,
-    fhirPathMappings.patientVitalStatus,
-  );
-
-  if (isPatientDeceased === undefined) {
+  const isDeceased = isPatientDeceased(fhirBundle);
+  if (isDeceased === undefined) {
     return "";
+  } else {
+    return isDeceased === true ? "Deceased" : "Alive";
   }
-
-  return isPatientDeceased ? "Deceased" : "Alive";
 };
 
 /**
@@ -349,10 +309,6 @@ export const evaluateDemographicsData = (fhirBundle: Bundle) => {
       value: evaluatePatientDOB(fhirBundle),
     },
     createPatientAgeDataProp(fhirBundle),
-    {
-      title: "Age at Death",
-      value: formatAge(calculatePatientAgeAtDeath(fhirBundle)),
-    },
     {
       title: "Vital Status",
       value: evaluatePatientVitalStatus(fhirBundle),
@@ -730,7 +686,7 @@ export const censorGender = (gender: string | undefined) => {
  * 1) If the patient has a death date, it returns an empty object.
  * 2) If the encounter has a start date, it calculates the age at that date.
  * 3) If the encounter has an end date and it is in the past, it calculates the age at that end date.
- * 4) If there are no encounter dates, it calculates the current age.
+ * 4) If there are no encounter dates, it calculates the age when eCr was created, as a proxy for encounter date.
  * @param fhirBundle - The FHIR bundle containing patient data.
  * @returns A DisplayDataProps object with title, tooltip, and value for patient age.
  */
@@ -741,14 +697,28 @@ export const createPatientAgeDataProp = (
     fhirBundle,
     fhirPathMappings.encounterPeriod,
   );
-  const hasDeathDate = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
+  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
+
   let title = "Current Age";
   let toolTip;
   let value;
 
   // If patient has death date, return empty object
-  if (hasDeathDate) {
-    return { title, toolTip, value };
+  if (isPatientDeceased(fhirBundle)) {
+    title = "Age at Death";
+    const patientDODString = evaluateOne(
+      fhirBundle,
+      fhirPathMappings.patientDOD,
+    );
+    if (patientDOBString && patientDODString) {
+      value = formatAge(calculatePatientAge(fhirBundle, patientDODString));
+    }
+
+    return {
+      title,
+      value,
+      toolTip,
+    };
   }
 
   // Handle encounter start date
@@ -771,17 +741,37 @@ export const createPatientAgeDataProp = (
       value = formatAge(calculatePatientAge(fhirBundle));
       if (value) {
         toolTip =
-          "Age at current date. No encounter start date and encounter end date is in the future.";
+          "Using the date eCR was received as a proxy for date of encounter. No encounter start date and encounter end date is in the future.";
       }
     }
     return { title, toolTip, value };
   }
 
   // Handle no encounter dates
-  value = formatAge(calculatePatientAge(fhirBundle));
+  value = formatAge(
+    calculatePatientAge(
+      fhirBundle,
+      evaluateOne(fhirBundle, fhirPathMappings.dateTimeEcrCreated),
+    ),
+  );
   if (value) {
-    toolTip = "Age at current date. No encounter date available.";
+    toolTip =
+      "Using the date eCR was created as a proxy for date of encounter. No encounter date available.";
   }
 
   return { title, toolTip, value };
+};
+
+/***
+ * A patient is deceased if `patient.deceasedBoolean` is true or if there is a date of death. If both are `undefined`
+ * return `undefined`.
+ */
+const isPatientDeceased = (fhirBundle: Bundle) => {
+  const vitalStatus = evaluateOne(
+    fhirBundle,
+    fhirPathMappings.patientVitalStatus,
+  );
+  const dod = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
+
+  return dod ? true : vitalStatus;
 };

--- a/containers/ecr-viewer/src/app/services/formatDateService.ts
+++ b/containers/ecr-viewer/src/app/services/formatDateService.ts
@@ -1,5 +1,3 @@
-import { Period } from "fhir/r4";
-
 // Determine if we can extract out the timezone part of the datetime string.
 const hasTimeZoneString = (dateTimeString: string): boolean => {
   // Z
@@ -133,38 +131,43 @@ export const formatDate = (dateString?: string): string | undefined => {
   }
 };
 
+interface Period {
+  start?: string;
+  end?: string;
+}
+
 /**
- * Formats the provided period and returns a formatted string
+ * Formats the provided start and end date-time strings and returns a formatted string
  * with both the start and end times. Each time is labeled and separated by a carriage return
  * and newline for clarity in display or further processing.
- * @param period - The period to be formatted.
+ * @param root0 - An object containing the start and end date-time strings.
+ * @param root0.start - The start date-time string to be formatted.
+ * @param root0.end - The end date-time string to be formatted.
  * @returns A string with the formatted start and end times, each on a new line.
  */
-export const formatStartEndDateTime = (period: Period | undefined) =>
-  formatStartEnd(period, formatDateTime);
+export const formatStartEndDateTime = ({ start, end }: Period = {}) =>
+  formatStartEnd({ start, end }, formatDateTime);
 
 /**
- * Formats the provided period and returns a formatted string
+ * Formats the provided start and end date strings and returns a formatted string
  * with both the start and end dates. Each date is labeled and separated by a carriage return
  * and newline for clarity in display or further processing.
- * @param period - The start date-time string to be formatted.
+ * @param root0 - An object containing the start and end date strings.
+ * @param root0.start - The start date-time string to be formatted.
+ * @param root0.end - The end date-time string to be formatted.
  * @returns A string with the formatted start and end times, each on a new line.
  */
-export const formatStartEndDate = (period: Period | undefined) =>
-  formatStartEnd(period, formatDate);
+export const formatStartEndDate = ({ start, end }: Period = {}) =>
+  formatStartEnd({ start, end }, formatDate);
 
 const formatStartEnd = (
-  period: Period | undefined,
+  { start, end }: Period = {},
   formatFn: (dt: string | undefined) => string | undefined,
 ) => {
-  if (!period) {
-    return "";
-  }
-
   const textArray: String[] = [];
 
-  const startDateObject = formatFn(period.start);
-  const endDateObject = formatFn(period.end);
+  const startDateObject = formatFn(start);
+  const endDateObject = formatFn(end);
 
   if (startDateObject) {
     textArray.push(`Start: ${startDateObject}`);

--- a/containers/ecr-viewer/src/app/services/formatDateService.ts
+++ b/containers/ecr-viewer/src/app/services/formatDateService.ts
@@ -1,3 +1,5 @@
+import { Period } from "fhir/r4";
+
 // Determine if we can extract out the timezone part of the datetime string.
 const hasTimeZoneString = (dateTimeString: string): boolean => {
   // Z
@@ -132,40 +134,37 @@ export const formatDate = (dateString?: string): string | undefined => {
 };
 
 /**
- * Formats the provided start and end date-time strings and returns a formatted string
+ * Formats the provided period and returns a formatted string
  * with both the start and end times. Each time is labeled and separated by a carriage return
  * and newline for clarity in display or further processing.
- * @param startDateTime - The start date-time string to be formatted.
- * @param endDateTime - The end date-time string to be formatted.
+ * @param period - The period to be formatted.
  * @returns A string with the formatted start and end times, each on a new line.
  */
-export const formatStartEndDateTime = (
-  startDateTime: string | undefined,
-  endDateTime: string | undefined,
-) => formatStartEnd(startDateTime, endDateTime, formatDateTime);
+export const formatStartEndDateTime = (period: Period | undefined) =>
+  formatStartEnd(period, formatDateTime);
 
 /**
- * Formats the provided start and end date strings and returns a formatted string
+ * Formats the provided period and returns a formatted string
  * with both the start and end dates. Each date is labeled and separated by a carriage return
  * and newline for clarity in display or further processing.
- * @param startDate - The start date-time string to be formatted.
- * @param endDate - The end date-time string to be formatted.
+ * @param period - The start date-time string to be formatted.
  * @returns A string with the formatted start and end times, each on a new line.
  */
-export const formatStartEndDate = (
-  startDate: string | undefined,
-  endDate: string | undefined,
-) => formatStartEnd(startDate, endDate, formatDate);
+export const formatStartEndDate = (period: Period | undefined) =>
+  formatStartEnd(period, formatDate);
 
 const formatStartEnd = (
-  start: string | undefined,
-  end: string | undefined,
+  period: Period | undefined,
   formatFn: (dt: string | undefined) => string | undefined,
 ) => {
+  if (!period) {
+    return "";
+  }
+
   const textArray: String[] = [];
 
-  const startDateObject = formatFn(start);
-  const endDateObject = formatFn(end);
+  const startDateObject = formatFn(period.start);
+  const endDateObject = formatFn(period.end);
 
   if (startDateObject) {
     textArray.push(`Start: ${startDateObject}`);

--- a/containers/ecr-viewer/src/app/tests/components/Demographics.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/Demographics.test.tsx
@@ -12,7 +12,7 @@ describe("Demographics", () => {
         value: "Test patient",
       },
       { title: "DOB", value: "06/01/1996" },
-      { title: "Current Age", value: "27" },
+      { title: "Age at Encounter", value: "27" },
       { title: "Vital Status", value: "Alive" },
       { title: "Sex", value: "female" },
       { title: "Race", value: "Asian/Pacific Islander" },

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
             data-testid="button"
             type="button"
           >
-            Expand all 
+            Expand all
             sections
           </button>
           <span
@@ -43,7 +43,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
             data-testid="button"
             type="button"
           >
-            Collapse all 
+            Collapse all
             sections
           </button>
         </div>
@@ -269,7 +269,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                         <div
                           class="data-title padding-right-1"
                         >
-                          Current Age
+                          Age at Encounter
                         </div>
                         <div
                           class="grid-col maxw7 text-pre-line p-list text-italic text-base"

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                         <div
                           class="data-title padding-right-1"
                         >
-                          Current Age
+                          Age at Encounter
                         </div>
                         <div
                           class="grid-col maxw7 text-pre-line p-list text-italic text-base"

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -288,25 +288,6 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                         <div
                           class="data-title padding-right-1"
                         >
-                          Age at Death
-                        </div>
-                        <div
-                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
-                        >
-                          No data
-                        </div>
-                      </div>
-                      <div
-                        class="section__line_gray"
-                      />
-                    </div>
-                    <div>
-                      <div
-                        class="grid-row"
-                      >
-                        <div
-                          class="data-title padding-right-1"
-                        >
                           Vital Status
                         </div>
                         <div

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
             data-testid="button"
             type="button"
           >
-            Expand all
+            Expand all 
             sections
           </button>
           <span
@@ -43,7 +43,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
             data-testid="button"
             type="button"
           >
-            Collapse all
+            Collapse all 
             sections
           </button>
         </div>

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                         <div
                           class="data-title padding-right-1"
                         >
-                          Age at Encounter
+                          Current Age
                         </div>
                         <div
                           class="grid-col maxw7 text-pre-line p-list text-italic text-base"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Demographics.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Demographics.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Demographics should match snapshot 1`] = `
                 <div
                   class="data-title padding-right-1"
                 >
-                  Current Age
+                  Age at Encounter
                 </div>
                 <div
                   class="grid-col maxw7 text-pre-line p-list"

--- a/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
+++ b/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
@@ -2,6 +2,8 @@ import { Bundle } from "fhir/r4";
 
 import BundleEcrMetadata from "../../../../../../test-data/fhir/BundleEcrMetadata.json";
 import BundlePatient from "../../../../../../test-data/fhir/BundlePatient.json";
+import * as _BundleWithPatient from "../../../../../../test-data/fhir/BundlePatient.json";
+import BundleWithDeceasedPatient from "../../../../../../test-data/fhir/BundlePatientDeceased.json";
 import BundlePatientMultiple from "../../../../../../test-data/fhir/BundlePatientMultiple.json";
 import BundlePractitionerRole from "../../../../../../test-data/fhir/BundlePractitionerRole.json";
 import {
@@ -18,9 +20,15 @@ import {
   evaluatePatientLanguage,
   evaluatePatientVitalStatus,
   censorGender,
+  calculatePatientAge,
+  calculatePatientAgeAtDeath,
+  createPatientAgeDataProp,
 } from "@/app/services/evaluateFhirDataService";
+import { formatAge } from "@/app/services/formatService";
 import { evaluateValue } from "@/app/utils/evaluate";
 import mappings from "@/app/utils/evaluate/fhir-paths";
+
+const BundleWithPatient = _BundleWithPatient as Bundle;
 
 describe("evaluateFhirDataServices tests", () => {
   describe("Evaluate Identifier", () => {
@@ -377,5 +385,198 @@ Home: 123-456-6909`,
       const actual = censorGender(expected);
       expect(actual).toEqual("");
     });
+  });
+
+  describe("Calculate Patient Age", () => {
+    it("when no date is given, should return patient age when DOB is available", () => {
+      // Fixed "today" for testing purposes
+      jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
+
+      const patientAge = calculatePatientAge(
+        BundleWithPatient as unknown as Bundle,
+      );
+
+      expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
+
+      // Return to real time
+      jest.useRealTimers();
+    });
+
+    it("should return nothing when DOB is unavailable", () => {
+      const patientAge = calculatePatientAge(undefined as any);
+
+      expect(patientAge).toEqual(undefined);
+    });
+
+    it("when date is given, should return age at given date", () => {
+      const givenDate = "2020-01-01";
+
+      const patientAge = calculatePatientAge(
+        BundleWithPatient as unknown as Bundle,
+        givenDate,
+      );
+
+      expect(patientAge).toEqual({ years: 142, months: 7, days: 7 });
+    });
+
+    it("should return a value that can display only in days", () => {
+      const patientAge = calculatePatientAge(
+        BundleWithPatient as unknown as Bundle,
+        "1877-05-30",
+      );
+
+      const formattedPatientAge = formatAge(patientAge);
+
+      expect(formattedPatientAge).toEqual("5 days");
+    });
+  });
+
+  describe("Calculate Age at Death", () => {
+    it("should return age at death when DOD is given", () => {
+      const patientAgeAtDeath = calculatePatientAgeAtDeath(
+        BundleWithDeceasedPatient as unknown as Bundle,
+      );
+
+      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
+    });
+
+    it("should have a defined Age at Death, and not have a defined Age at Encounter when Date of Death is given", () => {
+      jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
+      const expectedAge = undefined;
+
+      const patientAge = calculatePatientAge(
+        BundleWithDeceasedPatient as unknown as Bundle,
+      );
+
+      const patientAgeAtDeath = calculatePatientAgeAtDeath(
+        BundleWithDeceasedPatient as unknown as Bundle,
+      );
+
+      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
+      expect(patientAge).toEqual(expectedAge);
+
+      // Return to real time
+      jest.useRealTimers();
+    });
+
+    it("should return age at death in months/days when age is under 2 years", () => {
+      const patientWithDeathDate = {
+        ...BundleWithDeceasedPatient,
+        entry: [
+          {
+            ...BundleWithDeceasedPatient.entry[0],
+            resource: {
+              ...BundleWithDeceasedPatient.entry[0].resource,
+              birthDate: "1818-01-27",
+              deceasedDate: "1819-02-01",
+            },
+          },
+        ],
+      } as unknown as Bundle;
+
+      const patientAgeAtDeath =
+        calculatePatientAgeAtDeath(patientWithDeathDate);
+
+      const formattedPatientAgeAtDeath = formatAge(patientAgeAtDeath);
+
+      const expectedAgeAtDeath = "12 months, 5 days";
+
+      expect(formattedPatientAgeAtDeath).toEqual(expectedAgeAtDeath);
+    });
+  });
+
+  describe("Create Patient Age Data Prop", () => {
+    it("should return an undefined age if there is a death date", () => {
+      const patientAgeProp = createPatientAgeDataProp(
+        BundleWithDeceasedPatient as unknown as Bundle,
+      );
+      expect(patientAgeProp.value).toEqual(undefined);
+    });
+
+    it("should return the patient age at the encounter start date", () => {
+      const patientBundleWithEncounter: Bundle = {
+        resourceType: "Bundle",
+        type: "batch",
+        entry: [
+          ...BundleWithPatient.entry!,
+          {
+            resource: {
+              class: {
+                code: "testValue",
+              },
+              status: "unknown",
+              resourceType: "Encounter",
+              id: "123456789",
+              period: {
+                start: "1924-03-01",
+                end: "1924-03-12",
+              },
+            },
+          },
+        ],
+      };
+
+      const patientAgeProp = createPatientAgeDataProp(
+        patientBundleWithEncounter,
+      );
+
+      expect(patientAgeProp.value).toEqual("46 years");
+    });
+
+    it("should use the encounter end date if the start date does not exist and the end date is in the past.", () => {
+      const patientBundleWithEncounter: Bundle = {
+        resourceType: "Bundle",
+        type: "batch",
+        entry: [
+          ...BundleWithPatient.entry!,
+          {
+            resource: {
+              class: {
+                code: "testValue",
+              },
+              status: "unknown",
+              resourceType: "Encounter",
+              id: "123456789",
+              period: {
+                end: "1920-03-12",
+              },
+            },
+          },
+        ],
+      };
+
+      const patientAgeProp = createPatientAgeDataProp(
+        patientBundleWithEncounter,
+      );
+
+      expect(patientAgeProp.value).toEqual("42 years");
+    });
+
+    it("should use the current date if there is no encounter date.", () => {
+      jest.useFakeTimers().setSystemTime(new Date("1924-03-12"));
+      const patientAgeProp = createPatientAgeDataProp(BundleWithPatient);
+
+      expect(patientAgeProp.value).toEqual("46 years");
+    });
+  });
+
+  it("should have a defined Age at Encounter, and not have a defined Age at Death when Date of Death is not given", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
+
+    const expectedAgeAtDeath = undefined;
+
+    const patientAge = calculatePatientAge(
+      BundleWithPatient as unknown as Bundle,
+    );
+
+    const patientAgeAtDeath = calculatePatientAgeAtDeath(
+      BundleWithPatient as unknown as Bundle,
+    );
+
+    expect(patientAgeAtDeath).toEqual(expectedAgeAtDeath);
+    expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
+
+    // Return to real time
+    jest.useRealTimers();
   });
 });

--- a/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
+++ b/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
@@ -3,7 +3,7 @@ import { Bundle } from "fhir/r4";
 import BundleEcrMetadata from "../../../../../../test-data/fhir/BundleEcrMetadata.json";
 import * as _BundleWithPatient from "../../../../../../test-data/fhir/BundlePatient.json";
 import * as _BundleWithDeceasedPatient from "../../../../../../test-data/fhir/BundlePatientDeceased.json";
-import BundleWithPatientMultiple from "../../../../../../test-data/fhir/BundlePatientMultiple.json";
+import BundlePatientMultiple from "../../../../../../test-data/fhir/BundlePatientMultiple.json";
 import BundlePractitionerRole from "../../../../../../test-data/fhir/BundlePractitionerRole.json";
 import {
   evaluateEncounterId,
@@ -155,7 +155,7 @@ Home: 123-456-6909`,
     });
     it("should return all 3 of the addresses", () => {
       const actual = evaluatePatientAddress(
-        BundleWithPatientMultiple as unknown as Bundle,
+        BundlePatientMultiple as unknown as Bundle,
       );
       expect(actual).toEqual(
         "Home:\n" +
@@ -183,7 +183,7 @@ Home: 123-456-6909`,
     });
     it("should return all 2 of the names", () => {
       const actual = evaluatePatientName(
-        BundleWithPatientMultiple as unknown as Bundle,
+        BundlePatientMultiple as unknown as Bundle,
         false,
       );
       expect(actual).toEqual(
@@ -192,7 +192,7 @@ Home: 123-456-6909`,
     });
     it("should only return the official name for the banner", () => {
       const actual = evaluatePatientName(
-        BundleWithPatientMultiple as unknown as Bundle,
+        BundlePatientMultiple as unknown as Bundle,
         true,
       );
       expect(actual).toEqual("Anakin Skywalker");
@@ -214,7 +214,7 @@ Home: 123-456-6909`,
     });
     it("should empty string because there is no use, intake, or comment", () => {
       const actual = evaluateAlcoholUse(
-        BundleWithPatientMultiple as unknown as Bundle,
+        BundlePatientMultiple as unknown as Bundle,
       );
       expect(actual).toEqual("");
     });

--- a/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
+++ b/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
@@ -447,7 +447,10 @@ Home: 123-456-6909`,
         patientBundleWithEncounter,
       );
 
-      expect(patientAgeProp.value).toEqual("46 years");
+      expect(patientAgeProp).toEqual({
+        title: "Age at Encounter",
+        value: "46 years",
+      });
     });
 
     it("should use the encounter end date if the start date does not exist and the end date is in the past.", () => {
@@ -476,14 +479,86 @@ Home: 123-456-6909`,
         patientBundleWithEncounter,
       );
 
-      expect(patientAgeProp.value).toEqual("42 years");
+      expect(patientAgeProp).toEqual({
+        title: "Age at Encounter",
+        value: "42 years",
+        toolTip:
+          "Age at end date of encounter. Start date of encounter is not available.",
+      });
     });
 
-    it("should use the current date if there is no encounter date.", () => {
-      jest.useFakeTimers().setSystemTime(new Date("1924-03-12"));
-      const patientAgeProp = createPatientAgeDataProp(BundleWithPatient);
+    it("should use the eCR created date if the start date does not exist and the end date is in the future.", () => {
+      const patientBundleWithEncounter: Bundle = {
+        resourceType: "Bundle",
+        type: "batch",
+        entry: [
+          ...BundleWithPatient.entry!,
+          {
+            resource: {
+              resourceType: "Composition",
+              author: [{}],
+              date: "1924-03-12",
+              status: "final",
+              title: "test",
+              type: {},
+            },
+          },
+          {
+            resource: {
+              class: {
+                code: "testValue",
+              },
+              status: "unknown",
+              resourceType: "Encounter",
+              id: "123456789",
+              period: {
+                end: "2999-03-12",
+              },
+            },
+          },
+        ],
+      };
 
-      expect(patientAgeProp.value).toEqual("46 years");
+      const patientAgeProp = createPatientAgeDataProp(
+        patientBundleWithEncounter,
+      );
+
+      expect(patientAgeProp).toEqual({
+        title: "Age at Encounter",
+        value: "46 years",
+        toolTip:
+          "Using the date eCR was created as a proxy for date of encounter. No encounter start date and encounter end date is in the future.",
+      });
+    });
+
+    it("should use the eCR created date if there is no encounter date.", () => {
+      const patientBundleWithCreatedDate: Bundle = {
+        resourceType: "Bundle",
+        type: "batch",
+        entry: [
+          ...BundleWithPatient.entry!,
+          {
+            resource: {
+              resourceType: "Composition",
+              author: [{}],
+              date: "1924-03-12",
+              status: "final",
+              title: "test",
+              type: {},
+            },
+          },
+        ],
+      };
+      const patientAgeProp = createPatientAgeDataProp(
+        patientBundleWithCreatedDate,
+      );
+
+      expect(patientAgeProp).toEqual({
+        title: "Age at Encounter",
+        value: "46 years",
+        toolTip:
+          "Using the date eCR was created as a proxy for date of encounter. No encounter date available.",
+      });
     });
   });
 });

--- a/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
+++ b/containers/ecr-viewer/src/app/tests/services/evaluateFhirDataServices.test.ts
@@ -1,10 +1,9 @@
 import { Bundle } from "fhir/r4";
 
 import BundleEcrMetadata from "../../../../../../test-data/fhir/BundleEcrMetadata.json";
-import BundlePatient from "../../../../../../test-data/fhir/BundlePatient.json";
 import * as _BundleWithPatient from "../../../../../../test-data/fhir/BundlePatient.json";
-import BundleWithDeceasedPatient from "../../../../../../test-data/fhir/BundlePatientDeceased.json";
-import BundlePatientMultiple from "../../../../../../test-data/fhir/BundlePatientMultiple.json";
+import * as _BundleWithDeceasedPatient from "../../../../../../test-data/fhir/BundlePatientDeceased.json";
+import BundleWithPatientMultiple from "../../../../../../test-data/fhir/BundlePatientMultiple.json";
 import BundlePractitionerRole from "../../../../../../test-data/fhir/BundlePractitionerRole.json";
 import {
   evaluateEncounterId,
@@ -21,7 +20,6 @@ import {
   evaluatePatientVitalStatus,
   censorGender,
   calculatePatientAge,
-  calculatePatientAgeAtDeath,
   createPatientAgeDataProp,
 } from "@/app/services/evaluateFhirDataService";
 import { formatAge } from "@/app/services/formatService";
@@ -29,14 +27,12 @@ import { evaluateValue } from "@/app/utils/evaluate";
 import mappings from "@/app/utils/evaluate/fhir-paths";
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
+const BundleWithDeceasedPatient = _BundleWithDeceasedPatient as Bundle;
 
 describe("evaluateFhirDataServices tests", () => {
   describe("Evaluate Identifier", () => {
     it("should return the Identifier value", () => {
-      const actual = evaluateValue(
-        BundlePatient as unknown as Bundle,
-        mappings.patientIds,
-      );
+      const actual = evaluateValue(BundleWithPatient, mappings.patientIds);
 
       expect(actual).toEqual("1234567890");
     });
@@ -44,22 +40,20 @@ describe("evaluateFhirDataServices tests", () => {
 
   describe("Evaluate Patient Race", () => {
     it("should return race category and extension if available", () => {
-      const actual = evaluatePatientRace(BundlePatient as unknown as Bundle);
+      const actual = evaluatePatientRace(BundleWithPatient);
       expect(actual).toEqual("Black or African American\nAfrican");
     });
   });
 
   describe("Evaluate Patient Ethnicity", () => {
     it("should return ethnicity category and extension if available", () => {
-      const actual = evaluatePatientEthnicity(
-        BundlePatient as unknown as Bundle,
-      );
+      const actual = evaluatePatientEthnicity(BundleWithPatient);
       expect(actual).toEqual("Hispanic or Latino\nWhite");
     });
   });
 
   it("should return tribal affiliation if available", () => {
-    const actual = evaluateDemographicsData(BundlePatient as unknown as Bundle);
+    const actual = evaluateDemographicsData(BundleWithPatient);
     const ext = actual.availableData.filter(
       (d) => d.title === "Tribal Affiliation",
     );
@@ -70,7 +64,7 @@ describe("evaluateFhirDataServices tests", () => {
   });
 
   it("should return parent/guardian if available", () => {
-    const actual = evaluateDemographicsData(BundlePatient as unknown as Bundle);
+    const actual = evaluateDemographicsData(BundleWithPatient);
     const ext = actual.availableData.filter(
       (d) => d.title === "Parent/Guardian",
     );
@@ -156,12 +150,12 @@ Home: 123-456-6909`,
 
   describe("Evaluate Patient Address", () => {
     it("should return the 1 address", () => {
-      const actual = evaluatePatientAddress(BundlePatient as unknown as Bundle);
+      const actual = evaluatePatientAddress(BundleWithPatient);
       expect(actual).toEqual("1 Main St\nCloud City, CA\n00000, US");
     });
     it("should return all 3 of the addresses", () => {
       const actual = evaluatePatientAddress(
-        BundlePatientMultiple as unknown as Bundle,
+        BundleWithPatientMultiple as unknown as Bundle,
       );
       expect(actual).toEqual(
         "Home:\n" +
@@ -184,15 +178,12 @@ Home: 123-456-6909`,
 
   describe("Evaluate Patient Name", () => {
     it("should return the 1 name", () => {
-      const actual = evaluatePatientName(
-        BundlePatient as unknown as Bundle,
-        false,
-      );
+      const actual = evaluatePatientName(BundleWithPatient, false);
       expect(actual).toEqual("Han Solo");
     });
     it("should return all 2 of the names", () => {
       const actual = evaluatePatientName(
-        BundlePatientMultiple as unknown as Bundle,
+        BundleWithPatientMultiple as unknown as Bundle,
         false,
       );
       expect(actual).toEqual(
@@ -201,23 +192,20 @@ Home: 123-456-6909`,
     });
     it("should only return the official name for the banner", () => {
       const actual = evaluatePatientName(
-        BundlePatientMultiple as unknown as Bundle,
+        BundleWithPatientMultiple as unknown as Bundle,
         true,
       );
       expect(actual).toEqual("Anakin Skywalker");
     });
     it("should only return the official name for the banner", () => {
-      const actual = evaluatePatientName(
-        BundlePatient as unknown as Bundle,
-        true,
-      );
+      const actual = evaluatePatientName(BundleWithPatient, true);
       expect(actual).toEqual("Han Solo");
     });
   });
 
   describe("Evaluate Alcohol Use", () => {
     it("should return the use, intake comment", () => {
-      const actual = evaluateAlcoholUse(BundlePatient as unknown as Bundle);
+      const actual = evaluateAlcoholUse(BundleWithPatient);
       expect(actual).toEqual(
         "Use: Current drinker of alcohol (finding)\n" +
           "Intake (standard drinks/week): .29/d\n" +
@@ -226,7 +214,7 @@ Home: 123-456-6909`,
     });
     it("should empty string because there is no use, intake, or comment", () => {
       const actual = evaluateAlcoholUse(
-        BundlePatientMultiple as unknown as Bundle,
+        BundleWithPatientMultiple as unknown as Bundle,
       );
       expect(actual).toEqual("");
     });
@@ -248,9 +236,7 @@ Home: 123-456-6909`,
     }
 
     it("should return an empty string when no `deceasedBoolean` value is present", () => {
-      const actual = evaluatePatientVitalStatus(
-        BundlePatient as unknown as Bundle,
-      );
+      const actual = evaluatePatientVitalStatus(BundleWithPatient);
       expect(actual).toEqual("");
     });
 
@@ -271,9 +257,7 @@ Home: 123-456-6909`,
 
   describe("Evaluate Patient language", () => {
     it("Should display language, proficiency, and mode", () => {
-      const actual = evaluatePatientLanguage(
-        BundlePatient as unknown as Bundle,
-      );
+      const actual = evaluatePatientLanguage(BundleWithPatient);
 
       expect(actual).toEqual("English\nGood\nExpressed spoken");
     });
@@ -392,9 +376,7 @@ Home: 123-456-6909`,
       // Fixed "today" for testing purposes
       jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
 
-      const patientAge = calculatePatientAge(
-        BundleWithPatient as unknown as Bundle,
-      );
+      const patientAge = calculatePatientAge(BundleWithPatient);
 
       expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
 
@@ -411,19 +393,13 @@ Home: 123-456-6909`,
     it("when date is given, should return age at given date", () => {
       const givenDate = "2020-01-01";
 
-      const patientAge = calculatePatientAge(
-        BundleWithPatient as unknown as Bundle,
-        givenDate,
-      );
+      const patientAge = calculatePatientAge(BundleWithPatient, givenDate);
 
       expect(patientAge).toEqual({ years: 142, months: 7, days: 7 });
     });
 
     it("should return a value that can display only in days", () => {
-      const patientAge = calculatePatientAge(
-        BundleWithPatient as unknown as Bundle,
-        "1877-05-30",
-      );
+      const patientAge = calculatePatientAge(BundleWithPatient, "1877-05-30");
 
       const formattedPatientAge = formatAge(patientAge);
 
@@ -431,66 +407,17 @@ Home: 123-456-6909`,
     });
   });
 
-  describe("Calculate Age at Death", () => {
-    it("should return age at death when DOD is given", () => {
-      const patientAgeAtDeath = calculatePatientAgeAtDeath(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
-    });
-
-    it("should have a defined Age at Death, and not have a defined Age at Encounter when Date of Death is given", () => {
-      jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
-      const expectedAge = undefined;
-
-      const patientAge = calculatePatientAge(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      const patientAgeAtDeath = calculatePatientAgeAtDeath(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
-      expect(patientAge).toEqual(expectedAge);
-
-      // Return to real time
-      jest.useRealTimers();
-    });
-
-    it("should return age at death in months/days when age is under 2 years", () => {
-      const patientWithDeathDate = {
-        ...BundleWithDeceasedPatient,
-        entry: [
-          {
-            ...BundleWithDeceasedPatient.entry[0],
-            resource: {
-              ...BundleWithDeceasedPatient.entry[0].resource,
-              birthDate: "1818-01-27",
-              deceasedDate: "1819-02-01",
-            },
-          },
-        ],
-      } as unknown as Bundle;
-
-      const patientAgeAtDeath =
-        calculatePatientAgeAtDeath(patientWithDeathDate);
-
-      const formattedPatientAgeAtDeath = formatAge(patientAgeAtDeath);
-
-      const expectedAgeAtDeath = "12 months, 5 days";
-
-      expect(formattedPatientAgeAtDeath).toEqual(expectedAgeAtDeath);
-    });
-  });
-
   describe("Create Patient Age Data Prop", () => {
-    it("should return an undefined age if there is a death date", () => {
+    it("should return Age at Death if there is a date of death", () => {
       const patientAgeProp = createPatientAgeDataProp(
-        BundleWithDeceasedPatient as unknown as Bundle,
+        BundleWithDeceasedPatient,
       );
-      expect(patientAgeProp.value).toEqual(undefined);
+      expect(patientAgeProp).toEqual({
+        title: "Age at Death",
+        value: "4 years",
+        toolTip: undefined,
+      });
+      expect;
     });
 
     it("should return the patient age at the encounter start date", () => {
@@ -558,25 +485,5 @@ Home: 123-456-6909`,
 
       expect(patientAgeProp.value).toEqual("46 years");
     });
-  });
-
-  it("should have a defined Age at Encounter, and not have a defined Age at Death when Date of Death is not given", () => {
-    jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
-
-    const expectedAgeAtDeath = undefined;
-
-    const patientAge = calculatePatientAge(
-      BundleWithPatient as unknown as Bundle,
-    );
-
-    const patientAgeAtDeath = calculatePatientAgeAtDeath(
-      BundleWithPatient as unknown as Bundle,
-    );
-
-    expect(patientAgeAtDeath).toEqual(expectedAgeAtDeath);
-    expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
-
-    // Return to real time
-    jest.useRealTimers();
   });
 });

--- a/containers/ecr-viewer/src/app/tests/utils.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/utils.test.tsx
@@ -223,7 +223,7 @@ describe("Utils", () => {
     });
   });
 
-  it("should have a defined Current Age, and not have a defined Age at Death when Date of Death is not given", () => {
+  it("should have a defined Age at Encounter, and not have a defined Age at Death when Date of Death is not given", () => {
     jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
 
     const expectedAgeAtDeath = undefined;
@@ -263,7 +263,7 @@ describe("Utils", () => {
       expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
     });
 
-    it("should have a defined Age at Death, and not have a defined Current Age when Date of Death is given", () => {
+    it("should have a defined Age at Death, and not have a defined Age at Encounter when Date of Death is given", () => {
       jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
       const expectedAge = undefined;
 

--- a/containers/ecr-viewer/src/app/tests/utils.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/utils.test.tsx
@@ -10,7 +10,6 @@ import BundleCareTeam from "../../../../../test-data/fhir/BundleCareTeam.json";
 import BundleWithMiscNotes from "../../../../../test-data/fhir/BundleMiscNotes.json";
 import BundleNoActiveProblems from "../../../../../test-data/fhir/BundleNoActiveProblems.json";
 import BundleWithPatient from "../../../../../test-data/fhir/BundlePatient.json";
-import BundleWithDeceasedPatient from "../../../../../test-data/fhir/BundlePatientDeceased.json";
 import BundleWithPendingResultsOnly from "../../../../../test-data/fhir/BundlePendingResultsOnly.json";
 import BundleWithScheduledOrdersOnly from "../../../../../test-data/fhir/BundleScheduledOrdersOnly.json";
 import BundleWithSexualOrientation from "../../../../../test-data/fhir/BundleSexualOrientation.json";
@@ -19,11 +18,8 @@ import BundleWithTravelHistoryEmpty from "../../../../../test-data/fhir/BundleTr
 import {
   evaluateSocialData,
   evaluatePatientName,
-  calculatePatientAge,
   evaluatePatientAddress,
-  calculatePatientAgeAtDeath,
 } from "@/app/services/evaluateFhirDataService";
-import { formatAge } from "@/app/services/formatService";
 import { evaluateAll } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { DataDisplay } from "@/app/view-data/components/DataDisplay";
@@ -166,145 +162,6 @@ describe("Utils", () => {
       );
 
       expect(actual).toEqual("1 Main St\nCloud City, CA\n00000, US");
-    });
-  });
-
-  describe("Calculate Patient Age", () => {
-    it("should calculate a patient's age using the encounter date when one is available", () => {
-      const patientWithEncounterStartDate = {
-        ...BundleWithPatient,
-        entry: [
-          ...BundleWithPatient.entry,
-          {
-            resource: {
-              resourceType: "Encounter",
-              period: { start: "1900-05-28" },
-            },
-          },
-        ],
-      } as unknown as Bundle;
-
-      const patientAge = calculatePatientAge(
-        patientWithEncounterStartDate as unknown as Bundle,
-      );
-
-      expect(patientAge).toEqual({ years: 23, months: 0, days: 3 });
-    });
-
-    it("when no date is given, should return patient age when DOB is available", () => {
-      // Fixed "today" for testing purposes
-      jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
-
-      const patientAge = calculatePatientAge(
-        BundleWithPatient as unknown as Bundle,
-      );
-
-      expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
-
-      // Return to real time
-      jest.useRealTimers();
-    });
-
-    it("should return nothing when DOB is unavailable", () => {
-      const patientAge = calculatePatientAge(undefined as any);
-
-      expect(patientAge).toEqual(undefined);
-    });
-
-    it("when date is given, should return age at given date", () => {
-      const givenDate = "2020-01-01";
-
-      const patientAge = calculatePatientAge(
-        BundleWithPatient as unknown as Bundle,
-        givenDate,
-      );
-
-      expect(patientAge).toEqual({ years: 142, months: 7, days: 7 });
-    });
-  });
-
-  it("should have a defined Age at Encounter, and not have a defined Age at Death when Date of Death is not given", () => {
-    jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
-
-    const expectedAgeAtDeath = undefined;
-
-    const patientAge = calculatePatientAge(
-      BundleWithPatient as unknown as Bundle,
-    );
-
-    const patientAgeAtDeath = calculatePatientAgeAtDeath(
-      BundleWithPatient as unknown as Bundle,
-    );
-
-    expect(patientAgeAtDeath).toEqual(expectedAgeAtDeath);
-    expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
-
-    // Return to real time
-    jest.useRealTimers();
-  });
-
-  it("should return a value that can display only in days", () => {
-    const patientAge = calculatePatientAge(
-      BundleWithPatient as unknown as Bundle,
-      "1877-05-30",
-    );
-
-    const formattedPatientAge = formatAge(patientAge);
-
-    expect(formattedPatientAge).toEqual("5 days");
-  });
-
-  describe("Calculate Age at Death", () => {
-    it("should return age at death when DOD is given", () => {
-      const patientAgeAtDeath = calculatePatientAgeAtDeath(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
-    });
-
-    it("should have a defined Age at Death, and not have a defined Age at Encounter when Date of Death is given", () => {
-      jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
-      const expectedAge = undefined;
-
-      const patientAge = calculatePatientAge(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      const patientAgeAtDeath = calculatePatientAgeAtDeath(
-        BundleWithDeceasedPatient as unknown as Bundle,
-      );
-
-      expect(patientAgeAtDeath).toEqual({ years: 4, months: 9, days: 26 });
-      expect(patientAge).toEqual(expectedAge);
-
-      // Return to real time
-      jest.useRealTimers();
-    });
-
-    it("should return age at death in months/days when age is under 2 years", () => {
-      const patientWithDeathDate = {
-        ...BundleWithDeceasedPatient,
-        entry: [
-          {
-            ...BundleWithDeceasedPatient.entry[0],
-            resource: {
-              ...BundleWithDeceasedPatient.entry[0].resource,
-              birthDate: "1818-01-27",
-              deceasedDate: "1819-02-01",
-            },
-          },
-        ],
-      } as unknown as Bundle;
-
-      const patientAgeAtDeath =
-        calculatePatientAgeAtDeath(patientWithDeathDate);
-
-      const formattedPatientAgeAtDeath = formatAge(patientAgeAtDeath);
-
-      const expectedAgeAtDeath = "12 months, 5 days";
-
-      expect(formattedPatientAgeAtDeath).toEqual(expectedAgeAtDeath);
     });
   });
 

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -17,6 +17,7 @@ import {
   Organization,
   PatientCommunication,
   PatientContact,
+  Period,
   Procedure,
   Quantity,
   Reference,
@@ -73,8 +74,7 @@ export type PathTypes = {
   ehrManufacturerModel: string;
   eRSDwarnings: Coding;
   compositionAuthorRefs: Reference;
-  encounterEndDate: string;
-  encounterStartDate: string;
+  encounterPeriod: Period;
   encounterDiagnosis: EncounterDiagnosis;
   encounterType: string;
   encounterID: Identifier;
@@ -316,13 +316,9 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
 
   // Encounter Info
-  encounterEndDate: {
-    type: "string",
-    path: "Bundle.entry.resource.where(resourceType = 'Encounter').period.end",
-  },
-  encounterStartDate: {
-    type: "string",
-    path: "Bundle.entry.resource.where(resourceType = 'Encounter').period.start",
+  encounterPeriod: {
+    type: "Period",
+    path: "Bundle.entry.resource.where(resourceType = 'Encounter').period",
   },
   encounterDiagnosis: {
     type: "EncounterDiagnosis",

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -211,10 +211,9 @@ export const returnCareTeamTable = (
       };
 
       if (initialParticipant.period) {
-        const { start, end } = initialParticipant.period;
         mctp.period = {
           ...initialParticipant.period,
-          text: formatStartEndDate(start, end),
+          text: formatStartEndDate(initialParticipant.period),
         };
       }
 

--- a/test-data/fhir/BundlePatientDeceased.json
+++ b/test-data/fhir/BundlePatientDeceased.json
@@ -11,7 +11,7 @@
           "profile": [
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
           ],
-          "source": ["ecr"]
+          "source": "ecr"
         },
         "name": [
           {


### PR DESCRIPTION
# PULL REQUEST

## Summary

Makes the patient age field dynamic:
- if there is an date of death:
  - name: Age at Death
  - value: age at death
  - tooltip: none
- If there is an Encounter start date
  - name: Age at Encounter
  - value: age at start of encounter
  - tooltip: none
![image](https://github.com/user-attachments/assets/4dcdf2d0-4749-4c08-8e61-b52a2b6568e7)
- If there is not an encounter start date and encounter end date in the past
  - name: Age at Encounter
  - value: age at the end of the encounter
  - tooltip: "Age at end date of encounter. Start date of encounter is not available."
![image](https://github.com/user-attachments/assets/a29b4fea-9778-427a-89dd-f5a8d0d86823)
- If there is not an encounter start date, and the encounter end date is in the future
  - name: Age at Encounter
  - value: age at the eCR created date.
  - tooltip: "Using the date eCR was created as a proxy for date of encounter. No encounter start date and encounter end date is in the future."
![image](https://github.com/user-attachments/assets/a3c2cf13-63af-4c02-aac4-1aaca5984987)
- If there is not an encounter period
  - name: Age at Encounter
  - value: age at the eCR created date.
  - tooltip: "Using the date eCR was created as a proxy for date of encounter. No encounter date available."
![image](https://github.com/user-attachments/assets/f497bf54-2b97-4198-bcfa-0ba256bf360b)
- If there is no date of birth
  - Do not show the patient's age.

In addition to the above, always show the onset age, even if there is a death date.

## Related Issue

Fixes #508 

