### PR TITLE
feat: add optional flag to return bundle from process-zip

### DIFF
--- a/containers/ecr-viewer/api-documentation.md
+++ b/containers/ecr-viewer/api-documentation.md
@@ -1,4 +1,6 @@
-# View eCR
+# eCR Viewer API Documentatino
+
+## View eCR
 
 Display an eCR
 
@@ -16,11 +18,11 @@ Display an eCR
 
 **Permissions required** : None
 
-## Example Architecture
+### Example Architecture
 
 ![NBS -> ECR Viewer sequence diagram](assets/nbs-ecr-viewer-arch.png)
 
-## Success Response
+### Success Response
 
 **Condition** : eCR exists and authentication is valid.
 
@@ -28,7 +30,7 @@ Display an eCR
 
 **Content** : eCR will be displayed to the user
 
-## Error Responses
+### Error Responses
 
 **Condition** : eCR does not exist with `id`
 
@@ -36,10 +38,51 @@ Display an eCR
 
 **Content** : Error will be displayed to user
 
-### Or
+#### Or
 
 **Condition** : Authentication is invalid
 
 **Code** : `401 UNAUTHORIZED`
 
 **Content** : Error will be displayed to user
+
+## Process eCR zip
+
+Process a zip file containing an eCR/RR pair
+
+**URL** : `/process-zip`
+
+**POST Form Fields** :
+
+- `upload_file=[File]` where the file is a zip containing an eCR named `CDA_eICR.xml` and optionally a reportability response named `CDA_RR.xml`.
+- `return_fhir_bundle=[true|false]` By default, the fhir bundle is not returned. Set this field to `"true"` to have the response include the `bundle` field with the FHIR json object. OPTIONAL.
+
+**Method** : `POST`
+
+**Auth required** : Coming Soon
+
+**Permissions required** : None
+
+### Success Response
+
+**Condition** : eCR was processed and saved to storage. If metadata database is enabled, metadata was saved to relational database.
+
+**Code** : `200 OK`
+
+**Content** : `message` and optionally `bundle` if requested
+
+### Error Responses
+
+**Condition** : eCR failed to process or metadata failed to save if enabled
+
+**Code** : `400`
+
+**Content** : `message` with details on error
+
+#### Or
+
+**Condition** : eCR already processed
+
+**Code** : `409 CONFLICT`
+
+**Content** : `message` with details on error

--- a/containers/ecr-viewer/api-documentation.md
+++ b/containers/ecr-viewer/api-documentation.md
@@ -4,7 +4,7 @@
 
 Display an eCR
 
-**URL** : `/view-data?id=:id&snomed-code=:snomed&auth=:auth`
+**URL** : `/ecr-viewer/view-data?id=:id&snomed-code=:snomed&auth=:auth`
 
 **URL Parameters** :
 
@@ -50,7 +50,7 @@ Display an eCR
 
 Process a zip file containing an eCR/RR pair
 
-**URL** : `/process-zip`
+**URL** : `/ecr-viewer/api/process-zip`
 
 **POST Form Fields** :
 
@@ -62,6 +62,16 @@ Process a zip file containing an eCR/RR pair
 **Auth required** : Coming Soon
 
 **Permissions required** : None
+
+### Example
+
+Process an eCR (e.g. `seed-scripts/baseECR/star-wars/yoda-zika-v1-positive`) and have the processed FHIR bundle returned.
+
+```sh
+curl --location '<DIBBS_URL>/ecr-viewer/api/process-zip' \
+--form 'upload_file=@"<PATH_TO_ECR_ZIP_FILE>";type=application/zip' \
+--form 'return_fhir_bundle=true'
+```
 
 ### Success Response
 

--- a/containers/ecr-viewer/seed-scripts/create-seed-data.py
+++ b/containers/ecr-viewer/seed-scripts/create-seed-data.py
@@ -1,5 +1,6 @@
 import argparse
 import io
+import json
 import os
 import zipfile
 
@@ -59,8 +60,9 @@ def _process_files():
             zip_buffer = zip_folder(folder_path)
 
             files = [("upload_file", (f"{folder}.zip", zip_buffer, "application/zip"))]
-            print(files)
-            request = grequests.post(UPLOAD_URL, files=files)
+            request = grequests.post(
+                UPLOAD_URL, files=files, data={"return_fhir_bundle": True}
+            )
 
             requests.append(request)
             folder_paths.append(folder_path)
@@ -83,9 +85,20 @@ def _process_files():
         if response.status_code != 200:
             failed.append(folder_path)
             print(
-                f"Received response {n} of {num_requests} - Failed to upload {folder_path}. Status: {response.status_code}"
+                f"Received response {n} of {num_requests} - Failed to upload {folder_path}. Status: {response.status_code}. Body: {json.dumps(response.json())}"
             )
         else:
+            response_json = response.json()
+            if "bundle" in response_json:
+                with open(
+                    os.path.join(folder_path, "bundle.json"),
+                    "w",
+                ) as fhir_file:
+                    json.dump(
+                        response_json["bundle"],
+                        fhir_file,
+                        indent=4,
+                    )
             print(
                 f"Received response {n} of {num_requests} - Successfully uploaded {folder_path}"
             )

--- a/containers/ecr-viewer/src/app/api/process-zip/route.ts
+++ b/containers/ecr-viewer/src/app/api/process-zip/route.ts
@@ -9,6 +9,10 @@ const schema = z.object({
     .refine((file) => file.type === "application/zip", {
       message: "File must be a zip",
     }),
+  return_fhir_bundle: z
+    .string()
+    .optional()
+    .transform((v) => v?.toLowerCase()),
 });
 
 /**
@@ -19,8 +23,11 @@ const schema = z.object({
 export async function POST(request: NextRequest) {
   try {
     const body = schema.parse(Object.fromEntries(await request.formData()));
-    const { message, status } = await processZip(body.upload_file);
-    return NextResponse.json({ message }, { status });
+    const { status, ...payload } = await processZip(
+      body.upload_file,
+      body.return_fhir_bundle === "true",
+    );
+    return NextResponse.json(payload, { status });
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/containers/ecr-viewer/src/app/api/process-zip/service.ts
+++ b/containers/ecr-viewer/src/app/api/process-zip/service.ts
@@ -96,9 +96,10 @@ const saveToSource = (
 /**
  * Save the zip via orchestration
  * @param file - the file to send to orchestration
+ * @param returnBundle - whether to return the fhir bundle (default false)
  * @returns An object containing the status and message.
  */
-export const processZip = async (file: File) => {
+export const processZip = async (file: File, returnBundle: boolean = false) => {
   let orchestrationResp: BundleInfo;
   try {
     orchestrationResp = await getOrchestrationResponse(file);
@@ -110,5 +111,14 @@ export const processZip = async (file: File) => {
       status: 500,
     };
   }
-  return await saveToSource(orchestrationResp.ecr, orchestrationResp.metadata);
+  const res = await saveToSource(
+    orchestrationResp.ecr,
+    orchestrationResp.metadata,
+  );
+
+  if (returnBundle) {
+    return { ...res, bundle: orchestrationResp.ecr };
+  } else {
+    return res;
+  }
 };

--- a/containers/ecr-viewer/src/app/tests/api/process-zip/route.test.ts
+++ b/containers/ecr-viewer/src/app/tests/api/process-zip/route.test.ts
@@ -36,6 +36,19 @@ describe("POST Process Zip", () => {
     expect(await response.json()).toEqual({ message: "ok" });
   });
 
+  it("should return a 200 response when valid zip file and return fhir bundle flag provided", async () => {
+    const formData = new FormData();
+    formData.append("upload_file", mockFile);
+    formData.append("return_fhir_bundle", "True");
+    const request = createRequest(formData);
+    (processZip as jest.Mock).mockReturnValue({ message: "ok", status: 200 });
+
+    const response = await POST(request);
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({ message: "ok" });
+  });
+
   it("should return a 400 response when file is not a zip", async () => {
     const invalidFile = new File(["content"], "test.txt", {
       type: "text/plain",

--- a/containers/ecr-viewer/src/app/tests/api/process-zip/service.test.ts
+++ b/containers/ecr-viewer/src/app/tests/api/process-zip/service.test.ts
@@ -41,7 +41,7 @@ describe("processZip", () => {
 
     const response = await processZip(mockFile);
 
-    expect(response).toEqual({ status: 200, message: "Success" });
+    expect(response).toStrictEqual({ status: 200, message: "Success" });
     expect(saveWithMetadata).toHaveBeenCalledWith(
       mockEcr,
       "123",
@@ -66,7 +66,31 @@ describe("processZip", () => {
 
     const response = await processZip(mockFile);
 
-    expect(response).toEqual({ status: 200, message: "Success" });
+    expect(response).toStrictEqual({ status: 200, message: "Success" });
+    expect(saveFhirData).toHaveBeenCalledWith(mockEcr, "123", S3_SOURCE);
+  });
+
+  it("should return fhir bundle when requested", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        processed_values: {
+          responses: [{ stamped_ecr: { extended_bundle: mockEcr } }],
+        },
+      }),
+    });
+    (saveFhirData as jest.Mock).mockResolvedValue({
+      status: 200,
+      message: "Success",
+    });
+
+    const response = await processZip(mockFile, true);
+
+    expect(response).toStrictEqual({
+      status: 200,
+      message: "Success",
+      bundle: mockEcr,
+    });
     expect(saveFhirData).toHaveBeenCalledWith(mockEcr, "123", S3_SOURCE);
   });
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add an optional flag to the `process-zip` endpoint to enable returning the processed FHIR bundle

## Related Issue

Fixes #648