### PR TITLE
fix: eICR Processing Info render bug

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/EcrMetadata.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/EcrMetadata.test.tsx
@@ -163,10 +163,8 @@ describe("ECR Metadata", () => {
         eRSDProcessingInfo={undefined}
         eCRCustodianDetails={ecrCustodianDetails}
         eicrAuthorDetails={eicrAuthorDetails}
-      />
+      />,
     );
-    expect(
-      screen.queryByText("Warning")
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Warning")).not.toBeInTheDocument();
   });
 });

--- a/containers/ecr-viewer/src/app/tests/components/EcrMetadata.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/EcrMetadata.test.tsx
@@ -155,4 +155,18 @@ describe("ECR Metadata", () => {
       screen.getByText("No reportable condition found"),
     ).toBeInTheDocument();
   });
+  it("should not render eRSD Processing Info section if no eRSD Processing Info is available", () => {
+    render(
+      <EcrMetadata
+        eicrDetails={eicrDetails}
+        rrDetails={rrConditionsList}
+        eRSDProcessingInfo={undefined}
+        eCRCustodianDetails={ecrCustodianDetails}
+        eicrAuthorDetails={eicrAuthorDetails}
+      />
+    );
+    expect(
+      screen.queryByText("Warning")
+    ).not.toBeInTheDocument()
+  });
 });

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrMetadata.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrMetadata.test.tsx.snap
@@ -234,10 +234,10 @@ exports[`ECR Metadata should match snapshot 1`] = `
                   </tr>
                 </tbody>
               </table>
+              <div
+                class="section__line_gray"
+              />
             </div>
-            <div
-              class="section__line_gray"
-            />
           </div>
         </div>
         <div

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { Bundle } from "fhir/r4";
 
 import {
-  ERSDInfo,
   evaluateEcrMetadata,
 } from "@/app/services/ecrMetadataService";
 import {

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -160,7 +160,7 @@ export const getEcrDocumentAccordionItems = (
                 ecrMetadata.ecrCustodianDetails.availableData
               }
               rrDetails={ecrMetadata.rrDetails}
-              eRSDProcessingInfo={ecrMetadata.eRSDProcessingInfo as ERSDInfo}
+              eRSDProcessingInfo={ecrMetadata.eRSDProcessingInfo}
               eicrAuthorDetails={ecrMetadata.eicrAuthorDetails
                 .filter((details) => details.availableData.length > 0)
                 .map((details) => details.availableData)}

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -2,9 +2,7 @@ import React from "react";
 
 import { Bundle } from "fhir/r4";
 
-import {
-  evaluateEcrMetadata,
-} from "@/app/services/ecrMetadataService";
+import { evaluateEcrMetadata } from "@/app/services/ecrMetadataService";
 import {
   evaluateDemographicsData,
   evaluateSocialData,

--- a/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
@@ -17,7 +17,7 @@ import { ToolTipElement } from "./ToolTipElement";
 interface EcrMetadataProps {
   rrDetails: ReportableConditions;
   eicrDetails: DisplayDataProps[];
-  eRSDProcessingInfo: ERSDInfo;
+  eRSDProcessingInfo: ERSDInfo | undefined;
   eCRCustodianDetails: DisplayDataProps[];
   eicrAuthorDetails: DisplayDataProps[][];
 }
@@ -50,15 +50,16 @@ const EcrMetadata = ({
       <AccordionSubSection title="RR Details">
         <ReportabilitySummary rrDetails={rrDetails} />
         <div className="section__line_gray" />
-        {eRSDProcessingInfo.success ? (
+        {eRSDProcessingInfo?.success ? (
           <div>
             <div className="header-data-title">{eRSDWarningTooltip}</div>
             <p className="text-italic text-base padding-bottom-0">
               eICR processed
             </p>
+            <div className="section__line_gray"></div>
           </div>
         ) : (
-          eRSDProcessingInfo.eRSDWarning && (
+          eRSDProcessingInfo?.eRSDWarning && (
             <div>
               <Table
                 bordered={false}
@@ -92,10 +93,10 @@ const EcrMetadata = ({
                   </tr>
                 </tbody>
               </Table>
+              <div className="section__line_gray"></div>
             </div>
           )
         )}
-        <div className="section__line_gray"></div>
       </AccordionSubSection>
 
       <AccordionSubSection title="eICR Details">


### PR DESCRIPTION
# PULL REQUEST
## Summary

- Fix bug where eCR wouldn't render because eICR Processing Info doesn't exist
- Update snapshot test, Add unit test 

## Related Issue
#643 

## Acceptance Criteria

- [ ] Sample 3.1 eCR should render in the Viewer. For this eCR, the `eICR Processing info` section should appear in the `Unavailable Data` section.

## Additional Information

N/A

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
