### PR TITLE
docs: minor cleanup and udpate CI to deploy the ecr-viewer docs instead of all

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -175,13 +175,14 @@ jobs:
         with:
           pattern: container-docs-*
           merge-multiple: true
-          path: ./docs/${{ needs.build-containers-for-release.outputs.version }}/containers
+          path: ./all-docs/${{ needs.build-containers-for-release.outputs.version }}/containers
 
-      - name: Copy to latest folder
+      - name: Copy to latest folder - copy ecr-viewer docs to main deployment folder
         run: |
-          rm -rf ./docs/latest
-          mkdir -p ./docs/latest/containers
-          cp -r ./docs/${{ needs.build-containers-for-release.outputs.version }}/containers/* ./docs/latest/containers
+          rm -rf ./all-docs/latest
+          mkdir -p ./all-docs/latest/containers
+          cp -r ./all-docs/${{ needs.build-containers-for-release.outputs.version }}/containers/* ./all-docs/latest/containers
+          cp -r ./all-docs/latest/containers/ecr-viewer ./docs/
 
       - name: Commit New Documentation
         uses: EndBug/add-and-commit@v9

--- a/containers/ecr-viewer/README.md
+++ b/containers/ecr-viewer/README.md
@@ -1,6 +1,8 @@
 # Getting Started with DIBBs eCR Viewer
 
-If you're looking to contribute to development on the eCR Viewer, you're in the right place. If you're trying to run a deployment of the Viewer instead, please refer to our [guide.md](./guide.md)
+**If you're trying to deploy the Viewer, please refer to our [Setup Guide](./guide.md)**
+
+If you're looking to contribute to development on the eCR Viewer, you're in the right place. 
 
 ## Introduction
 

--- a/containers/ecr-viewer/README.md
+++ b/containers/ecr-viewer/README.md
@@ -2,7 +2,7 @@
 
 **If you're trying to deploy the Viewer, please refer to our [Setup Guide](./guide.md)**
 
-If you're looking to contribute to development on the eCR Viewer, you're in the right place. 
+If you're looking to contribute to development on the eCR Viewer, you're in the right place.
 
 ## Introduction
 

--- a/containers/ecr-viewer/typedoc.json
+++ b/containers/ecr-viewer/typedoc.json
@@ -25,5 +25,6 @@
     "tsx",
     "typescript"
   ],
-  "plugin": ["typedoc-plugin-mermaid"]
+  "plugin": ["typedoc-plugin-mermaid"],
+  "name": "eCR Viewer"
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Update the deployment CI for docs to put all docs in the `all-docs` folder, then copy out the latest ecr viewer docs to the `/docs` folder for deployment to our github page. Plus minor cleanup to docs to make links/names a wee bit nicer.

## Related Issue

Fixes #655

## Acceptance Criteria

* New guide is available on Github pages site (replacing current, old static site)
* When a new release is cut, this triggers a new publication of the guide

## Additional Information

We could just stop creating the docs for everything else, but I could see a world where they're useful for posterity, so for now I left them. Thoughts?
