### PR TITLE
fix: handle rollbacks on partially failed save

### DIFF
--- a/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
@@ -395,23 +395,54 @@ describe("save metadata", () => {
       expect(rolledback).toBeFalse();
       expect(res).toHaveLength(0);
     });
-  });
 
-  it("should 400 with unknown schema", async () => {
-    let rolledback = false;
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "unknown" as "core", // appease typescript
-      baseCoreMetadata,
-      makePromiseResolveWithStatus(200),
-      () => {
-        rolledback = true;
-        return makePromiseResolveWithStatus(200);
-      },
-    );
+    it("should 409 if same eCR inserted twice", async () => {
+      let rolledback = false;
+      const resp1 = await saveFhirMetadata(
+        "1-2-3-4",
+        "core",
+        baseCoreMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
 
-    expect(resp.message).toEqual("Unknown metadataType: unknown");
-    expect(resp.status).toEqual(400);
-    expect(rolledback).toBeFalse();
+      expect(resp1.status).toEqual(200);
+      expect(rolledback).toBeFalse();
+
+      const resp2 = await saveFhirMetadata(
+        "1-2-3-4",
+        "core",
+        baseCoreMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
+
+      expect(resp2.status).toEqual(409);
+      expect(rolledback).toBeFalse();
+    });
+
+    it("should 400 with unknown schema", async () => {
+      let rolledback = false;
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "unknown" as "core", // appease typescript
+        baseCoreMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
+
+      expect(resp.message).toEqual("Unknown metadataType: unknown");
+      expect(resp.status).toEqual(400);
+      expect(rolledback).toBeFalse();
+    });
   });
 });

--- a/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/app/api/save-fhir-data/types";
 import { getDb } from "@/app/api/services/database";
 import { Core } from "@/app/api/services/types/core";
+import { Extended } from "@/app/api/services/types/extended";
 import { BlobResponse } from "@/app/data/blobStorage/utils";
 
 import {
@@ -176,7 +177,8 @@ describe("save extended metadata", () => {
     expect(resp.status).toEqual(200);
   });
 
-  it("should return an error when db save fails", async () => {
+  it("should return an error and roll back fhir data when db save fails", async () => {
+    let rolledback = false;
     const badMetadata = {
       last_name: null,
       first_name: null,
@@ -193,11 +195,48 @@ describe("save extended metadata", () => {
       "extended",
       badMetadata,
       makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
+      () => {
+        rolledback = true;
+        return makePromiseResolveWithStatus(200);
+      },
     );
+
+    const res = await getDb<Extended>()
+      .selectFrom("ecr_data")
+      .selectAll()
+      .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
+      .execute();
 
     expect(resp.message).toEqual("Failed to insert metadata to database.");
     expect(resp.status).toEqual(500);
+    expect(rolledback).toBeTrue();
+    expect(res).toHaveLength(0);
+  });
+
+  it("should return an error and roll back db when fhir bundle save fails", async () => {
+    let rolledback = false;
+    jest.spyOn(console, "error").mockImplementation();
+    const resp = await saveFhirMetadata(
+      "1-2-3-4-5-6",
+      "extended",
+      baseExtendedMetadata,
+      makePromiseResolveWithStatus(500),
+      () => {
+        rolledback = true;
+        return makePromiseResolveWithStatus(200);
+      },
+    );
+
+    const res = await getDb<Extended>()
+      .selectFrom("ecr_data")
+      .selectAll()
+      .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
+      .execute();
+
+    expect(resp.message).toEqual("Failed to insert metadata to database.");
+    expect(resp.status).toEqual(500);
+    expect(rolledback).toBeFalse();
+    expect(res).toHaveLength(0);
   });
 });
 
@@ -306,7 +345,7 @@ describe("save core metadata", () => {
       report_date: new Date("a"),
     } as unknown as BundleMetadata;
     const resp = await saveFhirMetadata(
-      "1-2-3-4",
+      "1-2-3-4-3-2",
       "core",
       badMetadata,
       makePromiseResolveWithStatus(200),
@@ -316,9 +355,16 @@ describe("save core metadata", () => {
       },
     );
 
+    const res = await getDb<Core>()
+      .selectFrom("ecr_data")
+      .selectAll()
+      .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
+      .execute();
+
     expect(resp.message).toEqual("Failed to insert metadata to database.");
     expect(resp.status).toEqual(500);
     expect(rolledback).toBeTrue();
+    expect(res).toHaveLength(0);
   });
 
   it("should return an error and roll back db when fhir bundle save fails", async () => {

--- a/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
@@ -2,14 +2,12 @@
  * @jest-environment node
  */
 
-import {
-  saveCoreMetadata,
-  saveExtendedMetadata,
-} from "@/app/api/save-fhir-data/save-fhir-data-service";
+import { saveFhirMetadata } from "@/app/api/save-fhir-data/save-fhir-data-service";
 import {
   BundleMetadata,
   BundleExtendedMetadata,
 } from "@/app/api/save-fhir-data/types";
+import { BlobResponse } from "@/app/data/blobStorage/utils";
 
 import {
   buildCore,
@@ -105,7 +103,7 @@ const baseExtendedMetadata: BundleExtendedMetadata = {
   report_date: "2024-12-20",
 };
 
-describe("saveExtendedMetadata", () => {
+describe("save extended metadata", () => {
   beforeAll(async () => {
     await buildExtended();
   });
@@ -119,7 +117,13 @@ describe("saveExtendedMetadata", () => {
   });
 
   it("should save without any rr", async () => {
-    const resp = await saveExtendedMetadata(baseExtendedMetadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "extended",
+      baseExtendedMetadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
   });
@@ -135,7 +139,13 @@ describe("saveExtendedMetadata", () => {
       ],
     };
 
-    const resp = await saveExtendedMetadata(metadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "extended",
+      metadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
@@ -152,7 +162,13 @@ describe("saveExtendedMetadata", () => {
       ],
     };
 
-    const resp = await saveExtendedMetadata(metadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "extended",
+      metadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
@@ -170,7 +186,13 @@ describe("saveExtendedMetadata", () => {
       report_date: new Date("12/20/2024"),
     } as unknown as BundleExtendedMetadata;
     jest.spyOn(console, "error").mockImplementation();
-    const resp = await saveExtendedMetadata(badMetadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "extended",
+      badMetadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Failed to insert metadata to database.");
     expect(resp.status).toEqual(500);
@@ -188,7 +210,10 @@ const baseCoreMetadata: BundleMetadata = {
   report_date: "12/20/2024",
 };
 
-describe("saveCoreMetadata", () => {
+const makePromiseResolveWithStatus = (status: number): Promise<BlobResponse> =>
+  new Promise((resolve) => resolve({ message: "hi there", status }));
+
+describe("save core metadata", () => {
   beforeAll(async () => {
     await buildCore();
   });
@@ -202,7 +227,13 @@ describe("saveCoreMetadata", () => {
   });
 
   it("should save without any rr", async () => {
-    const resp = await saveCoreMetadata(baseCoreMetadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "core",
+      baseCoreMetadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
@@ -219,7 +250,13 @@ describe("saveCoreMetadata", () => {
       ],
     };
 
-    const resp = await saveCoreMetadata(metadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "core",
+      metadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
@@ -236,7 +273,13 @@ describe("saveCoreMetadata", () => {
       ],
     };
 
-    const resp = await saveCoreMetadata(metadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "core",
+      metadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
@@ -254,7 +297,13 @@ describe("saveCoreMetadata", () => {
       rr: [],
       report_date: new Date("a"),
     } as unknown as BundleMetadata;
-    const resp = await saveCoreMetadata(badMetadata, "1-2-3-4");
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "core",
+      badMetadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
 
     expect(resp.message).toEqual("Failed to insert metadata to database.");
     expect(resp.status).toEqual(500);

--- a/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
@@ -7,6 +7,8 @@ import {
   BundleMetadata,
   BundleExtendedMetadata,
 } from "@/app/api/save-fhir-data/types";
+import { getDb } from "@/app/api/services/database";
+import { Core } from "@/app/api/services/types/core";
 import { BlobResponse } from "@/app/data/blobStorage/utils";
 
 import {
@@ -227,16 +229,21 @@ describe("save core metadata", () => {
   });
 
   it("should save without any rr", async () => {
+    let rolledback = false;
     const resp = await saveFhirMetadata(
       "1-2-3-4",
       "core",
       baseCoreMetadata,
       makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
+      () => {
+        rolledback = true;
+        return makePromiseResolveWithStatus(200);
+      },
     );
 
     expect(resp.message).toEqual("Success. Saved metadata to database.");
     expect(resp.status).toEqual(200);
+    expect(rolledback).toBeFalse();
   });
 
   it("should save with rr without rule summaries", async () => {
@@ -285,7 +292,8 @@ describe("save core metadata", () => {
     expect(resp.status).toEqual(200);
   });
 
-  it("should return an error when db save fails", async () => {
+  it("should return an error and roll back fhir bundle when db save fails", async () => {
+    let rolledback = false;
     jest.spyOn(console, "error").mockImplementation();
     const badMetadata = {
       last_name: null,
@@ -302,10 +310,40 @@ describe("save core metadata", () => {
       "core",
       badMetadata,
       makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
+      () => {
+        rolledback = true;
+        return makePromiseResolveWithStatus(200);
+      },
     );
 
     expect(resp.message).toEqual("Failed to insert metadata to database.");
     expect(resp.status).toEqual(500);
+    expect(rolledback).toBeTrue();
+  });
+
+  it("should return an error and roll back db when fhir bundle save fails", async () => {
+    let rolledback = false;
+    jest.spyOn(console, "error").mockImplementation();
+    const resp = await saveFhirMetadata(
+      "1-2-3-4-5-6",
+      "core",
+      baseCoreMetadata,
+      makePromiseResolveWithStatus(500),
+      () => {
+        rolledback = true;
+        return makePromiseResolveWithStatus(200);
+      },
+    );
+
+    const res = await getDb<Core>()
+      .selectFrom("ecr_data")
+      .selectAll()
+      .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
+      .execute();
+
+    expect(resp.message).toEqual("Failed to insert metadata to database.");
+    expect(resp.status).toEqual(500);
+    expect(rolledback).toBeFalse();
+    expect(res).toHaveLength(0);
   });
 });

--- a/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/integration/save-fhir-data-service.test.ts
@@ -106,172 +106,302 @@ const baseExtendedMetadata: BundleExtendedMetadata = {
   report_date: "2024-12-20",
 };
 
-describe("save extended metadata", () => {
-  beforeAll(async () => {
-    await buildExtended();
-  });
+describe("save metadata", () => {
+  describe("extended", () => {
+    beforeAll(async () => {
+      await buildExtended();
+    });
 
-  afterAll(async () => {
-    await dropExtended();
-  });
+    afterAll(async () => {
+      await dropExtended();
+    });
 
-  afterEach(async () => {
-    await clearExtended();
-  });
+    afterEach(async () => {
+      await clearExtended();
+    });
 
-  it("should save without any rr", async () => {
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "extended",
-      baseExtendedMetadata,
-      makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
-    );
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
-  });
+    it("should save without any rr", async () => {
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "extended",
+        baseExtendedMetadata,
+        makePromiseResolveWithStatus(200),
+        () => makePromiseResolveWithStatus(200),
+      );
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+    });
 
-  it("should save with rr without rule summaries", async () => {
-    const metadata: BundleExtendedMetadata = {
-      ...baseExtendedMetadata,
-      rr: [
-        {
-          condition: "flu",
-          rule_summaries: [],
+    it("should save with rr without rule summaries", async () => {
+      const metadata: BundleExtendedMetadata = {
+        ...baseExtendedMetadata,
+        rr: [
+          {
+            condition: "flu",
+            rule_summaries: [],
+          },
+        ],
+      };
+
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "extended",
+        metadata,
+        makePromiseResolveWithStatus(200),
+        () => makePromiseResolveWithStatus(200),
+      );
+
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+    });
+
+    it("should save with rr with rule summaries", async () => {
+      const metadata: BundleExtendedMetadata = {
+        ...baseExtendedMetadata,
+        rr: [
+          {
+            condition: "flu",
+            rule_summaries: [{ summary: "fever" }, { summary: "influenza" }],
+          },
+        ],
+      };
+
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "extended",
+        metadata,
+        makePromiseResolveWithStatus(200),
+        () => makePromiseResolveWithStatus(200),
+      );
+
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+    });
+
+    it("should return an error and roll back fhir data when db save fails", async () => {
+      let rolledback = false;
+      const badMetadata = {
+        last_name: null,
+        first_name: null,
+        birth_date: "01/01/2000",
+        data_source: "s3",
+        eicr_set_id: "1234",
+        eicr_version_number: "1",
+        rr: [],
+        report_date: new Date("12/20/2024"),
+      } as unknown as BundleExtendedMetadata;
+      jest.spyOn(console, "error").mockImplementation();
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "extended",
+        badMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
         },
-      ],
-    };
+      );
 
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "extended",
-      metadata,
-      makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
-    );
+      const res = await getDb<Extended>()
+        .selectFrom("ecr_data")
+        .selectAll()
+        .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
+        .execute();
 
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
-  });
+      expect(resp.message).toEqual("Failed to insert metadata to database.");
+      expect(resp.status).toEqual(500);
+      expect(rolledback).toBeTrue();
+      expect(res).toHaveLength(0);
+    });
 
-  it("should save with rr with rule summaries", async () => {
-    const metadata: BundleExtendedMetadata = {
-      ...baseExtendedMetadata,
-      rr: [
-        {
-          condition: "flu",
-          rule_summaries: [{ summary: "fever" }, { summary: "influenza" }],
+    it("should return an error and roll back db when fhir bundle save fails", async () => {
+      let rolledback = false;
+      jest.spyOn(console, "error").mockImplementation();
+      const resp = await saveFhirMetadata(
+        "1-2-3-4-5-6",
+        "extended",
+        baseExtendedMetadata,
+        makePromiseResolveWithStatus(500),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
         },
-      ],
-    };
+      );
 
+      const res = await getDb<Extended>()
+        .selectFrom("ecr_data")
+        .selectAll()
+        .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
+        .execute();
+
+      expect(resp.message).toEqual("Failed to insert metadata to database.");
+      expect(resp.status).toEqual(500);
+      expect(rolledback).toBeFalse();
+      expect(res).toHaveLength(0);
+    });
+  });
+
+  const baseCoreMetadata: BundleMetadata = {
+    last_name: "lname",
+    first_name: "fname",
+    birth_date: "2000-01-01",
+    data_source: "s3",
+    eicr_set_id: "1234",
+    eicr_version_number: "1",
+    rr: [],
+    report_date: "12/20/2024",
+  };
+
+  const makePromiseResolveWithStatus = (
+    status: number,
+  ): Promise<BlobResponse> =>
+    new Promise((resolve) => resolve({ message: "hi there", status }));
+
+  describe("core", () => {
+    beforeAll(async () => {
+      await buildCore();
+    });
+
+    afterAll(async () => {
+      await dropCore();
+    });
+
+    afterEach(async () => {
+      await clearCore();
+    });
+
+    it("should save without any rr", async () => {
+      let rolledback = false;
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "core",
+        baseCoreMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
+
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+      expect(rolledback).toBeFalse();
+    });
+
+    it("should save with rr without rule summaries", async () => {
+      const metadata: BundleMetadata = {
+        ...baseCoreMetadata,
+        rr: [
+          {
+            condition: "flu",
+            rule_summaries: [],
+          },
+        ],
+      };
+
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "core",
+        metadata,
+        makePromiseResolveWithStatus(200),
+        () => makePromiseResolveWithStatus(200),
+      );
+
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+    });
+
+    it("should save with rr with rule summaries", async () => {
+      const metadata: BundleMetadata = {
+        ...baseCoreMetadata,
+        rr: [
+          {
+            condition: "flu",
+            rule_summaries: [{ summary: "fever" }, { summary: "influenza" }],
+          },
+        ],
+      };
+
+      const resp = await saveFhirMetadata(
+        "1-2-3-4",
+        "core",
+        metadata,
+        makePromiseResolveWithStatus(200),
+        () => makePromiseResolveWithStatus(200),
+      );
+
+      expect(resp.message).toEqual("Success. Saved metadata to database.");
+      expect(resp.status).toEqual(200);
+    });
+
+    it("should return an error and roll back fhir bundle when db save fails", async () => {
+      let rolledback = false;
+      jest.spyOn(console, "error").mockImplementation();
+      const badMetadata = {
+        last_name: null,
+        first_name: null,
+        birth_date: "01/01/2000",
+        data_source: "s3",
+        eicr_set_id: "1234",
+        eicr_version_number: "1",
+        rr: [],
+        report_date: new Date("a"),
+      } as unknown as BundleMetadata;
+      const resp = await saveFhirMetadata(
+        "1-2-3-4-3-2",
+        "core",
+        badMetadata,
+        makePromiseResolveWithStatus(200),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
+
+      const res = await getDb<Core>()
+        .selectFrom("ecr_data")
+        .selectAll()
+        .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
+        .execute();
+
+      expect(resp.message).toEqual("Failed to insert metadata to database.");
+      expect(resp.status).toEqual(500);
+      expect(rolledback).toBeTrue();
+      expect(res).toHaveLength(0);
+    });
+
+    it("should return an error and roll back db when fhir bundle save fails", async () => {
+      let rolledback = false;
+      jest.spyOn(console, "error").mockImplementation();
+      const resp = await saveFhirMetadata(
+        "1-2-3-4-5-6",
+        "core",
+        baseCoreMetadata,
+        makePromiseResolveWithStatus(500),
+        () => {
+          rolledback = true;
+          return makePromiseResolveWithStatus(200);
+        },
+      );
+
+      const res = await getDb<Core>()
+        .selectFrom("ecr_data")
+        .selectAll()
+        .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
+        .execute();
+
+      expect(resp.message).toEqual("Failed to insert metadata to database.");
+      expect(resp.status).toEqual(500);
+      expect(rolledback).toBeFalse();
+      expect(res).toHaveLength(0);
+    });
+  });
+
+  it("should 400 with unknown schema", async () => {
+    let rolledback = false;
     const resp = await saveFhirMetadata(
       "1-2-3-4",
-      "extended",
-      metadata,
-      makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
-    );
-
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
-  });
-
-  it("should return an error and roll back fhir data when db save fails", async () => {
-    let rolledback = false;
-    const badMetadata = {
-      last_name: null,
-      first_name: null,
-      birth_date: "01/01/2000",
-      data_source: "s3",
-      eicr_set_id: "1234",
-      eicr_version_number: "1",
-      rr: [],
-      report_date: new Date("12/20/2024"),
-    } as unknown as BundleExtendedMetadata;
-    jest.spyOn(console, "error").mockImplementation();
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "extended",
-      badMetadata,
-      makePromiseResolveWithStatus(200),
-      () => {
-        rolledback = true;
-        return makePromiseResolveWithStatus(200);
-      },
-    );
-
-    const res = await getDb<Extended>()
-      .selectFrom("ecr_data")
-      .selectAll()
-      .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
-      .execute();
-
-    expect(resp.message).toEqual("Failed to insert metadata to database.");
-    expect(resp.status).toEqual(500);
-    expect(rolledback).toBeTrue();
-    expect(res).toHaveLength(0);
-  });
-
-  it("should return an error and roll back db when fhir bundle save fails", async () => {
-    let rolledback = false;
-    jest.spyOn(console, "error").mockImplementation();
-    const resp = await saveFhirMetadata(
-      "1-2-3-4-5-6",
-      "extended",
-      baseExtendedMetadata,
-      makePromiseResolveWithStatus(500),
-      () => {
-        rolledback = true;
-        return makePromiseResolveWithStatus(200);
-      },
-    );
-
-    const res = await getDb<Extended>()
-      .selectFrom("ecr_data")
-      .selectAll()
-      .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
-      .execute();
-
-    expect(resp.message).toEqual("Failed to insert metadata to database.");
-    expect(resp.status).toEqual(500);
-    expect(rolledback).toBeFalse();
-    expect(res).toHaveLength(0);
-  });
-});
-
-const baseCoreMetadata: BundleMetadata = {
-  last_name: "lname",
-  first_name: "fname",
-  birth_date: "2000-01-01",
-  data_source: "s3",
-  eicr_set_id: "1234",
-  eicr_version_number: "1",
-  rr: [],
-  report_date: "12/20/2024",
-};
-
-const makePromiseResolveWithStatus = (status: number): Promise<BlobResponse> =>
-  new Promise((resolve) => resolve({ message: "hi there", status }));
-
-describe("save core metadata", () => {
-  beforeAll(async () => {
-    await buildCore();
-  });
-
-  afterAll(async () => {
-    await dropCore();
-  });
-
-  afterEach(async () => {
-    await clearCore();
-  });
-
-  it("should save without any rr", async () => {
-    let rolledback = false;
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "core",
+      "unknown" as "core", // appease typescript
       baseCoreMetadata,
       makePromiseResolveWithStatus(200),
       () => {
@@ -280,116 +410,8 @@ describe("save core metadata", () => {
       },
     );
 
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
+    expect(resp.message).toEqual("Unknown metadataType: unknown");
+    expect(resp.status).toEqual(400);
     expect(rolledback).toBeFalse();
-  });
-
-  it("should save with rr without rule summaries", async () => {
-    const metadata: BundleMetadata = {
-      ...baseCoreMetadata,
-      rr: [
-        {
-          condition: "flu",
-          rule_summaries: [],
-        },
-      ],
-    };
-
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "core",
-      metadata,
-      makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
-    );
-
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
-  });
-
-  it("should save with rr with rule summaries", async () => {
-    const metadata: BundleMetadata = {
-      ...baseCoreMetadata,
-      rr: [
-        {
-          condition: "flu",
-          rule_summaries: [{ summary: "fever" }, { summary: "influenza" }],
-        },
-      ],
-    };
-
-    const resp = await saveFhirMetadata(
-      "1-2-3-4",
-      "core",
-      metadata,
-      makePromiseResolveWithStatus(200),
-      () => makePromiseResolveWithStatus(200),
-    );
-
-    expect(resp.message).toEqual("Success. Saved metadata to database.");
-    expect(resp.status).toEqual(200);
-  });
-
-  it("should return an error and roll back fhir bundle when db save fails", async () => {
-    let rolledback = false;
-    jest.spyOn(console, "error").mockImplementation();
-    const badMetadata = {
-      last_name: null,
-      first_name: null,
-      birth_date: "01/01/2000",
-      data_source: "s3",
-      eicr_set_id: "1234",
-      eicr_version_number: "1",
-      rr: [],
-      report_date: new Date("a"),
-    } as unknown as BundleMetadata;
-    const resp = await saveFhirMetadata(
-      "1-2-3-4-3-2",
-      "core",
-      badMetadata,
-      makePromiseResolveWithStatus(200),
-      () => {
-        rolledback = true;
-        return makePromiseResolveWithStatus(200);
-      },
-    );
-
-    const res = await getDb<Core>()
-      .selectFrom("ecr_data")
-      .selectAll()
-      .where("ecr_data.eicr_id", "=", "1-2-3-4-3-2")
-      .execute();
-
-    expect(resp.message).toEqual("Failed to insert metadata to database.");
-    expect(resp.status).toEqual(500);
-    expect(rolledback).toBeTrue();
-    expect(res).toHaveLength(0);
-  });
-
-  it("should return an error and roll back db when fhir bundle save fails", async () => {
-    let rolledback = false;
-    jest.spyOn(console, "error").mockImplementation();
-    const resp = await saveFhirMetadata(
-      "1-2-3-4-5-6",
-      "core",
-      baseCoreMetadata,
-      makePromiseResolveWithStatus(500),
-      () => {
-        rolledback = true;
-        return makePromiseResolveWithStatus(200);
-      },
-    );
-
-    const res = await getDb<Core>()
-      .selectFrom("ecr_data")
-      .selectAll()
-      .where("ecr_data.eicr_id", "=", "1-2-3-4-5-6")
-      .execute();
-
-    expect(resp.message).toEqual("Failed to insert metadata to database.");
-    expect(resp.status).toEqual(500);
-    expect(rolledback).toBeFalse();
-    expect(res).toHaveLength(0);
   });
 });

--- a/containers/ecr-viewer/jest.config.js
+++ b/containers/ecr-viewer/jest.config.js
@@ -20,6 +20,7 @@ const customJestConfig = {
     process.env.TEST_TYPE === "integration"
       ? ["<rootDir>/integration/setup.ts"]
       : [],
+  // transformIgnorePatterns: ["/node_modules/(?!(@azure)/)", "\\.pnp\\.[^\\\/]+$"]
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/containers/ecr-viewer/jest.config.js
+++ b/containers/ecr-viewer/jest.config.js
@@ -20,7 +20,6 @@ const customJestConfig = {
     process.env.TEST_TYPE === "integration"
       ? ["<rootDir>/integration/setup.ts"]
       : [],
-  // transformIgnorePatterns: ["/node_modules/(?!(@azure)/)", "\\.pnp\\.[^\\\/]+$"]
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
@@ -50,7 +50,7 @@ export const get_s3 = async (
   ecr_id: string | null,
 ): Promise<FhirDataResponse> => {
   const bucketName = process.env.ECR_BUCKET_NAME;
-  const objectKey = `${ecr_id}.json`; // This could also come from the request, e.g., req.query.key
+  const objectKey = `${ecr_id}.json`;
 
   try {
     const command = new GetObjectCommand({

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -109,6 +109,19 @@ export const saveFhirMetadata = async (
     return await getDb<Core>()
       .transaction()
       .execute(async (trx) => {
+        // check ecr doesn't already exist
+        const res = await trx
+          .selectFrom("ecr_data")
+          .select((eb) => eb.fn.countAll().as("num_ecr"))
+          .where("ecr_data.eicr_id", "=", ecrId)
+          .executeTakeFirst();
+        if (res && Number(res.num_ecr) > 0) {
+          return {
+            message: `eCR already loaded: ${ecrId}`,
+            status: 409,
+          };
+        }
+
         // Insert main ECR metadata
         if (metadataType === "core") {
           await saveCoreMetadata(trx, metadata as BundleMetadata, ecrId);

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 
 import { Bundle } from "fhir/r4";
-import { Kysely } from "kysely";
+import { Kysely, Transaction } from "kysely";
 
 import { dbSchema, getDb } from "@/app/api/services/database";
 import { Common } from "@/app/api/services/types/common";
@@ -80,13 +80,11 @@ export const deleteFhirData = async (
 };
 
 /**
- * @async
- * @function saveFhirMetadata
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
- * @param fhirDataPromise
- * @param rollbackFhirDataFn
  * @param metadataType - Whether metadata is persisted using the "core" or "extended" schema
  * @param metadata - The metadata to be saved.
+ * @param fhirDataPromise - promise that resolves to whether the fhir bundle saved
+ * @param rollbackFhirDataFn - thunk to roll back the saving of the fhir bundle
  * @returns An object containing the status and message.
  */
 const saveFhirMetadata = async (
@@ -94,32 +92,65 @@ const saveFhirMetadata = async (
   metadataType: "core" | "extended" | undefined,
   metadata: BundleMetadata | BundleExtendedMetadata,
   fhirDataPromise: Promise<SaveResponse>,
-  rollbackFhirDataFn: () => Promise<void>,
+  rollbackFhirDataFn: () => Promise<SaveResponse>,
 ): Promise<SaveResponse> => {
+  let rollBackFhirData = true;
+
   try {
-    if (metadataType === "core") {
-      return await saveCoreMetadata(
-        metadata as BundleMetadata,
-        ecrId,
-        fhirDataPromise,
-        rollbackFhirDataFn,
-      );
-    } else if (metadataType === "extended") {
-      return await saveExtendedMetadata(
-        metadata as BundleExtendedMetadata,
-        ecrId,
-        fhirDataPromise,
-        rollbackFhirDataFn,
-      );
-    } else {
+    if (!metadata) {
+      console.error("eICR Data is required.");
       return {
-        message: "Unknown metadataType: " + metadataType,
+        message: "Failed: eICR Data is required.",
         status: 400,
       };
     }
+
+    // Start transaction
+    await getDb<Core>()
+      .transaction()
+      .execute(async (trx) => {
+        // Insert main ECR metadata
+        if (metadataType === "core") {
+          await saveCoreMetadata(trx, metadata as BundleMetadata, ecrId);
+        } else if (metadataType === "extended") {
+          await saveExtendedMetadata(
+            trx as unknown as Transaction<Extended>,
+            metadata as BundleExtendedMetadata,
+            ecrId,
+          );
+        } else {
+          return {
+            message: "Unknown metadataType: " + metadataType,
+            status: 400,
+          };
+        }
+
+        // The actual type here is a beast, but we know that this mapping is functionally sound
+        await saveRR(trx as unknown as Kysely<Common>, metadata, ecrId);
+
+        // Make sure the fhir data also saves
+        const fhirDataResponse = await fhirDataPromise;
+        if (fhirDataResponse.status !== 200) {
+          rollBackFhirData = false;
+          throw new Error(
+            `Failed to save fhir data - rolling back metadata: ${JSON.stringify(
+              fhirDataResponse,
+            )}`,
+          );
+        }
+      });
+    return {
+      message: "Success. Saved metadata to database.",
+      status: 200,
+    };
   } catch (error: unknown) {
-    const message = "Failed to save FHIR metadata.";
+    const message = "Failed to insert metadata to database.";
     console.error({ message, error, ecrId });
+
+    if (rollBackFhirData) {
+      await rollbackFhirDataFn();
+    }
+
     return {
       message,
       status: 500,
@@ -130,128 +161,123 @@ const saveFhirMetadata = async (
 /**
  * @async
  * @function saveExtendedMetaData
- * @param fhirDataPromise
- * @param rollbackFhirDataFn
+ * @param trx kyseley transaction
  * @param metadata - The FHIR bundle metadata to be saved.
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
  * @returns An object containing the status and message.
  */
 export const saveExtendedMetadata = async (
+  trx: Transaction<Extended>,
   metadata: BundleExtendedMetadata,
   ecrId: string,
-  fhirDataPromise: Promise<SaveResponse>,
-  rollbackFhirDataFn: () => Promise<void>,
-): Promise<SaveResponse> => {
-  try {
-    await getDb<Extended>()
-      .transaction()
-      .execute(async (trx) => {
-        await trx
-          .insertInto("ecr_data")
-          .values({
-            eicr_id: ecrId,
-            set_id: metadata.eicr_set_id,
-            last_name: metadata.last_name,
-            first_name: metadata.first_name,
-            birth_date: metadata.birth_date,
-            gender: metadata.gender,
-            birth_sex: metadata.birth_sex,
-            gender_identity: metadata.gender_identity,
-            race: metadata.race,
-            ethnicity: metadata.ethnicity,
-            latitude: metadata.latitude,
-            longitude: metadata.longitude,
-            homelessness_status: metadata.homelessness_status,
-            disabilities: metadata.disabilities,
-            tribal_affiliation: metadata.tribal_affiliation,
-            tribal_enrollment_status: metadata.tribal_enrollment_status,
-            current_job_title: metadata.current_job_title,
-            current_job_industry: metadata.current_job_industry,
-            usual_occupation: metadata.usual_occupation,
-            usual_industry: metadata.usual_industry,
-            preferred_language: metadata.preferred_language,
-            pregnancy_status: metadata.pregnancy_status,
-            rr_id: metadata.rr_id,
-            processing_status: metadata.processing_status,
-            eicr_version_number: metadata.eicr_version_number,
-            authoring_date: asDate(metadata.authoring_datetime),
-            authoring_provider: metadata.provider_id,
-            provider_id: metadata.provider_id,
-            facility_id: metadata.facility_id_number,
-            facility_name: metadata.facility_name,
-            encounter_type: metadata.encounter_type,
-            encounter_start_date: asDate(metadata.encounter_start_date),
-            encounter_end_date: asDate(metadata.encounter_end_date),
-            reason_for_visit: metadata.reason_for_visit,
-            active_problems: metadata.active_problems,
-          })
-          .execute();
-        if (metadata.patient_addresses) {
-          for (const address of metadata.patient_addresses) {
-            const patient_address_uuid = randomUUID();
-            await trx
-              .insertInto("patient_address")
-              .values({
-                uuid: patient_address_uuid,
-                ...address,
-                period_start: asDate(address.period_start),
-                period_end: asDate(address.period_end),
-                eicr_id: ecrId,
-              })
-              .execute();
-          }
-        }
-        if (metadata.labs) {
-          for (const lab of metadata.labs) {
-            // some fields need renaming
-            const {
-              test_result_ref_range_low: test_result_reference_range_low_value,
-              test_result_ref_range_high:
-                test_result_reference_range_high_value,
-              test_result_ref_range_low_units:
-                test_result_reference_range_low_units,
-              test_result_ref_range_high_units:
-                test_result_reference_range_high_units,
-              ...labValues
-            } = lab;
-            await trx
-              .insertInto("ecr_labs")
-              .values({
-                ...labValues,
-                test_result_reference_range_low_value,
-                test_result_reference_range_high_value,
-                test_result_reference_range_low_units,
-                test_result_reference_range_high_units,
-                eicr_id: ecrId,
-                specimen_collection_date: asDate(lab.specimen_collection_date),
-              })
-              .execute();
-          }
-        }
-
-        // The actual type here is a beast, but we know that this mapping is functionally sound
-        await saveRR(trx as unknown as Kysely<Common>, metadata, ecrId);
-
-        // Make sure the fhir data also saves
-        const fhirDataResponse = await fhirDataPromise;
-        if (fhirDataResponse.status !== 200) {
-          throw new Error(
-            `Failed to save fhir data: ${JSON.stringify(fhirDataResponse)}`,
-          );
-        }
-      });
-    return {
-      message: "Success. Saved metadata to database.",
-      status: 200,
-    };
-  } catch (error: unknown) {
-    const message = "Failed to insert metadata to database.";
-    console.error({ message, error });
-    return {
-      message,
-      status: 500,
-    };
+): Promise<void> => {
+  await trx
+    .insertInto("ecr_data")
+    .values({
+      eicr_id: ecrId,
+      set_id: metadata.eicr_set_id,
+      last_name: metadata.last_name,
+      first_name: metadata.first_name,
+      birth_date: metadata.birth_date,
+      gender: metadata.gender,
+      birth_sex: metadata.birth_sex,
+      gender_identity: metadata.gender_identity,
+      race: metadata.race,
+      ethnicity: metadata.ethnicity,
+      latitude: metadata.latitude,
+      longitude: metadata.longitude,
+      homelessness_status: metadata.homelessness_status,
+      disabilities: metadata.disabilities,
+      tribal_affiliation: metadata.tribal_affiliation,
+      tribal_enrollment_status: metadata.tribal_enrollment_status,
+      current_job_title: metadata.current_job_title,
+      current_job_industry: metadata.current_job_industry,
+      usual_occupation: metadata.usual_occupation,
+      usual_industry: metadata.usual_industry,
+      preferred_language: metadata.preferred_language,
+      pregnancy_status: metadata.pregnancy_status,
+      rr_id: metadata.rr_id,
+      processing_status: metadata.processing_status,
+      eicr_version_number: metadata.eicr_version_number,
+      authoring_date: asDate(metadata.authoring_datetime),
+      authoring_provider: metadata.provider_id,
+      provider_id: metadata.provider_id,
+      facility_id: metadata.facility_id_number,
+      facility_name: metadata.facility_name,
+      encounter_type: metadata.encounter_type,
+      encounter_start_date: asDate(metadata.encounter_start_date),
+      encounter_end_date: asDate(metadata.encounter_end_date),
+      reason_for_visit: metadata.reason_for_visit,
+      active_problems: metadata.active_problems,
+    })
+    .execute();
+  if (metadata.patient_addresses) {
+    for (const address of metadata.patient_addresses) {
+      const patient_address_uuid = randomUUID();
+      await trx
+        .insertInto("patient_address")
+        .values({
+          uuid: patient_address_uuid,
+          ...address,
+          period_start: asDate(address.period_start),
+          period_end: asDate(address.period_end),
+          eicr_id: ecrId,
+        })
+        .execute();
+    }
   }
+  if (metadata.labs) {
+    for (const lab of metadata.labs) {
+      // some fields need renaming
+      const {
+        test_result_ref_range_low: test_result_reference_range_low_value,
+        test_result_ref_range_high: test_result_reference_range_high_value,
+        test_result_ref_range_low_units: test_result_reference_range_low_units,
+        test_result_ref_range_high_units:
+          test_result_reference_range_high_units,
+        ...labValues
+      } = lab;
+      await trx
+        .insertInto("ecr_labs")
+        .values({
+          ...labValues,
+          test_result_reference_range_low_value,
+          test_result_reference_range_high_value,
+          test_result_reference_range_low_units,
+          test_result_reference_range_high_units,
+          eicr_id: ecrId,
+          specimen_collection_date: asDate(lab.specimen_collection_date),
+        })
+        .execute();
+    }
+  }
+};
+
+/**
+ * Saves a FHIR bundle metadata to a postgres database.
+ * @param trx kyseley transaction
+ * @param metadata - The FHIR bundle metadata to be saved.
+ * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
+ * @returns An object containing the status and message.
+ */
+export const saveCoreMetadata = async (
+  trx: Transaction<Core>,
+  metadata: BundleMetadata,
+  ecrId: string,
+): Promise<void> => {
+  await trx
+    .insertInto("ecr_data")
+    .values({
+      eicr_id: ecrId,
+      set_id: metadata.eicr_set_id,
+      patient_name_last: metadata.last_name,
+      patient_name_first: metadata.first_name,
+      patient_birth_date: metadata.birth_date,
+      data_source: "DB",
+      report_date: new Date(metadata.report_date),
+      eicr_version_number: metadata.eicr_version_number,
+    })
+    .execute();
 };
 
 // Helper to save RR to the database (common across schemas)
@@ -292,85 +318,6 @@ const saveRR = async (
 };
 
 /**
- * Saves a FHIR bundle metadata to a postgres database.
- * @async
- * @function saveCoreMetadata
- * @param fhirDataPromise
- * @param rollbackFhirDataFn
- * @param metadata - The FHIR bundle metadata to be saved.
- * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
- * @returns An object containing the status and message.
- */
-export const saveCoreMetadata = async (
-  metadata: BundleMetadata,
-  ecrId: string,
-  fhirDataPromise: Promise<SaveResponse>,
-  rollbackFhirDataFn: () => Promise<void>,
-): Promise<SaveResponse> => {
-  let rollBackFhirData = true;
-
-  try {
-    if (!metadata) {
-      console.error("eICR Data is required.");
-      return {
-        message: "Failed: eICR Data is required.",
-        status: 400,
-      };
-    }
-
-    // Start transaction
-    await getDb<Core>()
-      .transaction()
-      .execute(async (trx) => {
-        // Insert main ECR metadata
-        await trx
-          .insertInto("ecr_data")
-          .values({
-            eicr_id: ecrId,
-            set_id: metadata.eicr_set_id,
-            patient_name_last: metadata.last_name,
-            patient_name_first: metadata.first_name,
-            patient_birth_date: metadata.birth_date,
-            data_source: "DB",
-            report_date: new Date(metadata.report_date),
-            eicr_version_number: metadata.eicr_version_number,
-          })
-          .execute();
-
-        // The actual type here is a beast, but we know that this mapping is functionally sound
-        await saveRR(trx as unknown as Kysely<Common>, metadata, ecrId);
-
-        // Make sure the fhir data also saves
-        const fhirDataResponse = await fhirDataPromise;
-        if (fhirDataResponse.status !== 200) {
-          rollBackFhirData = false;
-          throw new Error(
-            `Failed to save fhir data - rolling back metadata: ${JSON.stringify(
-              fhirDataResponse,
-            )}`,
-          );
-        }
-      });
-    return {
-      message: "Success. Saved metadata to database.",
-      status: 200,
-    };
-  } catch (error: unknown) {
-    const message = "Failed to insert metadata to database.";
-    console.error({ message, error });
-
-    if (rollBackFhirData) {
-      await rollbackFhirDataFn();
-    }
-
-    return {
-      message,
-      status: 500,
-    };
-  }
-};
-
-/**
  * @async
  * @function saveWithMetadata
  * @param fhirBundle - The FHIR bundle to be saved.
@@ -385,27 +332,14 @@ export const saveWithMetadata = async (
   saveSource: string,
   metadata: BundleMetadata | BundleExtendedMetadata,
 ): Promise<SaveResponse> => {
-  let fhirDataResult;
-  let metadataResult;
-
   try {
-    metadataResult = saveFhirMetadata(
+    return await saveFhirMetadata(
       ecrId,
       dbSchema(),
       metadata as BundleMetadata | BundleExtendedMetadata,
       saveFhirData(fhirBundle, ecrId, saveSource),
       () => deleteFhirData(ecrId, saveSource),
     );
-
-    // try {
-    //   [fhirDataResult, metadataResult] = await Promise.all([
-    //     saveFhirData(fhirBundle, ecrId, saveSource),
-    //     saveFhirMetadata(
-    //       ecrId,
-    //       dbSchema(),
-    //       metadata as BundleMetadata | BundleExtendedMetadata,
-    //     ),
-    //   ]);
   } catch (error: unknown) {
     const message = "Failed to save FHIR data with metadata.";
     console.error({ message, error, ecrId });
@@ -414,23 +348,6 @@ export const saveWithMetadata = async (
       status: 500,
     };
   }
-
-  let responseMessage = "";
-  let responseStatus = 200;
-  if (fhirDataResult.status !== 200) {
-    responseMessage += "Failed to save FHIR data.\n";
-    responseStatus = fhirDataResult.status;
-  } else {
-    responseMessage += "Saved FHIR data.\n";
-  }
-  if (metadataResult.status !== 200) {
-    responseMessage += "Failed to save metadata.";
-    responseStatus = metadataResult.status;
-  } else {
-    responseMessage += "Saved metadata.";
-  }
-
-  return { message: responseMessage, status: responseStatus };
 };
 
 // helper to parse a maybe string into a date or undefined

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "crypto";
 
-import { PutObjectCommand, PutObjectCommandOutput } from "@aws-sdk/client-s3";
 import { Bundle } from "fhir/r4";
 import { Kysely } from "kysely";
 
@@ -9,9 +8,12 @@ import { Common } from "@/app/api/services/types/common";
 import { Core } from "@/app/api/services/types/core";
 import { Extended } from "@/app/api/services/types/extended";
 import { S3_SOURCE, AZURE_SOURCE, GCP_SOURCE } from "@/app/api/utils";
-import { azureBlobContainerClient } from "@/app/data/blobStorage/azureClient";
-import { gcpClient } from "@/app/data/blobStorage/gcpClient";
-import { s3Client } from "@/app/data/blobStorage/s3Client";
+import {
+  deleteFromAzure,
+  saveToAzure,
+} from "@/app/data/blobStorage/azureClient";
+import { deleteFromGCP, saveToGCP } from "@/app/data/blobStorage/gcpClient";
+import { deleteFromS3, saveToS3 } from "@/app/data/blobStorage/s3Client";
 
 import { BundleExtendedMetadata, BundleMetadata } from "./types";
 
@@ -19,142 +21,6 @@ interface SaveResponse {
   message: string;
   status: number;
 }
-
-/**
- * Saves a FHIR bundle to an AWS S3 bucket.
- * @async
- * @function saveToS3
- * @param fhirBundle - The FHIR bundle to be saved.
- * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
- * @returns An object containing the status and message.
- */
-const saveToS3 = async (fhirBundle: Bundle, ecrId: string) => {
-  const bucketName = process.env.ECR_BUCKET_NAME;
-  const objectKey = `${ecrId}.json`;
-  const body = JSON.stringify(fhirBundle);
-
-  try {
-    const input = {
-      Body: body,
-      Bucket: bucketName,
-      Key: objectKey,
-      ContentType: "application/json",
-    };
-    const command = new PutObjectCommand(input);
-    const response: PutObjectCommandOutput = await s3Client.send(command);
-    const httpStatusCode = response?.$metadata?.httpStatusCode;
-
-    if (httpStatusCode !== 200) {
-      throw new Error(`HTTP Status Code: ${httpStatusCode}`);
-    }
-
-    return {
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    };
-  } catch (error: unknown) {
-    console.error({
-      message: "Failed to save FHIR bundle to S3.",
-      error,
-      ecrId,
-    });
-    return {
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    };
-  }
-};
-
-/**
- * Saves a FHIR bundle to Azure Blob Storage.
- * @async
- * @function saveToAzure
- * @param fhirBundle - The FHIR bundle to be saved.
- * @param ecrId - The unique ID for the eCR associated with the FHIR bundle.
- * @returns An object containing the status and message.
- */
-const saveToAzure = async (
-  fhirBundle: Bundle,
-  ecrId: string,
-): Promise<SaveResponse> => {
-  const containerClient = azureBlobContainerClient();
-  const blobName = `${ecrId}.json`;
-  const body = JSON.stringify(fhirBundle);
-
-  if (!containerClient) {
-    return {
-      message: "Failed to save FHIR bundle due to misconfiguration of client.",
-      status: 500,
-    };
-  }
-
-  try {
-    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
-
-    const response = await blockBlobClient.upload(body, body.length, {
-      blobHTTPHeaders: { blobContentType: "application/json" },
-    });
-
-    if (response._response.status !== 201) {
-      throw new Error(`HTTP Status Code: ${response._response.status}`);
-    }
-
-    return {
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    };
-  } catch (error: unknown) {
-    console.error({
-      message: "Failed to save FHIR bundle to Azure Blob Storage.",
-      error,
-      ecrId,
-    });
-    return {
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    };
-  }
-};
-
-/**
- * Saves a FHIR bundle to Google Cloud Storage.
- * @param fhirBundle - The FHIR bundle to be saved.
- * @param ecrId - The unique ID for the eCR associated with the FHIR bundle.
- * @returns An object containing the status and message.
- */
-const saveToGCP = async (
-  fhirBundle: Bundle,
-  ecrId: string,
-): Promise<SaveResponse> => {
-  const containerClient = gcpClient();
-  const blobName = `${ecrId}.json`;
-  const body = JSON.stringify(fhirBundle);
-
-  if (!containerClient) {
-    return {
-      message: "Failed to save the FHIR bundle due to misconfiguration.",
-      status: 500,
-    };
-  }
-  try {
-    await containerClient.file(blobName).save(body);
-
-    return {
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    };
-  } catch (error: unknown) {
-    console.error({
-      message: "Failed to save FHIR bundle to Google Cloud Storage.",
-      error,
-      ecrId,
-    });
-    return {
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    };
-  }
-};
 
 /**
  * @async
@@ -169,12 +35,14 @@ export const saveFhirData = async (
   ecrId: string,
   saveSource: string,
 ): Promise<SaveResponse> => {
+  const body = JSON.stringify(fhirBundle);
+  const objectKey = `${ecrId}.json`;
   if (saveSource === S3_SOURCE) {
-    return await saveToS3(fhirBundle, ecrId);
+    return await saveToS3(body, objectKey);
   } else if (saveSource === AZURE_SOURCE) {
-    return await saveToAzure(fhirBundle, ecrId);
+    return await saveToAzure(body, objectKey);
   } else if (saveSource === GCP_SOURCE) {
-    return await saveToGCP(fhirBundle, ecrId);
+    return await saveToGCP(body, objectKey);
   } else {
     return {
       message:
@@ -195,12 +63,13 @@ export const deleteFhirData = async (
   ecrId: string,
   saveSource: string,
 ): Promise<SaveResponse> => {
+  const objectKey = `${ecrId}.json`;
   if (saveSource === S3_SOURCE) {
-    return await deleteFromS3(ecrId);
+    return await deleteFromS3(objectKey);
   } else if (saveSource === AZURE_SOURCE) {
-    return await deleteFromAzure(ecrId);
+    return await deleteFromAzure(objectKey);
   } else if (saveSource === GCP_SOURCE) {
-    return await deleteFromGCP(ecrId);
+    return await deleteFromGCP(objectKey);
   } else {
     return {
       message:

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -106,7 +106,7 @@ export const saveFhirMetadata = async (
     }
 
     // Start transaction
-    await getDb<Core>()
+    return await getDb<Core>()
       .transaction()
       .execute(async (trx) => {
         // Insert main ECR metadata
@@ -138,11 +138,12 @@ export const saveFhirMetadata = async (
             )}`,
           );
         }
+
+        return {
+          message: "Success. Saved metadata to database.",
+          status: 200,
+        };
       });
-    return {
-      message: "Success. Saved metadata to database.",
-      status: 200,
-    };
   } catch (error: unknown) {
     const message = "Failed to insert metadata to database.";
     console.error({ message, error, ecrId });

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -186,8 +186,36 @@ export const saveFhirData = async (
 
 /**
  * @async
+ * @function deleteFhirData
+ * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
+ * @param saveSource - The location to save the FHIR bundle.
+ * @returns An object containing the status and message.
+ */
+export const deleteFhirData = async (
+  ecrId: string,
+  saveSource: string,
+): Promise<SaveResponse> => {
+  if (saveSource === S3_SOURCE) {
+    return await deleteFromS3(ecrId);
+  } else if (saveSource === AZURE_SOURCE) {
+    return await deleteFromAzure(ecrId);
+  } else if (saveSource === GCP_SOURCE) {
+    return await deleteFromGCP(ecrId);
+  } else {
+    return {
+      message:
+        'Invalid save source. Please provide a valid value for \'saveSource\' ("s3", "azure", or "gcp").',
+      status: 400,
+    };
+  }
+};
+
+/**
+ * @async
  * @function saveFhirMetadata
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
+ * @param fhirDataPromise
+ * @param rollbackFhirDataFn
  * @param metadataType - Whether metadata is persisted using the "core" or "extended" schema
  * @param metadata - The metadata to be saved.
  * @returns An object containing the status and message.
@@ -196,14 +224,23 @@ const saveFhirMetadata = async (
   ecrId: string,
   metadataType: "core" | "extended" | undefined,
   metadata: BundleMetadata | BundleExtendedMetadata,
+  fhirDataPromise: Promise<SaveResponse>,
+  rollbackFhirDataFn: () => Promise<void>,
 ): Promise<SaveResponse> => {
   try {
     if (metadataType === "core") {
-      return await saveCoreMetadata(metadata as BundleMetadata, ecrId);
+      return await saveCoreMetadata(
+        metadata as BundleMetadata,
+        ecrId,
+        fhirDataPromise,
+        rollbackFhirDataFn,
+      );
     } else if (metadataType === "extended") {
       return await saveExtendedMetadata(
         metadata as BundleExtendedMetadata,
         ecrId,
+        fhirDataPromise,
+        rollbackFhirDataFn,
       );
     } else {
       return {
@@ -224,6 +261,8 @@ const saveFhirMetadata = async (
 /**
  * @async
  * @function saveExtendedMetaData
+ * @param fhirDataPromise
+ * @param rollbackFhirDataFn
  * @param metadata - The FHIR bundle metadata to be saved.
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
  * @returns An object containing the status and message.
@@ -231,6 +270,8 @@ const saveFhirMetadata = async (
 export const saveExtendedMetadata = async (
   metadata: BundleExtendedMetadata,
   ecrId: string,
+  fhirDataPromise: Promise<SaveResponse>,
+  rollbackFhirDataFn: () => Promise<void>,
 ): Promise<SaveResponse> => {
   try {
     await getDb<Extended>()
@@ -321,6 +362,14 @@ export const saveExtendedMetadata = async (
 
         // The actual type here is a beast, but we know that this mapping is functionally sound
         await saveRR(trx as unknown as Kysely<Common>, metadata, ecrId);
+
+        // Make sure the fhir data also saves
+        const fhirDataResponse = await fhirDataPromise;
+        if (fhirDataResponse.status !== 200) {
+          throw new Error(
+            `Failed to save fhir data: ${JSON.stringify(fhirDataResponse)}`,
+          );
+        }
       });
     return {
       message: "Success. Saved metadata to database.",
@@ -377,6 +426,8 @@ const saveRR = async (
  * Saves a FHIR bundle metadata to a postgres database.
  * @async
  * @function saveCoreMetadata
+ * @param fhirDataPromise
+ * @param rollbackFhirDataFn
  * @param metadata - The FHIR bundle metadata to be saved.
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
  * @returns An object containing the status and message.
@@ -384,7 +435,11 @@ const saveRR = async (
 export const saveCoreMetadata = async (
   metadata: BundleMetadata,
   ecrId: string,
+  fhirDataPromise: Promise<SaveResponse>,
+  rollbackFhirDataFn: () => Promise<void>,
 ): Promise<SaveResponse> => {
+  let rollBackFhirData = true;
+
   try {
     if (!metadata) {
       console.error("eICR Data is required.");
@@ -415,6 +470,17 @@ export const saveCoreMetadata = async (
 
         // The actual type here is a beast, but we know that this mapping is functionally sound
         await saveRR(trx as unknown as Kysely<Common>, metadata, ecrId);
+
+        // Make sure the fhir data also saves
+        const fhirDataResponse = await fhirDataPromise;
+        if (fhirDataResponse.status !== 200) {
+          rollBackFhirData = false;
+          throw new Error(
+            `Failed to save fhir data - rolling back metadata: ${JSON.stringify(
+              fhirDataResponse,
+            )}`,
+          );
+        }
       });
     return {
       message: "Success. Saved metadata to database.",
@@ -423,6 +489,11 @@ export const saveCoreMetadata = async (
   } catch (error: unknown) {
     const message = "Failed to insert metadata to database.";
     console.error({ message, error });
+
+    if (rollBackFhirData) {
+      await rollbackFhirDataFn();
+    }
+
     return {
       message,
       status: 500,
@@ -449,14 +520,23 @@ export const saveWithMetadata = async (
   let metadataResult;
 
   try {
-    [fhirDataResult, metadataResult] = await Promise.all([
+    metadataResult = saveFhirMetadata(
+      ecrId,
+      dbSchema(),
+      metadata as BundleMetadata | BundleExtendedMetadata,
       saveFhirData(fhirBundle, ecrId, saveSource),
-      saveFhirMetadata(
-        ecrId,
-        dbSchema(),
-        metadata as BundleMetadata | BundleExtendedMetadata,
-      ),
-    ]);
+      () => deleteFhirData(ecrId, saveSource),
+    );
+
+    // try {
+    //   [fhirDataResult, metadataResult] = await Promise.all([
+    //     saveFhirData(fhirBundle, ecrId, saveSource),
+    //     saveFhirMetadata(
+    //       ecrId,
+    //       dbSchema(),
+    //       metadata as BundleMetadata | BundleExtendedMetadata,
+    //     ),
+    //   ]);
   } catch (error: unknown) {
     const message = "Failed to save FHIR data with metadata.";
     console.error({ message, error, ecrId });

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -87,7 +87,7 @@ export const deleteFhirData = async (
  * @param rollbackFhirDataFn - thunk to roll back the saving of the fhir bundle
  * @returns An object containing the status and message.
  */
-const saveFhirMetadata = async (
+export const saveFhirMetadata = async (
   ecrId: string,
   metadataType: "core" | "extended" | undefined,
   metadata: BundleMetadata | BundleExtendedMetadata,
@@ -166,7 +166,7 @@ const saveFhirMetadata = async (
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
  * @returns An object containing the status and message.
  */
-export const saveExtendedMetadata = async (
+const saveExtendedMetadata = async (
   trx: Transaction<Extended>,
   metadata: BundleExtendedMetadata,
   ecrId: string,
@@ -260,7 +260,7 @@ export const saveExtendedMetadata = async (
  * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
  * @returns An object containing the status and message.
  */
-export const saveCoreMetadata = async (
+const saveCoreMetadata = async (
   trx: Transaction<Core>,
   metadata: BundleMetadata,
   ecrId: string,

--- a/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/azureClient.ts
@@ -2,6 +2,16 @@ import { BlobServiceClient } from "@azure/storage-blob";
 
 import { AZURE_SOURCE } from "@/app/api/utils";
 
+import {
+  BlobResponse,
+  DELETE_FAILURE,
+  DELETE_MISCONFIGURED,
+  DELETE_SUCCESS,
+  SAVE_FAILURE,
+  SAVE_MISCONFIGURED,
+  SAVE_SUCCESS,
+} from "./utils";
+
 /**
  * Connect to the Azure blob container.
  * @returns A promise resolving to a azure blob container client.
@@ -42,5 +52,77 @@ export const azureBlobStorageHealthCheck = async () => {
   } catch (error: unknown) {
     console.error(error);
     return "DOWN";
+  }
+};
+
+/**
+ * Saves a blob to Azure Blob Storage.
+ * @param body - The string content to save as a blob.
+ * @param objectKey - The name of the blob.
+ * @returns An object containing the status and message.
+ */
+export const saveToAzure = async (
+  body: string,
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const containerClient = azureBlobContainerClient();
+
+  if (!containerClient) {
+    return SAVE_MISCONFIGURED;
+  }
+
+  try {
+    const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
+
+    const response = await blockBlobClient.upload(body, body.length, {
+      blobHTTPHeaders: { blobContentType: "application/json" },
+    });
+
+    if (response._response.status !== 201) {
+      throw new Error(`HTTP Status Code: ${response._response.status}`);
+    }
+
+    return SAVE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to save blob to Azure Blob Storage.",
+      error,
+      objectKey,
+    });
+    return SAVE_FAILURE;
+  }
+};
+
+/**
+ * Delete a blob from Azure Blob Storage.
+ * @param objectKey - The name of the blob.
+ * @returns An object containing the status and message.
+ */
+export const deleteFromAzure = async (
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const containerClient = azureBlobContainerClient();
+
+  if (!containerClient) {
+    return DELETE_MISCONFIGURED;
+  }
+
+  try {
+    const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
+
+    const response = await blockBlobClient.deleteIfExists();
+
+    if (!response.succeeded) {
+      throw new Error(`HTTP Status Code: ${response._response.status}`);
+    }
+
+    return DELETE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to save blob to Azure Blob Storage.",
+      error,
+      objectKey,
+    });
+    return DELETE_FAILURE;
   }
 };

--- a/containers/ecr-viewer/src/app/data/blobStorage/gcpClient.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/gcpClient.ts
@@ -2,6 +2,16 @@ import { Storage } from "@google-cloud/storage";
 
 import { GCP_SOURCE } from "@/app/api/utils";
 
+import {
+  BlobResponse,
+  DELETE_FAILURE,
+  DELETE_MISCONFIGURED,
+  DELETE_SUCCESS,
+  SAVE_FAILURE,
+  SAVE_MISCONFIGURED,
+  SAVE_SUCCESS,
+} from "./utils";
+
 /**
  * Connect to the google cloud storage bucket.
  * @returns The google cloud storage bucket.
@@ -38,5 +48,61 @@ export const gcpHealthCheck = async () => {
   } catch (error: unknown) {
     console.error(error);
     return "DOWN";
+  }
+};
+
+/**
+ * Saves content to Google Cloud Storage.
+ * @param body - The string content to be saved.
+ * @param objectKey - The unique ID for the blob.
+ * @returns An object containing the status and message.
+ */
+export const saveToGCP = async (
+  body: string,
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const containerClient = gcpClient();
+
+  if (!containerClient) {
+    return SAVE_MISCONFIGURED;
+  }
+  try {
+    await containerClient.file(objectKey).save(body);
+
+    return SAVE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to save blob to Google Cloud Storage.",
+      error,
+      objectKey,
+    });
+    return SAVE_FAILURE;
+  }
+};
+
+/**
+ * Deletes content from Google Cloud Storage.
+ * @param objectKey - The unique ID for the blob.
+ * @returns An object containing the status and message.
+ */
+export const deleteFromGCP = async (
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const containerClient = gcpClient();
+
+  if (!containerClient) {
+    return DELETE_MISCONFIGURED;
+  }
+  try {
+    await containerClient.file(objectKey).delete();
+
+    return DELETE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to delete blob to Google Cloud Storage.",
+      error,
+      objectKey,
+    });
+    return DELETE_FAILURE;
   }
 };

--- a/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/s3Client.ts
@@ -1,6 +1,21 @@
-import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectCommand,
+  DeleteObjectCommandOutput,
+  HeadBucketCommand,
+  PutObjectCommand,
+  PutObjectCommandOutput,
+  S3Client,
+} from "@aws-sdk/client-s3";
 
 import { S3_SOURCE } from "@/app/api/utils";
+
+import {
+  BlobResponse,
+  DELETE_FAILURE,
+  DELETE_SUCCESS,
+  SAVE_FAILURE,
+  SAVE_SUCCESS,
+} from "./utils";
 
 export const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -28,5 +43,77 @@ export const s3HealthCheck = async () => {
   } catch (error: unknown) {
     console.error(error);
     return "DOWN";
+  }
+};
+
+/**
+ * Saves a FHIR bundle to an AWS S3 bucket.
+ * @param body - The string content to be saved.
+ * @param objectKey - The name of the blob.
+ * @returns An object containing the status and message.
+ */
+export const saveToS3 = async (
+  body: string,
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const bucketName = process.env.ECR_BUCKET_NAME;
+
+  try {
+    const input = {
+      Body: body,
+      Bucket: bucketName,
+      Key: objectKey,
+      ContentType: "application/json",
+    };
+    const command = new PutObjectCommand(input);
+    const response: PutObjectCommandOutput = await s3Client.send(command);
+    const httpStatusCode = response?.$metadata?.httpStatusCode;
+
+    if (httpStatusCode !== 200) {
+      throw new Error(`HTTP Status Code: ${httpStatusCode}`);
+    }
+
+    return SAVE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to save blob to S3.",
+      error,
+      objectKey,
+    });
+    return SAVE_FAILURE;
+  }
+};
+
+/**
+ * Deletes a blob from an AWS S3 bucket.
+ * @param objectKey - The name of the blob.
+ * @returns An object containing the status and message.
+ */
+export const deleteFromS3 = async (
+  objectKey: string,
+): Promise<BlobResponse> => {
+  const bucketName = process.env.ECR_BUCKET_NAME;
+
+  try {
+    const input = {
+      Bucket: bucketName,
+      Key: objectKey,
+    };
+    const command = new DeleteObjectCommand(input);
+    const response: DeleteObjectCommandOutput = await s3Client.send(command);
+    const httpStatusCode = response?.$metadata?.httpStatusCode;
+
+    if (httpStatusCode !== 200) {
+      throw new Error(`HTTP Status Code: ${httpStatusCode}`);
+    }
+
+    return DELETE_SUCCESS;
+  } catch (error: unknown) {
+    console.error({
+      message: "Failed to delete blob to S3.",
+      error,
+      objectKey,
+    });
+    return DELETE_FAILURE;
   }
 };

--- a/containers/ecr-viewer/src/app/data/blobStorage/utils.ts
+++ b/containers/ecr-viewer/src/app/data/blobStorage/utils.ts
@@ -1,0 +1,34 @@
+export interface BlobResponse {
+  message: string;
+  status: number;
+}
+
+export const SAVE_SUCCESS = {
+  message: "Success. Saved FHIR bundle.",
+  status: 200,
+};
+
+export const SAVE_FAILURE = {
+  message: "Failed to save FHIR bundle.",
+  status: 500,
+};
+
+export const SAVE_MISCONFIGURED = {
+  message: "Failed to save the FHIR bundle due to misconfiguration.",
+  status: 500,
+};
+
+export const DELETE_SUCCESS = {
+  message: "Success. Deleted FHIR bundle.",
+  status: 200,
+};
+
+export const DELETE_FAILURE = {
+  message: "Failed to delete FHIR bundle.",
+  status: 500,
+};
+
+export const DELETE_MISCONFIGURED = {
+  message: "Failed to delete the FHIR bundle due to misconfiguration.",
+  status: 500,
+};

--- a/containers/ecr-viewer/src/app/tests/api/save-fhir-data/save-fhir-data-service.test.ts
+++ b/containers/ecr-viewer/src/app/tests/api/save-fhir-data/save-fhir-data-service.test.ts
@@ -1,31 +1,21 @@
+/**
+ * @jest-environment node
+ */
 import { Bundle } from "fhir/r4";
 
 import { saveFhirData } from "@/app/api/save-fhir-data/save-fhir-data-service";
-import { azureBlobContainerClient } from "@/app/data/blobStorage/azureClient";
-import { gcpClient } from "@/app/data/blobStorage/gcpClient";
-import { s3Client } from "@/app/data/blobStorage/s3Client";
+import { saveToAzure } from "@/app/data/blobStorage/azureClient";
+import { saveToGCP } from "@/app/data/blobStorage/gcpClient";
+import { saveToS3 } from "@/app/data/blobStorage/s3Client";
 
-jest.mock("../../../../app/data/blobStorage/azureClient", () => ({
-  azureBlobContainerClient: jest.fn(),
-}));
-jest.mock("../../../../app/data/blobStorage/gcpClient", () => ({
-  gcpClient: jest.fn(),
-}));
-jest.mock("../../../../app/data/blobStorage/s3Client", () => ({
-  s3Client: { send: jest.fn() },
-}));
-jest.mock("@aws-sdk/client-s3", () => ({
-  PutObjectCommand: jest.fn().mockImplementation((input) => ({
-    input,
-  })),
-}));
+jest.mock("../../../../app/data/blobStorage/azureClient");
+jest.mock("../../../../app/data/blobStorage/gcpClient");
+jest.mock("../../../../app/data/blobStorage/s3Client");
 jest.mock("../../../../app/api/services/database");
 
 describe("saveFhirData", () => {
   const fhirBundle: Bundle = { resourceType: "Bundle", type: "batch" };
-  const fhirBundleString = JSON.stringify(fhirBundle);
   const ecrId = "1234";
-  const ecrFileName = `${ecrId}.json`;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,134 +25,25 @@ describe("saveFhirData", () => {
     process.env.ECR_BUCKET_NAME = "";
   });
 
-  it("should return 200 when saving to s3 succeeds", async () => {
+  it("should call s3", async () => {
     process.env.ECR_BUCKET_NAME = "bucket";
-    (s3Client.send as jest.Mock).mockResolvedValue({
-      $metadata: { httpStatusCode: 200 },
-    });
 
-    const result = await saveFhirData(fhirBundle, ecrId, "s3");
-
-    expect(result).toEqual({
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    });
-    expect(s3Client.send).toHaveBeenCalledOnce();
-    expect(s3Client.send).toHaveBeenCalledWith({
-      input: {
-        Body: fhirBundleString,
-        Bucket: "bucket",
-        Key: ecrFileName,
-        ContentType: "application/json",
-      },
-    });
+    await saveFhirData(fhirBundle, ecrId, "s3");
+    expect(saveToS3).toHaveBeenCalledOnce();
   });
 
-  it("should return 500 when saving to s3 fails", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    (s3Client.send as jest.Mock).mockResolvedValue({
-      $metadata: { httpStatusCode: 500 },
-    });
+  it("should call azure", async () => {
+    process.env.ECR_BUCKET_NAME = "bucket";
 
-    const result = await saveFhirData(fhirBundle, ecrId, "s3");
-
-    expect(result).toEqual({
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    });
+    await saveFhirData(fhirBundle, ecrId, "azure");
+    expect(saveToAzure).toHaveBeenCalledOnce();
   });
 
-  it("should return 200 when saving to Azure succeeds", async () => {
-    const mockUpload = jest
-      .fn()
-      .mockResolvedValue({ _response: { status: 201 } });
-    const mockBlockBlobClient = jest.fn().mockReturnValue({
-      upload: mockUpload,
-    });
-    (azureBlobContainerClient as jest.Mock).mockReturnValue({
-      getBlockBlobClient: mockBlockBlobClient,
-    });
+  it("should call gcp", async () => {
+    process.env.ECR_BUCKET_NAME = "bucket";
 
-    const result = await saveFhirData(fhirBundle, ecrId, "azure");
-
-    expect(result).toEqual({
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    });
-    expect(mockBlockBlobClient).toHaveBeenCalledExactlyOnceWith(ecrFileName);
-    expect(mockUpload).toHaveBeenCalledOnce();
-    expect(mockUpload).toHaveBeenCalledWith(
-      fhirBundleString,
-      fhirBundleString.length,
-      {
-        blobHTTPHeaders: { blobContentType: "application/json" },
-      },
-    );
-  });
-
-  it("should return 500 when saving to Azure succeeds", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    const mockUpload = jest
-      .fn()
-      .mockResolvedValue({ _response: { status: 500 } });
-    const mockBlockBlobClient = jest.fn().mockReturnValue({
-      upload: mockUpload,
-    });
-    (azureBlobContainerClient as jest.Mock).mockReturnValue({
-      getBlockBlobClient: mockBlockBlobClient,
-    });
-
-    const result = await saveFhirData(fhirBundle, ecrId, "azure");
-
-    expect(result).toEqual({
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    });
-  });
-
-  it("should return 200 when saving to GCP succeeds", async () => {
-    const mockSave = jest.fn().mockResolvedValue(undefined);
-    const mockFile = jest.fn().mockReturnValue({ save: mockSave });
-    (gcpClient as jest.Mock).mockReturnValue({
-      file: mockFile,
-    });
-
-    const result = await saveFhirData(fhirBundle, ecrId, "gcp");
-
-    expect(result).toEqual({
-      message: "Success. Saved FHIR bundle.",
-      status: 200,
-    });
-    expect(gcpClient).toHaveBeenCalledOnce();
-    expect(mockFile).toHaveBeenCalledExactlyOnceWith(ecrFileName);
-    expect(mockSave).toHaveBeenCalledExactlyOnceWith(fhirBundleString);
-  });
-
-  it("should return 500 when saving to GCP fails", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    const mockSave = jest.fn().mockRejectedValue(new Error("Failed to save"));
-    const mockFile = jest.fn().mockReturnValue({ save: mockSave });
-    (gcpClient as jest.Mock).mockReturnValue({
-      file: mockFile,
-    });
-
-    const result = await saveFhirData(fhirBundle, ecrId, "gcp");
-
-    expect(result).toEqual({
-      message: "Failed to save FHIR bundle.",
-      status: 500,
-    });
-  });
-
-  it("should return 500 when GCP is not configured", async () => {
-    (gcpClient as jest.Mock).mockReturnValue(undefined);
-
-    const result = await saveFhirData(fhirBundle, ecrId, "gcp");
-
-    expect(result).toEqual({
-      message: "Failed to save the FHIR bundle due to misconfiguration.",
-      status: 500,
-    });
+    await saveFhirData(fhirBundle, ecrId, "gcp");
+    expect(saveToGCP).toHaveBeenCalledOnce();
   });
 
   it("should return an error for an invalid save source", async () => {

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -7,9 +7,13 @@ import { AZURE_SOURCE, S3_SOURCE } from "@/app/api/utils";
 import {
   azureBlobContainerClient,
   azureBlobStorageHealthCheck,
+  saveToAzure,
 } from "@/app/data/blobStorage/azureClient";
 
 jest.mock("@azure/storage-blob");
+
+const fhirBundleString = "{hi: 1}";
+const fileName = "test.json";
 
 describe("azure blob container", () => {
   describe("client", () => {
@@ -50,6 +54,7 @@ describe("azure blob container", () => {
       expect(mockGetContainerClient).toHaveBeenCalledWith("container2");
     });
   });
+
   describe("health check", () => {
     let mockExists: jest.Mock;
 
@@ -61,6 +66,7 @@ describe("azure blob container", () => {
         }),
       });
     });
+
     afterEach(() => {
       jest.resetAllMocks();
       delete process.env.AZURE_STORAGE_CONNECTION_STRING;
@@ -71,6 +77,7 @@ describe("azure blob container", () => {
       process.env.SOURCE = S3_SOURCE;
       expect(await azureBlobStorageHealthCheck()).toBeUndefined();
     });
+
     it("should return UP when the container exists", async () => {
       process.env.SOURCE = AZURE_SOURCE;
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
@@ -80,6 +87,7 @@ describe("azure blob container", () => {
       const result = await azureBlobStorageHealthCheck();
       expect(result).toEqual("UP");
     });
+
     it("should return DOWN when the container is not initialized", async () => {
       process.env.SOURCE = AZURE_SOURCE;
       delete process.env.AZURE_STORAGE_CONNECTION_STRING;
@@ -88,6 +96,7 @@ describe("azure blob container", () => {
       const result = await azureBlobStorageHealthCheck();
       expect(result).toEqual("DOWN");
     });
+
     it("should return DOWN when the container does not exist", async () => {
       jest.spyOn(console, "error").mockImplementation();
       process.env.SOURCE = AZURE_SOURCE;
@@ -96,6 +105,7 @@ describe("azure blob container", () => {
       const result = await azureBlobStorageHealthCheck();
       expect(result).toEqual("DOWN");
     });
+
     it("should return DOWN when the container throws an error", async () => {
       jest.spyOn(console, "error").mockImplementation();
       process.env.SOURCE = AZURE_SOURCE;
@@ -103,6 +113,68 @@ describe("azure blob container", () => {
 
       const result = await azureBlobStorageHealthCheck();
       expect(result).toEqual("DOWN");
+    });
+  });
+
+  describe("saveToAzure", () => {
+    it("should return 200 when saving to Azure succeeds", async () => {
+      process.env.SOURCE = AZURE_SOURCE;
+      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
+      process.env.AZURE_CONTAINER_NAME = "container";
+      const mockUpload = jest
+        .fn()
+        .mockResolvedValue({ _response: { status: 201 } });
+      const mockBlockBlobClient = jest.fn().mockReturnValue({
+        upload: mockUpload,
+      });
+      const mockGetContainerClient = jest
+        .fn()
+        .mockReturnValue({ getBlockBlobClient: mockBlockBlobClient });
+      (BlobServiceClient.fromConnectionString as jest.Mock).mockReturnValue({
+        getContainerClient: mockGetContainerClient,
+      });
+
+      const result = await saveToAzure(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Success. Saved FHIR bundle.",
+        status: 200,
+      });
+      expect(mockBlockBlobClient).toHaveBeenCalledExactlyOnceWith(fileName);
+      expect(mockUpload).toHaveBeenCalledOnce();
+      expect(mockUpload).toHaveBeenCalledWith(
+        fhirBundleString,
+        fhirBundleString.length,
+        {
+          blobHTTPHeaders: { blobContentType: "application/json" },
+        },
+      );
+    });
+
+    it("should return 500 when saving to Azure succeeds", async () => {
+      process.env.SOURCE = AZURE_SOURCE;
+      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
+      process.env.AZURE_CONTAINER_NAME = "container";
+      const mockUpload = jest
+        .fn()
+        .mockResolvedValue({ _response: { status: 500 } });
+      const mockBlockBlobClient = jest.fn().mockReturnValue({
+        upload: mockUpload,
+      });
+      const mockGetContainerClient = jest
+        .fn()
+        .mockReturnValue({ getBlockBlobClient: mockBlockBlobClient });
+      (BlobServiceClient.fromConnectionString as jest.Mock).mockReturnValue({
+        getContainerClient: mockGetContainerClient,
+      });
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await saveToAzure(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Failed to save FHIR bundle.",
+        status: 500,
+      });
     });
   });
 });

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/azureClient.test.ts
@@ -7,6 +7,7 @@ import { AZURE_SOURCE, S3_SOURCE } from "@/app/api/utils";
 import {
   azureBlobContainerClient,
   azureBlobStorageHealthCheck,
+  deleteFromAzure,
   saveToAzure,
 } from "@/app/data/blobStorage/azureClient";
 
@@ -116,7 +117,7 @@ describe("azure blob container", () => {
     });
   });
 
-  describe("saveToAzure", () => {
+  describe("save blob", () => {
     it("should return 200 when saving to Azure succeeds", async () => {
       process.env.SOURCE = AZURE_SOURCE;
       process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
@@ -173,6 +174,61 @@ describe("azure blob container", () => {
 
       expect(result).toEqual({
         message: "Failed to save FHIR bundle.",
+        status: 500,
+      });
+    });
+  });
+
+  describe("delete blob", () => {
+    it("should return 200 when saving to Azure succeeds", async () => {
+      process.env.SOURCE = AZURE_SOURCE;
+      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
+      process.env.AZURE_CONTAINER_NAME = "container";
+      const mockDelete = jest
+        .fn()
+        .mockResolvedValue({ _response: { status: 200 }, succeeded: true });
+      const mockBlockBlobClient = jest.fn().mockReturnValue({
+        deleteIfExists: mockDelete,
+      });
+      const mockGetContainerClient = jest
+        .fn()
+        .mockReturnValue({ getBlockBlobClient: mockBlockBlobClient });
+      (BlobServiceClient.fromConnectionString as jest.Mock).mockReturnValue({
+        getContainerClient: mockGetContainerClient,
+      });
+
+      const result = await deleteFromAzure(fileName);
+
+      expect(result).toEqual({
+        message: "Success. Deleted FHIR bundle.",
+        status: 200,
+      });
+      expect(mockBlockBlobClient).toHaveBeenCalledExactlyOnceWith(fileName);
+      expect(mockDelete).toHaveBeenCalledOnce();
+    });
+
+    it("should return 500 when saving to Azure succeeds", async () => {
+      process.env.SOURCE = AZURE_SOURCE;
+      process.env.AZURE_STORAGE_CONNECTION_STRING = "connection";
+      process.env.AZURE_CONTAINER_NAME = "container";
+      const mockDelete = jest
+        .fn()
+        .mockResolvedValue({ _response: { status: 403 }, succeeded: false });
+      const mockBlockBlobClient = jest.fn().mockReturnValue({
+        deleteIfExists: mockDelete,
+      });
+      const mockGetContainerClient = jest
+        .fn()
+        .mockReturnValue({ getBlockBlobClient: mockBlockBlobClient });
+      (BlobServiceClient.fromConnectionString as jest.Mock).mockReturnValue({
+        getContainerClient: mockGetContainerClient,
+      });
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await deleteFromAzure(fileName);
+
+      expect(result).toEqual({
+        message: "Failed to delete FHIR bundle.",
         status: 500,
       });
     });

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/gcpClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/gcpClient.test.ts
@@ -1,6 +1,7 @@
 import { Storage } from "@google-cloud/storage";
 
 import {
+  deleteFromGCP,
   gcpClient,
   gcpHealthCheck,
   saveToGCP,
@@ -8,8 +9,11 @@ import {
 
 const mockExists = jest.fn();
 
+const mockDelete = jest.fn().mockResolvedValue(undefined);
 const mockSave = jest.fn().mockResolvedValue(undefined);
-const mockFile = jest.fn().mockReturnValue({ save: mockSave });
+const mockFile = jest
+  .fn()
+  .mockReturnValue({ save: mockSave, delete: mockDelete });
 
 const mockBucket = jest.fn().mockImplementation(() => ({
   exists: mockExists,
@@ -179,6 +183,41 @@ describe("gcp", () => {
 
       expect(result).toEqual({
         message: "Failed to save the FHIR bundle due to misconfiguration.",
+        status: 500,
+      });
+    });
+  });
+
+  describe("delete blob", () => {
+    it("should return 200 when deleting from GCP succeeds", async () => {
+      const result = await deleteFromGCP(fileName);
+
+      expect(result).toEqual({
+        message: "Success. Deleted FHIR bundle.",
+        status: 200,
+      });
+      expect(mockFile).toHaveBeenCalledExactlyOnceWith(fileName);
+      expect(mockDelete).toHaveBeenCalledExactlyOnceWith();
+    });
+
+    it("should return 500 when deleting from GCP fails", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      mockDelete.mockRejectedValue(new Error("Failed to delete"));
+
+      const result = await deleteFromGCP(fileName);
+
+      expect(result).toEqual({
+        message: "Failed to delete FHIR bundle.",
+        status: 500,
+      });
+    });
+
+    it("should return 500 when GCP is not configured", async () => {
+      process.env.SOURCE = "azure";
+      const result = await deleteFromGCP(fileName);
+
+      expect(result).toEqual({
+        message: "Failed to delete the FHIR bundle due to misconfiguration.",
         status: 500,
       });
     });

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/gcpClient.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/gcpClient.test.ts
@@ -1,11 +1,19 @@
 import { Storage } from "@google-cloud/storage";
 
-import { gcpClient, gcpHealthCheck } from "@/app/data/blobStorage/gcpClient";
+import {
+  gcpClient,
+  gcpHealthCheck,
+  saveToGCP,
+} from "@/app/data/blobStorage/gcpClient";
 
 const mockExists = jest.fn();
 
+const mockSave = jest.fn().mockResolvedValue(undefined);
+const mockFile = jest.fn().mockReturnValue({ save: mockSave });
+
 const mockBucket = jest.fn().mockImplementation(() => ({
   exists: mockExists,
+  file: mockFile,
 }));
 
 jest.mock("@google-cloud/storage", () => {
@@ -15,6 +23,10 @@ jest.mock("@google-cloud/storage", () => {
     })),
   };
 });
+
+const fhirBundleString = "{hi: 1}";
+const fileName = "test.json";
+
 describe("gcp", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -134,6 +146,41 @@ describe("gcp", () => {
       const result = await gcpHealthCheck();
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("save blob", () => {
+    it("should return 200 when saving to GCP succeeds", async () => {
+      const result = await saveToGCP(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Success. Saved FHIR bundle.",
+        status: 200,
+      });
+      expect(mockFile).toHaveBeenCalledExactlyOnceWith(fileName);
+      expect(mockSave).toHaveBeenCalledExactlyOnceWith(fhirBundleString);
+    });
+
+    it("should return 500 when saving to GCP fails", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      mockSave.mockRejectedValue(new Error("Failed to save"));
+
+      const result = await saveToGCP(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Failed to save FHIR bundle.",
+        status: 500,
+      });
+    });
+
+    it("should return 500 when GCP is not configured", async () => {
+      process.env.SOURCE = "azure";
+      const result = await saveToGCP(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Failed to save the FHIR bundle due to misconfiguration.",
+        status: 500,
+      });
     });
   });
 });

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
@@ -5,6 +5,7 @@ import {
   s3HealthCheck,
   s3Client,
   saveToS3,
+  deleteFromS3,
 } from "@/app/data/blobStorage/s3Client";
 
 jest.mock("@aws-sdk/client-s3", () => ({
@@ -13,6 +14,9 @@ jest.mock("@aws-sdk/client-s3", () => ({
   })),
   HeadBucketCommand: jest.fn(),
   PutObjectCommand: jest.fn().mockImplementation((input) => ({
+    input,
+  })),
+  DeleteObjectCommand: jest.fn().mockImplementation((input) => ({
     input,
   })),
 }));
@@ -67,7 +71,7 @@ describe("s3 client", () => {
     });
   });
 
-  describe("saveToS3", () => {
+  describe("save blob", () => {
     it("should return 200 when saving to s3 succeeds", async () => {
       process.env.ECR_BUCKET_NAME = "bucket";
       process.env.SOURCE = "s3";
@@ -94,6 +98,38 @@ describe("s3 client", () => {
 
       expect(result).toEqual({
         message: "Failed to save FHIR bundle.",
+        status: 500,
+      });
+    });
+  });
+
+  describe("delete blob", () => {
+    it("should return 200 when deleting from s3 succeeds", async () => {
+      process.env.ECR_BUCKET_NAME = "bucket";
+      process.env.SOURCE = "s3";
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 200 },
+      });
+
+      const result = await deleteFromS3(fileName);
+
+      expect(result).toEqual({
+        message: "Success. Deleted FHIR bundle.",
+        status: 200,
+      });
+      expect(s3Client.send).toHaveBeenCalledOnce();
+    });
+
+    it("should return 500 when deleting from s3 fails", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 500 },
+      });
+
+      const result = await deleteFromS3(fileName);
+
+      expect(result).toEqual({
+        message: "Failed to delete FHIR bundle.",
         status: 500,
       });
     });

--- a/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
+++ b/containers/ecr-viewer/src/app/tests/data/blobStorage/s3Client.test.ts
@@ -1,16 +1,26 @@
 /**
  * @jest-environment node
  */
-import { s3HealthCheck, s3Client } from "@/app/data/blobStorage/s3Client";
+import {
+  s3HealthCheck,
+  s3Client,
+  saveToS3,
+} from "@/app/data/blobStorage/s3Client";
 
 jest.mock("@aws-sdk/client-s3", () => ({
   S3Client: jest.fn().mockImplementation(() => ({
     send: jest.fn(),
   })),
   HeadBucketCommand: jest.fn(),
+  PutObjectCommand: jest.fn().mockImplementation((input) => ({
+    input,
+  })),
 }));
 
-describe("s3 health check", () => {
+const fhirBundleString = "{hi: 1}";
+const fileName = "test.json";
+
+describe("s3 client", () => {
   let mockSend: jest.Mock;
 
   beforeEach(() => {
@@ -24,31 +34,68 @@ describe("s3 health check", () => {
     process.env.SOURCE = "s3";
   });
 
-  it("should return UNDEFINED if SOURCE is not s3", async () => {
-    process.env.SOURCE = "azure";
-    expect(await s3HealthCheck()).toBeUndefined();
-  });
-  it("should return UP when health command succeeds", async () => {
-    process.env.SOURCE = "s3";
-    mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
+  describe("health check", () => {
+    it("should return UNDEFINED if SOURCE is not s3", async () => {
+      process.env.SOURCE = "azure";
+      expect(await s3HealthCheck()).toBeUndefined();
+    });
 
-    const result = await s3HealthCheck();
-    expect(result).toEqual("UP");
-  });
-  it("should return DOWN when health command fails", async () => {
-    jest.spyOn(console, "error").mockImplementation();
-    process.env.SOURCE = "s3";
-    mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 404 } });
+    it("should return UP when health command succeeds", async () => {
+      process.env.SOURCE = "s3";
+      mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
 
-    const result = await s3HealthCheck();
-    expect(result).toEqual("DOWN");
-  });
-  it("should return DOWN when s3 throws an error", async () => {
-    jest.spyOn(console, "error").mockImplementation();
-    process.env.SOURCE = "s3";
-    mockSend.mockRejectedValue(new Error("Connection failed"));
+      const result = await s3HealthCheck();
+      expect(result).toEqual("UP");
+    });
 
-    const result = await s3HealthCheck();
-    expect(result).toEqual("DOWN");
+    it("should return DOWN when health command fails", async () => {
+      jest.spyOn(console, "error").mockImplementation();
+      process.env.SOURCE = "s3";
+      mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 404 } });
+
+      const result = await s3HealthCheck();
+      expect(result).toEqual("DOWN");
+    });
+
+    it("should return DOWN when s3 throws an error", async () => {
+      jest.spyOn(console, "error").mockImplementation();
+      process.env.SOURCE = "s3";
+      mockSend.mockRejectedValue(new Error("Connection failed"));
+
+      const result = await s3HealthCheck();
+      expect(result).toEqual("DOWN");
+    });
+  });
+
+  describe("saveToS3", () => {
+    it("should return 200 when saving to s3 succeeds", async () => {
+      process.env.ECR_BUCKET_NAME = "bucket";
+      process.env.SOURCE = "s3";
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 200 },
+      });
+
+      const result = await saveToS3(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Success. Saved FHIR bundle.",
+        status: 200,
+      });
+      expect(s3Client.send).toHaveBeenCalledOnce();
+    });
+
+    it("should return 500 when saving to s3 fails", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 500 },
+      });
+
+      const result = await saveToS3(fhirBundleString, fileName);
+
+      expect(result).toEqual({
+        message: "Failed to save FHIR bundle.",
+        status: 500,
+      });
+    });
   });
 });

--- a/containers/ecr-viewer/tsconfig.json
+++ b/containers/ecr-viewer/tsconfig.json
@@ -24,12 +24,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    "node_modules/cypress/types/cypress.d.ts"
-  ],
-  "exclude": ["node_modules", "./cypress.config.ts", "cypress", "**/*.cy.tsx"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Handle rolling back fhir- or meta- data if the other fails when trying to save both.

Highlights:
* Kysely transactions roll back when an error is thrown, so check if fhir saving failed inside the transaction and throw an error if it does
* If the database saving throws an error, check if it was before rolling back the fhir data and if it was, roll back the fhir data
* Check if an eCR already exists and bail out early with a nicer error message than a 500
* move the blob saving/deleting code to the client files

## Related Issue

Fixes #69

## Acceptance Criteria

- [ ] When saveFhirData then no metadata should be saved
- [ ] When saveFhirMetadata then no bundle should be saved