### PR TITLE
chore: Update CODEOWNERS to team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @dibbs-ecr-viewer-reviewers
+*       @@CDCgov/dibbs-ecr-viewer-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @@CDCgov/dibbs-ecr-viewer-reviewers
+*       @CDCgov/dibbs-ecr-viewer-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @akasper @angelathe @austin-hall-skylight @gordonfarrell @JNygaard-Skylight @mcmcgrath13 
+*       @dibbs-ecr-viewer-reviewers


### PR DESCRIPTION
# PULL REQUEST

## Summary

Change the code owners to use the team, which has round robin PR reviews enabled