### PR TITLE
ci: fix docs commit flow

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -188,5 +188,7 @@ jobs:
       - name: Commit New Documentation
         uses: EndBug/add-and-commit@v9
         with:
-          add: docs
+          add: |
+            - docs
+            - all-docs
           message: Automated update of docs for ${{ needs.build-containers-for-release.outputs.version }} release.


### PR DESCRIPTION
# PULL REQUEST

## Summary

Commit both `docs` and `all-docs` folders to docs branch
