### PR TITLE
fix: consistently format units in reference ranges

### DIFF
--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -6,6 +6,7 @@ import {
   ContactPoint,
   HumanName,
   PatientContact,
+  Quantity,
   RelatedPerson,
 } from "fhir/r4";
 
@@ -323,6 +324,32 @@ export const formatCodeableConcept = (
   }
 
   return undefined;
+};
+
+// Map from computer to human readable units
+const UNIT_MAP = new Map([
+  ["[lb_av]", "lb"],
+  ["[in_i]", "in"],
+  ["[in_us]", "in"],
+]);
+
+/**
+ * Takes a quantity and formats it into a string. Handles spacing of units and re-maps
+ * certain robot-looking units into human-looking units
+ * @param data the Quantity to format
+ * @returns formatted string
+ */
+export const formatQuantity = (
+  data: Quantity | undefined,
+): string | undefined => {
+  if (!data || !data.value) return;
+  let unit = data.unit || "";
+  unit = UNIT_MAP.get(unit) || unit;
+  const firstLetterRegex = /^[a-z]/i;
+  if (unit?.match(firstLetterRegex)) {
+    unit = " " + unit;
+  }
+  return `${data.value ?? ""}${unit}`;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -7,6 +7,7 @@ import {
   HumanName,
   PatientContact,
   Quantity,
+  Range,
   RelatedPerson,
 } from "fhir/r4";
 
@@ -350,6 +351,25 @@ export const formatQuantity = (
     unit = " " + unit;
   }
   return `${data.value ?? ""}${unit}`;
+};
+
+/**
+ * Takes a range and formats it into a string. Handles spacing of units and re-maps
+ * certain robot-looking units into human-looking units
+ * @param data the Range to format
+ * @returns formatted string
+ */
+export const formatRange = (data: Range | undefined): string | undefined => {
+  if (!data) return;
+  const low = formatQuantity(data.low);
+  const high = formatQuantity(data.high);
+  if (low && high) {
+    return `${low} - ${high}`;
+  } else if (low) {
+    return `>=${low}`;
+  } else if (high) {
+    return `<=${high}`;
+  }
 };
 
 /**

--- a/containers/ecr-viewer/src/app/tests/services/formatService.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/services/formatService.test.tsx
@@ -14,6 +14,8 @@ import {
   formatPatientContactList,
   formatCodeableConcept,
   formatAge,
+  formatQuantity,
+  formatRange,
 } from "@/app/services/formatService";
 
 describe("FormatService tests", () => {
@@ -658,6 +660,55 @@ describe("FormatService tests", () => {
 
       const actual = formatCodeableConcept(codeableConcept);
       expect(actual).toEqual(codeValue);
+    });
+  });
+
+  describe("formatQuantity", () => {
+    it("should handle missing data", () => {
+      expect(formatQuantity({})).toBeUndefined();
+    });
+
+    it("should handle missing unit", () => {
+      expect(formatQuantity({ value: 1.234 })).toBe("1.234");
+    });
+
+    it("should handle percent unit", () => {
+      expect(formatQuantity({ value: 1.234, unit: "%" })).toBe("1.234%");
+    });
+
+    it("should handle mapped unit", () => {
+      expect(formatQuantity({ value: 1.234, unit: "[lb_av]" })).toBe(
+        "1.234 lb",
+      );
+    });
+
+    it("should handle regular unit", () => {
+      expect(formatQuantity({ value: 1.234, unit: "mmol/L" })).toBe(
+        "1.234 mmol/L",
+      );
+    });
+  });
+
+  describe("formatRange", () => {
+    it("should handle missing data", () => {
+      expect(formatRange({})).toBeUndefined();
+    });
+
+    it("should low and high", () => {
+      expect(
+        formatRange({
+          low: { value: 1.234, unit: "%" },
+          high: { value: 2, unit: "[lb_av]" },
+        }),
+      ).toBe("1.234% - 2 lb");
+    });
+
+    it("should low only", () => {
+      expect(formatRange({ low: { value: 1.234 } })).toBe(">=1.234");
+    });
+
+    it("should high only", () => {
+      expect(formatRange({ high: { value: 1.234 } })).toBe("<=1.234");
     });
   });
 });

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -14,6 +14,7 @@ import {
   Identifier,
   Immunization,
   Observation,
+  ObservationReferenceRange,
   Organization,
   PatientCommunication,
   PatientContact,
@@ -130,7 +131,7 @@ export type PathTypes = {
   observationReferenceValue: string;
   observationComponent: string;
   observationValue: string;
-  observationReferenceRange: string;
+  observationReferenceRange: ObservationReferenceRange;
   observationDeviceReference: Reference;
   observationNote: string;
   observationOrganism: string;
@@ -536,7 +537,10 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "string",
     path: "(valueQuantity.value.toString() | valueString | valueCodeableConcept.coding.display | iif(valueQuantity.unit.exists(), iif(valueQuantity.unit = '%', valueQuantity.unit, ' ' + valueQuantity.unit), '') | iif(interpretation.coding.display.exists(), ' (' + interpretation.coding.display + ')', '')).join('')",
   },
-  observationReferenceRange: { type: "string", path: "referenceRange.text" },
+  observationReferenceRange: {
+    type: "ObservationReferenceRange",
+    path: "referenceRange",
+  },
   observationDeviceReference: { type: "string", path: "device.reference" },
   observationNote: { type: "string", path: "note.text" },
   observationOrganism: { type: "string", path: "code.coding.display.first()" },

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -6,13 +6,17 @@ import {
   Coding,
   Element,
   FhirResource,
+  ObservationReferenceRange,
   Quantity,
   Resource,
 } from "fhir/r4";
 import { Context, evaluate as fhirPathEvaluate } from "fhirpath";
 import fhirpath_r4_model from "fhirpath/fhir-context/r4";
 
-import { formatCodeableConcept } from "@/app/services/formatService";
+import {
+  formatCodeableConcept,
+  formatQuantity,
+} from "@/app/services/formatService";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
 
@@ -198,13 +202,6 @@ export const evaluateOne = <K extends keyof PathTypes>(
   );
 };
 
-// Map from computer to human readable units
-const UNIT_MAP = new Map([
-  ["[lb_av]", "lb"],
-  ["[in_i]", "in"],
-  ["[in_us]", "in"],
-]);
-
 /**
  * Evaluates the FHIR path and formats it as an appropriate string value (may be empty). Supports
  * choice elements (e.g. using `.value` in path to get valueString or valueCoding) or
@@ -242,19 +239,22 @@ export const evaluateValue = (
 
   if (originalValuePath === "Quantity") {
     const data: Quantity = originalValue;
-    let unit = data.unit || "";
-    unit = UNIT_MAP.get(unit) || unit;
-    const firstLetterRegex = /^[a-z]/i;
-    if (unit?.match(firstLetterRegex)) {
-      unit = " " + unit;
-    }
-    value = `${data.value ?? ""}${unit}`;
+    value = formatQuantity(data) || "";
   } else if (originalValuePath === "CodeableConcept") {
     const data: CodeableConcept = originalValue;
     value = formatCodeableConcept(data) ?? "";
   } else if (originalValuePath === "Coding") {
     const data: Coding = originalValue;
     value = data?.display || data?.code || "";
+  } else if (originalValuePath === "Observation.referenceRange") {
+    const data: ObservationReferenceRange = originalValue;
+    const low = formatQuantity(data.low);
+    const high = formatQuantity(data.high);
+    if (low || high) {
+      value = `${low} - ${high}`;
+    } else {
+      value = data.text || "";
+    }
   } else if (typeof originalValue === "object") {
     console.log(`Not implemented for ${originalValuePath}`);
   }

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -16,6 +16,7 @@ import fhirpath_r4_model from "fhirpath/fhir-context/r4";
 import {
   formatCodeableConcept,
   formatQuantity,
+  formatRange,
 } from "@/app/services/formatService";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
@@ -248,13 +249,8 @@ export const evaluateValue = (
     value = data?.display || data?.code || "";
   } else if (originalValuePath === "Observation.referenceRange") {
     const data: ObservationReferenceRange = originalValue;
-    const low = formatQuantity(data.low);
-    const high = formatQuantity(data.high);
-    if (low || high) {
-      value = `${low} - ${high}`;
-    } else {
-      value = data.text || "";
-    }
+    const range = formatRange(data);
+    value = range || data.text || "";
   } else if (typeof originalValue === "object") {
     console.log(`Not implemented for ${originalValuePath}`);
   }

--- a/test-data/fhir/BundleLab.json
+++ b/test-data/fhir/BundleLab.json
@@ -833,7 +833,7 @@
               "unit": "mmol/L",
               "value": 145
             },
-            "text": "138 mmol/L - 145 mmol/L"
+            "text": "138mmol/L - 145 mmol/L"
           }
         ],
         "effectiveDateTime": "2000-01-20T02:42:28Z"


### PR DESCRIPTION
# PULL REQUEST

## Summary

Format observation reference ranges consistent with other quantities (when low/high available)

## Related Issue

Fixes #103
