### PR TITLE
fix: migrations don't error out if database is previously set up

### DIFF
--- a/containers/ecr-viewer/src/app/data/metadataDb/utils/db-metadata.ts
+++ b/containers/ecr-viewer/src/app/data/metadataDb/utils/db-metadata.ts
@@ -14,9 +14,7 @@ export const getTables = async (
 ): Promise<string[]> => {
   const tables = await db.introspection.getTables();
   return tables
-    .filter(({ schema }) => {
-      schema === schemaName;
-    })
+    .filter(({ schema }) => schema === schemaName)
     .map(({ name }) => name);
 };
 


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Fixes bug where migrations failed when metadata database is already set up, causing the application to be unusable.

## Related Issue

N/A

## Acceptance Criteria

- [ ] Calling migrate-db when the database is already setup will return success and update the ecr_viewer_schema_migration table, telling the application that migrations are up to date.

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
