### PR TITLE
feat: Add hospital admission and discharge diagnosis data to viewer

### DIFF
--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_RR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_RR.xml
@@ -1,0 +1,367 @@
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc"
+  xmlns:voc="http://www.lantanagroup.com/voc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:hl7-org:v3 ../../schema/infrastructure/cda/CDA_SDTC.xsd">
+  <realmCode code="US" />
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.1.2" />
+  <id root="deb6d64f-a4ce-402d-ad4f-3d3d912ccdef" />
+  <code code="88085-6" codeSystem="2.16.840.1.113883.6.1"
+    displayName="Reportability response report Document Public health" />
+  <title>Reportability Response</title>
+  <effectiveTime value="20250206072818+0000" />
+  <confidentialityCode code="R" codeSystem="2.16.840.1.113883.5.25" displayName="Restricted" />
+  <languageCode code="en-US" />
+  <recordTarget>
+    <patientRole>
+      <id extension="PT-234798" root="2.16.840.1.113883.19.5" />
+      <id extension="555555585" root="2.16.840.1.113883.4.1" />
+      <id extension="CHAN-MOTH-001" root="2.16.840.1.113883.4.2" />
+      <addr use="H">
+        <streetAddressLine>500 Republica, Suite 456</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="HP" value="tel:+1-555-555-5585" />
+      <telecom use="WP" value="mailto:mon.mothma@senate.gr" />
+      <patient>
+        <name use="L">
+          <given>Dash</given>
+          <family>Rendar</family>
+        </name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"
+          displayName="Female" />
+        <birthTime value="19551001" />
+        <sdtc:deceasedInd value="false" />
+        <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+          codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+        <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+          codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+        <languageCommunication>
+          <languageCode code="en" />
+          <preferenceInd value="true" />
+        </languageCommunication>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <author>
+    <time value="20250206072818+0000" />
+    <assignedAuthor>
+      <id root="2.16.840.1.114222.4.1.217446" />
+      <addr>
+        <streetAddressLine>400 Galactic Core, Suite 200</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-400</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="WP" value="tel:555-777-0123" />
+      <assignedAuthoringDevice>
+        <manufacturerModelName displayName="Senate Health Authority" />
+        <softwareName displayName="Galactic Health Information System" />
+      </assignedAuthoringDevice>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.114222.4.1.217446" />
+        <name>Senate District Health Department</name>
+        <telecom use="WP" value="tel:555-777-0123" />
+        <addr>
+          <streetAddressLine>400 Galactic Core, Suite 200</streetAddressLine>
+          <city>Senate District</city>
+          <state>Galactic City</state>
+          <postalCode>GC-400</postalCode>
+          <country>Coruscant</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <informationRecipient typeCode="PRCP">
+    <intendedRecipient>
+      <id extension="987654321" root="2.16.840.1.113883.4.6" />
+      <addr use="WP">
+        <streetAddressLine>200 Corusca Street</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="WP" value="tel:555-777-0123" />
+      <telecom use="WP" value="mailto:dr.hemlock@grandrepublic.med.gc" />
+      <informationRecipient>
+        <name>
+          <prefix>Dr.</prefix>
+          <given>Royce</given>
+          <family>Hemlock</family>
+          <suffix>MD, GCS</suffix>
+        </name>
+      </informationRecipient>
+      <receivedOrganization>
+        <name>Grand Republic Medical Facility Clinic</name>
+        <addr use="WP">
+          <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+          <city>Senate District</city>
+          <state>Galactic City</state>
+          <postalCode>GC-500</postalCode>
+          <country>Coruscant</country>
+        </addr>
+      </receivedOrganization>
+    </intendedRecipient>
+  </informationRecipient>
+  <componentOf>
+    <encompassingEncounter>
+      <id extension="GRMF-20250205-001" root="2.16.840.1.113883.19" />
+      <code code="AMB" codeSystem="2.16.840.1.113883.5.4"
+        codeSystemName="HL7 ActEncounterCode" displayName="Ambulatory" />
+      <effectiveTime>
+        <low value="20250205" />
+        <high value="20250205" />
+      </effectiveTime>
+    </encompassingEncounter>
+  </componentOf>
+  <component>
+    <structuredBody>
+      <!-- Reportability Response Summary Section -->
+      <component>
+        <section>
+          <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.2.1" />
+          <code code="88084-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+          <title>Reportability Response Summary</title>
+          <text>
+            <content styleCode="Bold">Subject:</content>
+            <paragraph>Public Health Reporting Communication: one or more conditions are
+              reportable, or may be reportable, to public health.</paragraph>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="INT">
+              <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.20" />
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.7" />
+              <id root="a0fd6898-c2e1-4350-bfff-3c6e51a802af" />
+              <code code="131195008" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Subject of information" />
+              <text>Public Health Reporting Communication: one or more conditions are
+                reportable, or may be reportable, to public health.</text>
+              <statusCode code="completed" />
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!-- Initial Case Report Processing Information Section -->
+      <component>
+        <section>
+          <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.2.3" />
+          <code code="88082-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Initial case report processing information Document" />
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.9" />
+              <id root="6bff7990-f218-4f9d-a5aa-eb7afa6e9a3c" />
+              <code code="RR5" codeSystem="2.16.840.1.114222.4.5.232"
+                codeSystemName="PHIN VS (CDC Local Coding System)"
+                displayName="Received eICR Information" />
+              <statusCode code="completed" />
+              <effectiveTime value="20250206072818+0000" />
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOCCLIN" moodCode="EVN">
+                  <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.115" />
+                  <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.10" />
+                  <id root="999-86a8-4a9a-aec6-b615921178df" />
+                  <code code="55751-2" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="Public Health Case Report (eICR)" />
+                  <setId extension="8d86218e-0fea-11eb-8216-a80388425cfb"
+                    root="1.2.840.114350.1.13.380.3.7.1.1" />
+                  <versionNumber value="1" />
+                </externalDocument>
+              </reference>
+            </act>
+          </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.29" />
+              <id root="39d966b9-8a3a-4024-93d8-138e97d5898a" />
+              <code code="RRVS19" codeSystem="2.16.840.1.114222.4.5.274"
+                codeSystemName="PHIN VS (CDC Local Coding System)" displayName="eICR processed" />
+              <entryRelationship typeCode="SPRT">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.33" />
+                  <id root="80f7b4ff-4d96-46ef-ae8f-af1f9c1f206e" />
+                  <code code="RR10" codeSystem="2.16.840.1.114222.4.5.232"
+                    codeSystemName="PHIN Questions" displayName="eICR Validation Output" />
+                  <value mediaType="text/xml" xsi:type="ED">
+                    <Report xmlns="urn:aims-org:val">
+                      <validation-report>
+                        <status>complete</status>
+                        <time>2025-02-06T07:28:18Z</time>
+                      </validation-report>
+                    </Report>
+                  </value>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!-- Report Summary Section -->
+      <component>
+        <section>
+          <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.2.2" />
+          <code code="55112-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+          <title>Report Summary</title>
+          <text>
+            <content styleCode="Bold">Summary:</content>
+            <paragraph>Your organization electronically submitted an initial case report
+              to determine if reporting to public health is needed for a patient.</paragraph>
+            <paragraph>"Coronavirus infection (disorder)" is reportable to "Senate District
+              Health Department". The initial case report was sent to "Senate District
+              Health Department". Additional information may be required for this report.</paragraph>
+            <paragraph>
+              <content styleCode="Bold">"Coronavirus infection (disorder)" for
+                "Senate District Health Department"</content>
+            </paragraph>
+            <paragraph>Reporting is required immediately. Reporting to this Public
+              Health Agency is based on "Both patient home address and provider facility address"</paragraph>
+            <paragraph>
+              <content>&gt; Galactic Health Authority COVID-19 webpage (<linkHtml
+                  href="https://www.health.senate.gc/coronavirus">Information
+                  only</linkHtml>)</content>
+              <content>&gt; Senate District Health Department Epidemiology Web Page (<linkHtml
+                  href="https://www.health.senate.gc/epi/">Information
+                  only</linkHtml>)</content>
+            </paragraph>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="INT">
+              <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.20" />
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.8" />
+              <id root="3350332c-7d7b-465f-aa7e-fd1da3184540" />
+              <code code="304561000" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Informing health care professional (procedure)" />
+              <text>Your organization electronically submitted an initial case report
+                to determine if reporting to public health is needed for a patient.</text>
+              <statusCode code="completed" />
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.30" />
+              <code code="RR9" codeSystem="2.16.840.1.114222.4.5.232"
+                codeSystemName="PHIN Questions" displayName="Reportability response priority" />
+              <value code="RRVS15" codeSystem="2.16.840.1.114222.4.5.274"
+                codeSystemName="PHIN VS (CDC Local Coding System)"
+                displayName="Information Only" xsi:type="CD" />
+            </observation>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.34" />
+              <code code="RR11" codeSystem="2.16.840.1.114222.4.5.232"
+                codeSystemName="PHIN Questions"
+                displayName="Reportability Response Coded Information" />
+              <statusCode code="completed" />
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.12" />
+                  <id root="17f6392f-9340-45d3-a1c8-bc0a30d09f53" />
+                  <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                    codeSystemName="SNOMED" displayName="Condition">
+                    <translation code="75323-6" codeSystem="2.16.840.1.113883.6.1"
+                      codeSystemName="LOINC" displayName="Condition" />
+                  </code>
+                  <value code="840539006" codeSystem="2.16.840.1.113883.6.96"
+                    codeSystemName="SNOMED CT"
+                    displayName="Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+                    xsi:type="CD" />
+                  <entryRelationship typeCode="COMP">
+                    <organizer classCode="CLUSTER" moodCode="EVN">
+                      <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.13" />
+                      <id root="64d30ae1-09f9-4f17-858f-79dec6581396" />
+                      <code code="RRVS7" codeSystem="2.16.840.1.114222.4.5.274"
+                        codeSystemName="Location Relevance"
+                        displayName="Both patient home address and provider facility address" />
+                      <statusCode code="completed" />
+                      <participant typeCode="LOC">
+                        <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.4.3" />
+                        <participantRole>
+                          <id extension="sdh" root="2.16.840.1.113883.4.6" />
+                          <code code="RR12" codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions"
+                            displayName="Rules Authoring Agency" />
+                          <addr use="WP">
+                            <streetAddressLine>400 Galactic Core, Suite 200</streetAddressLine>
+                            <city>Senate District</city>
+                            <state>Galactic City</state>
+                            <postalCode>GC-400</postalCode>
+                            <country>Coruscant</country>
+                          </addr>
+                          <telecom use="WP" value="tel:555-777-0123" />
+                          <playingEntity>
+                            <name>Senate District Health Department</name>
+                          </playingEntity>
+                        </participantRole>
+                      </participant>
+                      <component typeCode="COMP">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId extension="2017-04-01"
+                            root="2.16.840.1.113883.10.20.15.2.3.19" />
+                          <id root="4b581cf3-2a6c-49f8-afcb-e437d0af7a9e" />
+                          <code code="RR1" codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions"
+                            displayName="Determination of reportability" />
+                          <value code="RRVS1" codeSystem="2.16.840.1.114222.4.5.274"
+                            codeSystemName="PHIN VS (CDC Local Coding System)"
+                            displayName="Reportable" xsi:type="CD" />
+                          <entryRelationship typeCode="RSON">
+                            <observation classCode="OBS" moodCode="EVN">
+                              <templateId extension="2017-04-01"
+                                root="2.16.840.1.113883.10.20.15.2.3.27" />
+                              <id root="a8e67405-dca7-4de3-83c3-93fc177a52dc" />
+                              <code code="RR3" codeSystem="2.16.840.1.114222.4.5.232"
+                                codeSystemName="PHIN Questions"
+                                displayName="Determination of reportability rule" />
+                              <value xsi:type="ST">All results of tests for detection of SARS-CoV-2
+                                nucleic acid in a clinical specimen by any method</value>
+                            </observation>
+                          </entryRelationship>
+                        </observation>
+                      </component>
+                      <component typeCode="COMP">
+                        <act classCode="ACT" moodCode="EVN">
+                          <templateId extension="2017-04-01"
+                            root="2.16.840.1.113883.10.20.15.2.3.20" />
+                          <id root="6c22e63c-a7e7-4baa-84da-cc9ff165ec18" />
+                          <code code="RRVS13" codeSystem="2.16.840.1.114222.4.5.274"
+                            codeSystemName="PHIN VS (CDC Local Coding System)"
+                            displayName="Outbreak- or Cluster related" />
+                          <priorityCode code="RRVS15" codeSystem="2.16.840.1.114222.4.5.274"
+                            codeSystemName="PHIN VS (CDC Local Coding System)"
+                            displayName="Information only" />
+                          <reference typeCode="REFR">
+                            <externalDocument classCode="DOC" moodCode="EVN">
+                              <templateId extension="2017-04-01"
+                                root="2.16.840.1.113883.10.20.15.2.3.17" />
+                              <code nullFlavor="OTH">
+                                <originalText>Galactic Health Authority COVID-19 webpage</originalText>
+                              </code>
+                              <text mediaType="text/html">
+                                <reference value="https://www.health.senate.gc/coronavirus" />
+                              </text>
+                            </externalDocument>
+                          </reference>
+                        </act>
+                      </component>
+                    </organizer>
+                  </entryRelationship>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_eICR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_eICR.xml
@@ -1,0 +1,870 @@
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc"
+  xmlns:voc="http://www.lantanagroup.com/voc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:hl7-org:v3 ../../schema/infrastructure/cda/CDA_SDTC.xsd">
+  <realmCode code="US" />
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.1.1" />
+  <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2" />
+  <id root="999-86a8-4a9a-aec6-b615921178df" />
+  <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+    displayName="Public Health Case Report" />
+  <title>Initial Public Health Case Report</title>
+  <effectiveTime value="20250205084339+0000" />
+  <confidentialityCode code="R" codeSystem="2.16.840.1.113883.5.25" displayName="Restricted" />
+  <languageCode code="en-US" />
+  <setId extension="iamfakesetid"
+    root="1.2.840.114350.1.13.380.3.7.1.1" />
+  <versionNumber value="1" />
+
+  <!-- Patient Information -->
+  <recordTarget>
+    <patientRole>
+      <id extension="PT-234798" root="2.16.840.1.113883.19.5" />
+      <id extension="555555585" root="2.16.840.1.113883.4.1" />
+      <id extension="CHAN-MOTH-001" root="2.16.840.1.113883.4.2" />
+      <addr use="H">
+        <streetAddressLine>500 Republica, Suite 456</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="HP" value="tel:+1-555-555-5585" />
+      <telecom use="WP" value="mailto:mon.mothma@senate.gr" />
+      <patient>
+        <name use="L">
+          <given>Dash</given>
+          <family>Rendar</family>
+        </name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"
+          displayName="Female" />
+        <birthTime value="19551001" />
+        <sdtc:deceasedInd value="false" />
+        <maritalStatusCode code="M" displayName="Married"
+          codeSystem="2.16.840.1.113883.1.11.12212"
+          codeSystemName="MaritalStatusCode" />
+        <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+          codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+        <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+          codeSystemName="Race &amp; Ethnicity - CDC"
+          displayName="Not Hispanic or Latino" />
+        <languageCommunication>
+          <languageCode code="en" />
+          <preferenceInd value="true" />
+          <proficiencyLevelCode code="E" codeSystem="2.16.840.1.113883.1.11.12199"
+            displayName="Excellent" />
+        </languageCommunication>
+      </patient>
+    </patientRole>
+  </recordTarget>
+
+  <!-- Author Information -->
+  <author>
+    <time value="20250205084339+0000" />
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.3.72.5.20" />
+      <code code="163WX0200X" codeSystem="2.16.840.1.113883.6.101"
+        displayName="Registered Nurse" />
+      <addr use="WP">
+        <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="WP" value="tel:555-777-0123" />
+      <assignedAuthoringDevice>
+        <manufacturerModelName displayName="Grand Republic Medical Systems" />
+        <softwareName>GR-EHR-50.2.1</softwareName>
+      </assignedAuthoringDevice>
+    </assignedAuthor>
+  </author>
+
+  <!-- Legal Authenticator -->
+  <legalAuthenticator>
+    <time value="20250205084339+0000" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id extension="987654321" root="2.16.840.1.113883.4.6" />
+      <addr use="WP">
+        <streetAddressLine>200 Corusca Street</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom use="WP" value="tel:555-777-0123" />
+      <assignedPerson>
+        <name>
+          <prefix>Dr.</prefix>
+          <given>Royce</given>
+          <family>Hemlock</family>
+          <suffix>MD, GCS</suffix>
+        </name>
+      </assignedPerson>
+    </assignedEntity>
+  </legalAuthenticator>
+
+  <!-- Custodian -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+        <name>Grand Republic Medical Facility Clinic</name>
+        <telecom use="WP" value="tel:555-777-0123" />
+        <addr use="WP">
+          <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+          <city>Senate District</city>
+          <state>Galactic City</state>
+          <postalCode>GC-500</postalCode>
+          <country>Coruscant</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+
+  <!-- Emergency Contact -->
+  <participant typeCode="IND">
+    <time nullFlavor="UNK" />
+    <associatedEntity classCode="ECON">
+      <id root="2.16.840.1.113883.19.5.9999.456" />
+      <addr use="H">
+        <streetAddressLine>500 Republica, Suite 460</streetAddressLine>
+        <city>Senate District</city>
+        <state>Galactic City</state>
+        <postalCode>GC-500</postalCode>
+        <country>Coruscant</country>
+      </addr>
+      <telecom value="tel:+1-555-555-8858" use="MC" />
+      <associatedPerson>
+        <name use="L">
+          <prefix>Mr</prefix>
+          <given>Perrin</given>
+          <family>Fertha</family>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+
+  <!-- Encounter Information -->
+  <componentOf>
+    <encompassingEncounter>
+      <id extension="GRMF-20250205-001" root="2.16.840.1.113883.19" />
+      <code code="AMB" codeSystem="2.16.840.1.113883.5.4"
+        codeSystemName="HL7 ActEncounterCode" displayName="Ambulatory" />
+      <effectiveTime>
+        <low value="20250205" />
+        <high value="20250205" />
+      </effectiveTime>
+      <responsibleParty>
+        <assignedEntity>
+          <id extension="987654321" root="2.16.840.1.113883.4.6" />
+          <addr use="WP">
+            <streetAddressLine>200 Corusca Street</streetAddressLine>
+            <city>Senate District</city>
+            <state>Galactic City</state>
+            <postalCode>GC-500</postalCode>
+            <country>Coruscant</country>
+          </addr>
+          <telecom use="WP" value="tel:555-777-0123" />
+          <assignedPerson>
+            <name>
+              <prefix>Dr.</prefix>
+              <given>Royce</given>
+              <family>Hemlock</family>
+              <suffix>MD, GCS</suffix>
+            </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+            <name>Grand Republic Medical Facility Clinic</name>
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <country>Coruscant</country>
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </responsibleParty>
+      <location>
+        <healthCareFacility>
+          <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+          <code code="OF" codeSystem="2.16.840.1.113883.5.111"
+            codeSystemName="HL7RoleCode" displayName="Outpatient Facility" />
+          <location>
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <country>Coruscant</country>
+            </addr>
+          </location>
+          <serviceProviderOrganization>
+            <name>Grand Republic Medical Facility Clinic</name>
+            <telecom use="WP" value="tel:555-777-0123" />
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <country>Coruscant</country>
+            </addr>
+          </serviceProviderOrganization>
+        </healthCareFacility>
+      </location>
+    </encompassingEncounter>
+  </componentOf>
+
+  <!-- Clinical Content -->
+  <!-- Continuing from previous structuredBody opening -->
+  <component>
+    <structuredBody>
+      <!-- 1. Encounters Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22" />
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <id root="a392ac71-f6ec-4811-b299-432ae6b316e2" />
+          <effectiveTime value="20250205085919" />
+          <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="History of encounters" />
+          <title>Encounters</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Encounter</th>
+                  <th>Date(s)</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_fd7ee2ec-4d8e-4169-aeb6-836731cc7201_ref">
+                  <td>Office outpatient visit 15 minutes</td>
+                  <td>02/05/2025</td>
+                  <td>Grand Republic Medical Facility Clinic</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49" />
+              <id root="fd7ee2ec-4d8e-4169-aeb6-836731cc7201" />
+              <code code="99213" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4"
+                displayName="Office outpatient visit 15 minutes" />
+              <effectiveTime value="20250205" />
+            </encounter>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Admission Diagnosis -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.43" extension="2015-08-01"/>
+          <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" displayName="Hospital Admission Diagnosis">
+            <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1" displayName="Admission Diagnosis"></translation>
+          </code>
+          <title>HOSPITAL ADMISSION DIAGNOSIS</title>
+          <text>Khovid19</text>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.34" extension="2015-08-01" />
+              <id root="5a784260-6856-4f38-9638-80c751aff2fb" />
+              <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Hospital Admission Diagnosis" />
+              <statusCode code="active" />
+              <effectiveTime>
+                <low value="20090303" />
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ" inversionInd="false">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11e3-9c78-0800200c9a67" />
+                  <code code="64572001" displayName="Condition"
+                        codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                    <translation code="409586006" displayName="Complaint"
+                                 codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                  </code>
+                  <text>Potential exposure to SARS-CoV-2</text>
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <low value="20250205" />
+                  </effectiveTime>
+                  <value xsi:type="CD" code="840539006"
+                         displayName="Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+                         codeSystem="2.16.840.1.113883.6.96" />
+
+                  <!-- Added entryRelationship for Infectious Disease Encounter -->
+                  <entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <id root="4adc1020-7b14-11ee-b962-0242ac120002" />
+                      <code code="186747009"
+                            codeSystem="2.16.840.1.113883.6.96"
+                            codeSystemName="SNOMED CT"
+                            displayName="Patient encountered problem - Infectious disease">
+                        <translation code="V01.79"
+                                     codeSystem="2.16.840.1.113883.6.103"
+                                     codeSystemName="ICD-9-CM"
+                                     displayName="Contact with and (suspected) exposure to other viral diseases" />
+                        <translation code="Z20.828"
+                                     codeSystem="2.16.840.1.113883.6.90"
+                                     codeSystemName="ICD-10-CM"
+                                     displayName="Contact with and (suspected) exposure to other viral communicable diseases" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20250205" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="186747009"
+                             codeSystem="2.16.840.1.113883.6.96"
+                             displayName="Patient encountered problem - Infectious disease" />
+                      <author>
+                        <time value="20250205084339+0000" />
+                        <assignedAuthor>
+                          <id extension="987654321" root="2.16.840.1.113883.4.6" />
+                          <addr use="WP">
+                            <streetAddressLine>200 Corusca Street</streetAddressLine>
+                            <city>Senate District</city>
+                            <state>Galactic City</state>
+                            <postalCode>GC-500</postalCode>
+                            <country>Coruscant</country>
+                          </addr>
+                          <telecom use="WP" value="tel:555-777-0123" />
+                          <assignedPerson>
+                            <name>
+                              <prefix>Dr.</prefix>
+                              <given>Royce</given>
+                              <family>Hemlock</family>
+                              <suffix>MD, GCS</suffix>
+                            </name>
+                          </assignedPerson>
+                          <representedOrganization>
+                            <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                            <name>Grand Republic Medical Facility Clinic</name>
+                            <telecom use="WP" value="tel:555-777-0123" />
+                            <addr use="WP">
+                              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+                              <city>Senate District</city>
+                              <state>Galactic City</state>
+                              <postalCode>GC-500</postalCode>
+                              <country>Coruscant</country>
+                            </addr>
+                          </representedOrganization>
+                        </assignedAuthor>
+                      </author>
+                    </observation>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- Discharge Diagnosis -->
+      <component>
+        <section>
+          <!-- Discharge Diagnosis Section Template Id -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.24" extension="2015-08-01" />
+          <code code="11535-2" displayName="Hospital Discharge Diagnosis"
+                codeSystem="2.16.840.1.113883.6.1"
+                codeSystemName="LOINC">
+            <translation code="78375-3" displayName="Discharge Diagnosis"
+                         codeSystem="2.16.840.1.113883.6.1"
+                         codeSystemName="LOINC"></translation>
+          </code>
+          <title>Discharge Diagnosis</title>
+          <text>Diverticula of intestine</text>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!-- Hospital discharge Diagnosis act -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.33" extension="2015-08-01"/>
+              <id root="5a784260-6856-4f38-9638-80c751aff2fb" />
+              <code code="11535-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HOSPITAL DISCHARGE DIAGNOSIS" />
+              <statusCode code="active" />
+              <effectiveTime>
+                <low value="201209091904-0400" />
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ" inversionInd="false">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11e3-9c78-0800200c9a67" />
+                  <code code="64572001" displayName="Condition"
+                        codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                    <translation code="409586006" displayName="Complaint"
+                                 codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                  </code>
+                  <text>Potential exposure to SARS-CoV-2</text>
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <low value="20250205" />
+                  </effectiveTime>
+                  <value xsi:type="CD" code="840539006"
+                         displayName="Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+                         codeSystem="2.16.840.1.113883.6.96" />
+
+                  <!-- Added entryRelationship for Infectious Disease Encounter -->
+                  <entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <id root="4adc1020-7b14-11ee-b962-0242ac120002" />
+                      <code code="186747009"
+                            codeSystem="2.16.840.1.113883.6.96"
+                            codeSystemName="SNOMED CT"
+                            displayName="Patient encountered problem - Infectious disease">
+                        <translation code="V01.79"
+                                     codeSystem="2.16.840.1.113883.6.103"
+                                     codeSystemName="ICD-9-CM"
+                                     displayName="Contact with and (suspected) exposure to other viral diseases" />
+                        <translation code="Z20.828"
+                                     codeSystem="2.16.840.1.113883.6.90"
+                                     codeSystemName="ICD-10-CM"
+                                     displayName="Contact with and (suspected) exposure to other viral communicable diseases" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20250205" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="186747009"
+                             codeSystem="2.16.840.1.113883.6.96"
+                             displayName="Patient encountered problem - Infectious disease" />
+                      <author>
+                        <time value="20250205084339+0000" />
+                        <assignedAuthor>
+                          <id extension="987654321" root="2.16.840.1.113883.4.6" />
+                          <addr use="WP">
+                            <streetAddressLine>200 Corusca Street</streetAddressLine>
+                            <city>Senate District</city>
+                            <state>Galactic City</state>
+                            <postalCode>GC-500</postalCode>
+                            <country>Coruscant</country>
+                          </addr>
+                          <telecom use="WP" value="tel:555-777-0123" />
+                          <assignedPerson>
+                            <name>
+                              <prefix>Dr.</prefix>
+                              <given>Royce</given>
+                              <family>Hemlock</family>
+                              <suffix>MD, GCS</suffix>
+                            </name>
+                          </assignedPerson>
+                          <representedOrganization>
+                            <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                            <name>Grand Republic Medical Facility Clinic</name>
+                            <telecom use="WP" value="tel:555-777-0123" />
+                            <addr use="WP">
+                              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+                              <city>Senate District</city>
+                              <state>Galactic City</state>
+                              <postalCode>GC-500</postalCode>
+                              <country>Coruscant</country>
+                            </addr>
+                          </representedOrganization>
+                        </assignedAuthor>
+                      </author>
+                    </observation>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+
+      <!-- 2. History of Present Illness Section -->
+      <component>
+        <section>
+          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+          <id root="b47c4891-d48f-42c3-9f92-54c3c7d66d42" />
+          <effectiveTime value="20250205085919" />
+          <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="History of Present Illness" />
+          <title>History of Present Illness</title>
+          <text>Patient presents with concerns about potential viral exposure.</text>
+        </section>
+      </component>
+
+      <!-- 3. Medications Administered Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+          <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.38" />
+          <id root="c5638e31-8485-4cef-b860-7275b8267a93" />
+          <effectiveTime value="20250205085919" />
+          <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Medications Administered" />
+          <title>Medications Administered</title>
+          <text>No medications administered during this encounter.</text>
+        </section>
+      </component>
+
+      <!-- 4. Problems Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.5.1" />
+          <id root="d89f2c46-1824-4ff7-9f55-8498c3b7aa54" />
+          <effectiveTime value="20250206041023" />
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Problem List" />
+          <title>Problems</title>
+          <text>
+            <paragraph>Potential exposure to SARS-CoV-2 with confirmed infectious disease encounter</paragraph>
+          </text>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+              <id root="ab1791b0-5c71-11e3-9c78-0800200c9a66" />
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
+              <statusCode code="active" />
+              <effectiveTime>
+                <low value="20250205" />
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11e3-9c78-0800200c9a67" />
+                  <code code="64572001" displayName="Condition"
+                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                    <translation code="409586006" displayName="Complaint"
+                      codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                  </code>
+                  <text>Potential exposure to SARS-CoV-2</text>
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <low value="20250205" />
+                  </effectiveTime>
+                  <value xsi:type="CD" code="840539006"
+                    displayName="Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+                    codeSystem="2.16.840.1.113883.6.96" />
+
+                  <!-- Added entryRelationship for Infectious Disease Encounter -->
+                  <entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <id root="4adc1020-7b14-11ee-b962-0242ac120002" />
+                      <code code="186747009"
+                        codeSystem="2.16.840.1.113883.6.96"
+                        codeSystemName="SNOMED CT"
+                        displayName="Patient encountered problem - Infectious disease">
+                        <translation code="V01.79"
+                          codeSystem="2.16.840.1.113883.6.103"
+                          codeSystemName="ICD-9-CM"
+                          displayName="Contact with and (suspected) exposure to other viral diseases" />
+                        <translation code="Z20.828"
+                          codeSystem="2.16.840.1.113883.6.90"
+                          codeSystemName="ICD-10-CM"
+                          displayName="Contact with and (suspected) exposure to other viral communicable diseases" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20250205" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="186747009"
+                        codeSystem="2.16.840.1.113883.6.96"
+                        displayName="Patient encountered problem - Infectious disease" />
+                      <author>
+                        <time value="20250205084339+0000" />
+                        <assignedAuthor>
+                          <id extension="987654321" root="2.16.840.1.113883.4.6" />
+                          <addr use="WP">
+                            <streetAddressLine>200 Corusca Street</streetAddressLine>
+                            <city>Senate District</city>
+                            <state>Galactic City</state>
+                            <postalCode>GC-500</postalCode>
+                            <country>Coruscant</country>
+                          </addr>
+                          <telecom use="WP" value="tel:555-777-0123" />
+                          <assignedPerson>
+                            <name>
+                              <prefix>Dr.</prefix>
+                              <given>Royce</given>
+                              <family>Hemlock</family>
+                              <suffix>MD, GCS</suffix>
+                            </name>
+                          </assignedPerson>
+                          <representedOrganization>
+                            <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                            <name>Grand Republic Medical Facility Clinic</name>
+                            <telecom use="WP" value="tel:555-777-0123" />
+                            <addr use="WP">
+                              <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+                              <city>Senate District</city>
+                              <state>Galactic City</state>
+                              <postalCode>GC-500</postalCode>
+                              <country>Coruscant</country>
+                            </addr>
+                          </representedOrganization>
+                        </assignedAuthor>
+                      </author>
+                    </observation>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!-- 5. Reason for Visit Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.12" />
+          <id root="e1f39764-3c92-4b8e-a5d6-7890f456b123" />
+          <effectiveTime value="20250205085919" />
+          <code code="29299-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Reason for Visit" />
+          <title>Reason for Visit</title>
+          <text>
+            <paragraph>COVID-19 screening due to potential exposure</paragraph>
+          </text>
+        </section>
+      </component>
+
+      <!-- 6. Results Section (with trigger codes) -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.3" />
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.3.1" />
+          <id root="f2d48b52-5a31-4bf7-9cd8-912e3f678d45" />
+          <effectiveTime value="20250205085919" />
+          <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Relevant diagnostic tests and/or laboratory data" />
+          <title>Results</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Test</th>
+                  <th>Result</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_9890e2c3-019a-4168-8403-a0a069994440_ref">
+                  <td>SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with
+                    probe detection</td>
+                  <td>Detected</td>
+                  <td>02/05/2025</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1" />
+              <id root="2047cca3-559f-45da-8775-406538fa4815" />
+              <code code="94310-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                displayName="SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20250205" />
+                <high value="20250205" />
+              </effectiveTime>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2" />
+                  <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.2" />
+                  <id root="9890e2c3-019a-4168-8403-a0a069994440" />
+                  <code code="94310-0" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC"
+                    displayName="SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection"
+                    sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                    sdtc:valueSetVersion="20200429" xsi:type="CD" />
+                  <statusCode code="completed" />
+                  <effectiveTime value="20250205" />
+                  <value code="260373001" codeSystem="2.16.840.1.113883.6.96"
+                    codeSystemName="SNOMED-CT" displayName="Detected (qualifier value)"
+                    xsi:type="CD" />
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+      <!-- 7. Social History Section -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.17" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.17" />
+          <id root="g3e59c63-6b40-4d28-ae79-023f4789e567" />
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Social History" />
+          <title>Social History</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Social History Element</th>
+                  <th>Description</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Occupation</td>
+                  <td>Senator</td>
+                  <td>20250206</td>
+                </tr>
+                <tr>
+                  <td>Pregnancy Status</td>
+                  <td>No</td>
+                  <td>20250206</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38" />
+              <id root="4ff79772-5755-4deb-8992-ab827c731c6a" />
+              <code code="364703007" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Employment detail">
+                <!-- Adding LOINC translation -->
+                <translation code="11295-3" codeSystem="2.16.840.1.113883.6.1"
+                  codeSystemName="LOINC" displayName="Occupation history" />
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime value="20250206032811" />
+              <value code="410001" codeSystem="2.16.840.1.113883.6.96"
+                displayName="Senator" xsi:type="CD" />
+            </observation>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38" />
+              <id root="82f61228-21bc-4c0e-8491-d68bf0207d2f" />
+              <code code="442311008" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Pregnancy status">
+                <translation code="82810-3" codeSystem="2.16.840.1.113883.6.1"
+                  codeSystemName="LOINC" displayName="Pregnancy status" />
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime value="20250206032811" />
+              <value code="60001007" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Not pregnant" xsi:type="CD" />
+            </observation>
+          </entry>
+        </section>
+      </component>
+
+      <!-- 8. Immunizations Section (optional but recommended) -->
+      <component>
+        <section>
+          <id root="h4f60d74-7c51-5e39-bf8a-134g5890f678" />
+          <effectiveTime value="20250205223659" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.1" />
+          <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.2.1" />
+          <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="History of immunizations" />
+          <title>Immunizations</title>
+          <text>
+            <table border="1" width="100%">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Administration Dates</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><content ID="immunization1Name" />SARS-CoV-2 (COVID-19) vaccine, mRNA-LNP,
+                    spike protein</td>
+                  <td>Jan 2025</td>
+                  <td>Completed</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry>
+            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.52" />
+              <id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92" />
+              <text mediaType="text/xml">
+                <reference value="#immunization1" />
+              </text>
+              <statusCode code="completed" />
+              <effectiveTime value="20250115" />
+              <routeCode code="C28161" codeSystem="2.16.840.1.113883.3.26.1.1"
+                codeSystemName="National Cancer Institute (NCI) Thesaurus"
+                displayName="Intramuscular injection" />
+              <doseQuantity unit="ug" value="30" />
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.54" />
+                  <manufacturedMaterial>
+                    <code code="207" codeSystem="2.16.840.1.113883.12.292"
+                      codeSystemName="CVX"
+                      displayName="SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 30 mcg/0.3mL dose" />
+                    <lotNumberText>GR789456</lotNumberText>
+                  </manufacturedMaterial>
+                  <manufacturerOrganization>
+                    <name>Grand Republic Medical Systems</name>
+                  </manufacturerOrganization>
+                </manufacturedProduct>
+              </consumable>
+              <performer>
+                <assignedEntity>
+                  <id extension="987654321" root="2.16.840.1.113883.4.6" />
+                  <addr use="WP">
+                    <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+                    <city>Senate District</city>
+                    <state>Galactic City</state>
+                    <postalCode>GC-500</postalCode>
+                    <country>Coruscant</country>
+                  </addr>
+                  <telecom use="WP" value="tel:555-777-0123" />
+                  <assignedPerson>
+                    <name>
+                      <prefix>Dr.</prefix>
+                      <given>Royce</given>
+                      <family>Hemlock</family>
+                      <suffix>MD, GCS</suffix>
+                    </name>
+                  </assignedPerson>
+                  <representedOrganization>
+                    <id root="2.16.840.1.113883.19.5.9999.1394" />
+                    <name>Grand Republic Medical Facility Clinic</name>
+                    <telecom use="WP" value="tel:555-777-0123" />
+                    <addr use="WP">
+                      <streetAddressLine>500 Republica Medical Plaza, Suite 1000 Drive</streetAddressLine>
+                      <city>Senate District</city>
+                      <state>Galactic City</state>
+                      <postalCode>GC-500</postalCode>
+                      <country>Coruscant</country>
+                    </addr>
+                  </representedOrganization>
+                </assignedEntity>
+              </performer>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_eICR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/654321_CDA_eICR.xml
@@ -275,7 +275,7 @@
             <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1" displayName="Admission Diagnosis"></translation>
           </code>
           <title>HOSPITAL ADMISSION DIAGNOSIS</title>
-          <text>Khovid19</text>
+          <text>Covid19</text>
           <entry>
             <act classCode="ACT" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.22.4.34" extension="2015-08-01" />

--- a/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/services/evaluateFhirDataService.tsx
@@ -26,11 +26,13 @@ import {
   DataDisplay,
   DisplayDataProps,
 } from "@/app/view-data/components/DataDisplay";
+import EvaluateTable from "@/app/view-data/components/EvaluateTable";
 import { ExpandCollapseAccordion } from "@/app/view-data/components/ExpandCollapseAccordion";
 import { JsonTable } from "@/app/view-data/components/JsonTable";
 
 import {
   formatDate,
+  formatDateTime,
   formatPeriodDate,
   formatStartEndDate,
   formatStartEndDateTime,
@@ -47,6 +49,7 @@ import {
   formatPhoneNumber,
   sortByPeriod,
   formatCurrentAddress,
+  formatReference,
 } from "./formatService";
 import { HtmlTableJsonRow } from "./htmlTableService";
 import { evaluateTravelHistoryTable } from "./socialHistoryService";
@@ -602,6 +605,60 @@ export const evaluateEncounterData = (fhirBundle: Bundle) => {
     },
   ];
   return evaluateData(encounterData);
+};
+
+/**
+ * Evaluates Hospital Encounter Admission and Discharge diagnosis data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing hospital encounter data.
+ * @returns An array of evaluated and formatted hospital encounter data.
+ */
+export const evaluateHospitalEncounterData = (fhirBundle: Bundle) => {
+  const hospitalEncounterData = [
+    {
+      title: "Hospital Admission Diagnosis",
+      value: evaluateEncounterDiagnosisData(fhirBundle, "46241-6", "Hospital Admission Diagnosis"),
+      table: true
+    },
+    {
+      title: "Hospital Discharge Diagnosis",
+      value: evaluateEncounterDiagnosisData(fhirBundle, "11535-2", "Hospital Discharge Diagnosis"),
+      table: true
+    },
+  ];
+  return evaluateData(hospitalEncounterData);
+};
+
+/**
+ * Evaluates either Hospital Admission Diagnosis or Discharge diagnosis data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing hospital encounter data.
+ * @param code - the associated code for the section to be evaluated. e.g. 46241-6 for Admission Dx or 11535-2 for Discharge Dx
+ * @param caption - A string to set the caption for the UI element
+ * @returns An array of evaluated and formatted hospital encounter data.
+ */
+export const evaluateEncounterDiagnosisData = (fhirBundle: Bundle, code: string, caption: string) => {
+
+  const dxRefs = evaluateAll(fhirBundle, fhirPathMappings.hospitalEncounterDiagnosisRef, {code})
+
+  const dx: Condition[] = dxRefs.map((x)=> {
+    return evaluateReference<Condition>(fhirBundle, formatReference(x))
+  }).filter((x):x is Condition => Boolean(x))
+
+  if(dx.length === 0) return;
+
+
+  const dxColumns = [
+    {
+      columnName: "Problem",
+      infoPath: "hospitalEncounterDiagnosisCode",
+    },
+    {
+      columnName: "Date/Time",
+      infoPath: "hospitalEncounterDiagnosisDateTime",
+      applyToValue: formatDateTime
+    },
+  ];
+
+  return <EvaluateTable resources={dx} columns={dxColumns} caption={caption}/>;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -9,6 +9,7 @@ import {
   Period,
   Quantity,
   Range,
+  Reference,
   RelatedPerson,
 } from "fhir/r4";
 
@@ -423,6 +424,15 @@ export const formatAge = (age: Age | undefined): string | undefined => {
 
   return `${getFormattedMonths(totalMonths)}${days} day${makePlural(days)}`;
 };
+
+/**
+ * Returns the value of a Reference
+ * @param reference the reference being formatted
+ * @returns .reference value of the supplied reference
+ */
+export const formatReference = (reference: Reference): string => {
+  return reference?.reference || ""
+}
 
 const getFormattedMonths = (months: number): string => {
   if (months < 1) return "";

--- a/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -887,6 +887,57 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                   <h4
                     class="usa-summary-box__heading padding-y-105"
                   >
+                    Hospital Encounter Details
+                  </h4>
+                  <div
+                    class="usa-summary-box__text"
+                  >
+                    <div>
+                      <div
+                        class="grid-row"
+                      >
+                        <div
+                          class="data-title padding-right-1"
+                        >
+                          Hospital Admission Diagnosis
+                        </div>
+                        <div
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
+                        >
+                          No data
+                        </div>
+                      </div>
+                      <div
+                        class="section__line_gray"
+                      />
+                    </div>
+                    <div>
+                      <div
+                        class="grid-row"
+                      >
+                        <div
+                          class="data-title padding-right-1"
+                        >
+                          Hospital Discharge Diagnosis
+                        </div>
+                        <div
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
+                        >
+                          No data
+                        </div>
+                      </div>
+                      <div
+                        class="section__line_gray"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="gutter-3"
+                >
+                  <h4
+                    class="usa-summary-box__heading padding-y-105"
+                  >
                     Facility Details
                   </h4>
                   <div

--- a/containers/ecr-viewer/src/app/tests/components/Encounter.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/Encounter.test.tsx
@@ -47,6 +47,50 @@ describe("Encounter", () => {
         ),
       },
     ];
+
+    const hospitalEncounterData= [
+      {
+        title: "Hospital Admission Diagnosis",
+        table: true,
+        value: (
+            <table>
+              <thead>
+              <tr>
+                <th>Problem</th>
+                <th>Date/Time</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>COVID</td>
+                <td>2025-02-05</td>
+              </tr>
+              </tbody>
+            </table>
+        ),
+      },
+      {
+        title: "Hospital Discharge Diagnosis",
+        table: true,
+        value: (
+            <table>
+              <thead>
+              <tr>
+                <th>Problem</th>
+                <th>Date/Time</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>COVID</td>
+                <td>2025-02-05</td>
+              </tr>
+              </tbody>
+            </table>
+        ),
+      },
+    ];
+
     const facilityData = [
       {
         title: "Facility Name",
@@ -82,6 +126,7 @@ describe("Encounter", () => {
     container = render(
       <EncounterDetails
         encounterData={encounterData}
+        hospitalEncounterData={hospitalEncounterData}
         facilityData={facilityData}
         providerData={providerData}
       />,

--- a/containers/ecr-viewer/src/app/tests/components/Unavailable.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/Unavailable.test.tsx
@@ -48,6 +48,16 @@ describe("UnavailableInfo", () => {
         value: "",
       },
     ];
+    const hospitalEncounterUnavailableData = [
+      {
+        title: 'Hospital Admission Diagnosis',
+        value: ""
+      },
+      {
+        title: 'Hospital Discharge Diagnosis',
+        value: ""
+      }
+    ]
     const facilityUnavailableData = [
       {
         title: "Facility Name",
@@ -143,6 +153,7 @@ describe("UnavailableInfo", () => {
         demographicsUnavailableData={demographicsUnavailability}
         socialUnavailableData={socialUnavailability}
         encounterUnavailableData={encounterUnavailableData}
+        hospitalEncounterUnavailableData={hospitalEncounterUnavailableData}
         facilityUnavailableData={facilityUnavailableData}
         providerUnavailableData={providerUnavailableData}
         symptomsProblemsUnavailableData={[

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Encounter.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Encounter.test.tsx.snap
@@ -105,6 +105,86 @@ exports[`Encounter should match snapshot 1`] = `
         <div
           class="gutter-3"
         >
+          <h4
+            class="usa-summary-box__heading padding-y-105"
+            id="hospital-encounter-details"
+          >
+            Hospital Encounter Details
+          </h4>
+          <div
+            class="usa-summary-box__text"
+          >
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto width-full text-pre-line"
+              >
+                <table>
+                  <thead>
+                    <tr>
+                      <th>
+                        Problem
+                      </th>
+                      <th>
+                        Date/Time
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        COVID
+                      </td>
+                      <td>
+                        2025-02-05
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              class="section__line_gray"
+            />
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto width-full text-pre-line"
+              >
+                <table>
+                  <thead>
+                    <tr>
+                      <th>
+                        Problem
+                      </th>
+                      <th>
+                        Date/Time
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        COVID
+                      </td>
+                      <td>
+                        2025-02-05
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              class="section__line_gray"
+            />
+          </div>
+        </div>
+        <div
+          class="gutter-3"
+        >
           <span
             class="usa-tooltip"
             data-testid="tooltipWrapper"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Unavailable.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Unavailable.test.tsx.snap
@@ -229,6 +229,58 @@ exports[`UnavailableInfo should match snapshot 1`] = `
         >
           <h4
             class="usa-summary-box__heading padding-y-105"
+            id="unavailable-hospital-encounter-details"
+          >
+            Hospital Encounter Details
+          </h4>
+          <div
+            class="usa-summary-box__text"
+          >
+            <div>
+              <div
+                class="grid-row"
+              >
+                <div
+                  class="data-title padding-right-1"
+                >
+                  Hospital Admission Diagnosis
+                </div>
+                <div
+                  class="grid-col maxw7 text-pre-line p-list text-italic text-base"
+                >
+                  No data
+                </div>
+              </div>
+              <div
+                class="section__line_gray"
+              />
+            </div>
+            <div>
+              <div
+                class="grid-row"
+              >
+                <div
+                  class="data-title padding-right-1"
+                >
+                  Hospital Discharge Diagnosis
+                </div>
+                <div
+                  class="grid-col maxw7 text-pre-line p-list text-italic text-base"
+                >
+                  No data
+                </div>
+              </div>
+              <div
+                class="section__line_gray"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="gutter-3"
+        >
+          <h4
+            class="usa-summary-box__heading padding-y-105"
             id="unavailable-facility-details"
           >
             Facility Details

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -84,6 +84,9 @@ export type PathTypes = {
   encounterDiagnosis: EncounterDiagnosis;
   encounterType: string;
   encounterID: Identifier;
+  hospitalEncounterDiagnosisRef: Reference;
+  hospitalEncounterDiagnosisCode: CodeableConcept;
+  hospitalEncounterDiagnosisDateTime: String;
   facilityContact: string;
   facilityContactAddress: string;
   facilityLocation: string;
@@ -350,6 +353,21 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "Identifier",
     path: "Bundle.entry.resource.where(resourceType = 'Encounter')[0].identifier",
   },
+
+  hospitalEncounterDiagnosisRef: {
+    type: "Reference",
+    path: "Bundle.entry.resource.where(resourceType = 'Composition').section.where(code.coding.where(code = %code).exists()).entry"
+  },
+
+  hospitalEncounterDiagnosisCode:{
+    type: "CodeableConcept",
+    path: "Condition.code"
+  },
+  hospitalEncounterDiagnosisDateTime:{
+    type: "string",
+    path: "Condition.onsetDateTime"
+  },
+
   facilityContact: {
     type: "string",
     path: "Bundle.entry.resource.where(resourceType = 'Location')[0].telecom.where(system = 'phone')[0].value",
@@ -374,11 +392,6 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "ValueX",
     path: "Bundle.entry.resource.where(resourceType = 'Encounter')[0].location[0].extension.where(url = 'http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html//Location.type').value",
   },
-
-  // hospitalAdmissionDiagnosis: {
-  //
-  // }
-
   compositionEncounterRef: {
     type: "string",
     path: "Bundle.entry.resource.where(resourceType = 'Composition').encounter.reference",
@@ -471,7 +484,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     path: "Bundle.entry.resource.section.where(code.coding[0].code = '29549-3').entry.reference",
   },
 
-  // CareTEam
+  // CareTeam
   careTeamParticipants: {
     type: "CareTeamParticipant",
     path: "Bundle.entry.resource.where(resourceType = 'CareTeam').participant",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -375,6 +375,10 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     path: "Bundle.entry.resource.where(resourceType = 'Encounter')[0].location[0].extension.where(url = 'http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html//Location.type').value",
   },
 
+  // hospitalAdmissionDiagnosis: {
+  //
+  // }
+
   compositionEncounterRef: {
     type: "string",
     path: "Bundle.entry.resource.where(resourceType = 'Composition').encounter.reference",

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -17,7 +17,7 @@ import fhirpath_r4_model from "fhirpath/fhir-context/r4";
 import {
   formatCodeableConcept,
   formatQuantity,
-  formatRange,
+  formatRange, formatReference,
 } from "@/app/services/formatService";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
@@ -247,7 +247,7 @@ export const evaluateValue = (
     const range = formatRange(originalValue);
     value = range || originalValue.text || "";
   } else if (isReference(originalValue, originalValuePath)) {
-    value = originalValue?.reference || "";
+    value = formatReference(originalValue);
   } else if (typeof originalValue === "object") {
     console.error(`Not implemented for ${originalValuePath}`);
   }
@@ -265,7 +265,6 @@ const isObservationReferenceRange = (
   p: string,
 ): v is ObservationReferenceRange => p === "Observation.referenceRange";
 const isReference = (v: object, p: string): v is Reference => p === "Reference";
-
 /**
  * Evaluates a reference in a FHIR bundle. The resulting type of the expected resource
  * must be provided as a type parameter. This will also be checked at runtime and an

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -9,6 +9,7 @@ import {
   evaluateEncounterData,
   evaluateProviderData,
   evaluateFacilityData,
+  evaluateHospitalEncounterData,
 } from "@/app/services/evaluateFhirDataService";
 import { evaluateLabInfoData } from "@/app/services/labsService";
 import { evaluateAll } from "@/app/utils/evaluate";
@@ -35,6 +36,7 @@ export const getEcrDocumentAccordionItems = (
 ): AccordionItem[] => {
   const demographicsData = evaluateDemographicsData(fhirBundle);
   const socialData = evaluateSocialData(fhirBundle);
+  const hospitalEncounterData = evaluateHospitalEncounterData(fhirBundle);
   const encounterData = evaluateEncounterData(fhirBundle);
   const providerData = evaluateProviderData(fhirBundle);
   const clinicalData = evaluateClinicalData(fhirBundle);
@@ -44,11 +46,13 @@ export const getEcrDocumentAccordionItems = (
     fhirBundle,
     evaluateAll(fhirBundle, fhirPathMappings.diagnosticReports),
   );
+
   const hasUnavailableData = () => {
     const unavailableDataArrays = [
       demographicsData.unavailableData,
       socialData.unavailableData,
       encounterData.unavailableData,
+      hospitalEncounterData.unavailableData,
       clinicalData.reasonForVisitDetails.unavailableData,
       clinicalData.activeProblemsDetails.unavailableData,
       providerData.unavailableData,
@@ -91,10 +95,12 @@ export const getEcrDocumentAccordionItems = (
       content: (
         <>
           {encounterData.availableData.length > 0 ||
+          hospitalEncounterData.availableData.length > 0 ||
           facilityData.availableData.length > 0 ||
           providerData.availableData.length > 0 ? (
             <EncounterDetails
               encounterData={encounterData.availableData}
+              hospitalEncounterData={hospitalEncounterData.availableData}
               facilityData={facilityData.availableData}
               providerData={providerData.availableData}
             />
@@ -179,6 +185,7 @@ export const getEcrDocumentAccordionItems = (
               demographicsUnavailableData={demographicsData.unavailableData}
               socialUnavailableData={socialData.unavailableData}
               encounterUnavailableData={encounterData.unavailableData}
+              hospitalEncounterUnavailableData={hospitalEncounterData.unavailableData}
               facilityUnavailableData={facilityData.unavailableData}
               symptomsProblemsUnavailableData={[
                 ...clinicalData.reasonForVisitDetails.unavailableData,

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -38,10 +38,6 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
   conditionSummary,
   snomed,
 }) => {
-  console.log('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-  console.log('Encounter Details: ', encounterDetails)
-  console.log('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-
   const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
     (condition) => {
       return {

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -38,6 +38,10 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
   conditionSummary,
   snomed,
 }) => {
+  console.log('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+  console.log('Encounter Details: ', encounterDetails)
+  console.log('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+
   const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
     (condition) => {
       return {

--- a/containers/ecr-viewer/src/app/view-data/components/Encounter.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/Encounter.tsx
@@ -9,6 +9,7 @@ import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
 
 interface EncounterProps {
   encounterData: DisplayDataProps[];
+  hospitalEncounterData: DisplayDataProps[];
   facilityData: DisplayDataProps[];
   providerData: DisplayDataProps[];
 }
@@ -17,18 +18,21 @@ interface EncounterProps {
  * Functional component for displaying encounter details.
  * @param props - Props containing encounter details.
  * @param props.encounterData - Encounter details to be displayed.
+ * @param props.hospitalEncounterData - Hospital Encounter Diagnosis details to be displayed.
  * @param props.providerData - Provider details to be displayed.
  * @param props.facilityData - Facility details to be displayed.
  * @returns The JSX element representing the encounter details.
  */
 const EncounterDetails = ({
   encounterData,
+  hospitalEncounterData,
   facilityData,
   providerData,
 }: EncounterProps) => {
   return (
     <AccordionSection>
       <EncounterSection title="Encounter Details" data={encounterData} />
+      <EncounterSection title="Hospital Encounter Details" data={hospitalEncounterData} />
       <EncounterSection
         title="Facility Details"
         toolTip="Specific healthcare facility where the encounter took place."

--- a/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
@@ -11,6 +11,7 @@ interface UnavailableInfoProps {
   demographicsUnavailableData: DisplayDataProps[];
   socialUnavailableData: DisplayDataProps[];
   encounterUnavailableData: DisplayDataProps[];
+  hospitalEncounterUnavailableData: DisplayDataProps[];
   facilityUnavailableData: DisplayDataProps[];
   providerUnavailableData: DisplayDataProps[];
   symptomsProblemsUnavailableData: DisplayDataProps[];
@@ -43,6 +44,7 @@ const UnavailableInfo: React.FC<UnavailableInfoProps> = ({
   demographicsUnavailableData,
   socialUnavailableData,
   encounterUnavailableData,
+  hospitalEncounterUnavailableData,
   facilityUnavailableData,
   providerUnavailableData,
   symptomsProblemsUnavailableData,
@@ -63,6 +65,10 @@ const UnavailableInfo: React.FC<UnavailableInfoProps> = ({
       <UnavailableSection
         title="Encounter Details"
         data={encounterUnavailableData}
+      />
+      <UnavailableSection
+        title="Hospital Encounter Details"
+        data={hospitalEncounterUnavailableData}
       />
       <UnavailableSection
         title="Facility Details"

--- a/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
@@ -29,6 +29,7 @@ interface UnavailableInfoProps {
  * @param props.demographicsUnavailableData The unavailable demographic data
  * @param props.socialUnavailableData The unavailable social data
  * @param props.encounterUnavailableData The unavailable encounter data
+ * @param props.hospitalEncounterUnavailableData The unavailable hospital encounter diagnosis data
  * @param props.facilityUnavailableData The unavailable facility data
  * @param props.providerUnavailableData The unavailable provider data
  * @param props.symptomsProblemsUnavailableData The unavailable symptoms and problems data


### PR DESCRIPTION
# PULL REQUEST
## Summary

Adds a new Hospital Encounter Details section to the encounter that includes hospital admission and discharge diagnoses tables

## Related Issue

Fixes #570

## Acceptance Criteria

 Fields should be added to the eCR Viewer
 Any relevant unit/snapshot tests should be added.

## Additional Information

There's a new eCR being seeded on this branch with a patient name of Dash Rendar. This eCR has synthetic hospital admin/discharge diagnosis data in it for testing.
