### PR TITLE
fix: update OpenTelemetry dependencies to latest versions to resolve dependencyConflict warning

### DIFF
--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -6,6 +6,6 @@ uvicorn[standard]
 lxml
 requests
 python-dotenv
-opentelemetry-distro>=0.48b0
-opentelemetry-exporter-otlp>=1.27.0
-opentelemetry-exporter-prometheus>=0.48b0
+opentelemetry-distro>=0.54b0
+opentelemetry-exporter-otlp>=1.33.0
+opentelemetry-exporter-prometheus>=0.54b0


### PR DESCRIPTION
# PULL REQUEST

## Summary

Update to OpenTelemetry.

## Related Issue

Fixes #713 

## Additional Information

Ideally there should be some kind of check for bad dependencies, but OpenTelemetry appears to check dependencies at runtime. Another solution is to use lock files so that dependencies do not magically update unless we tell them to. [See this follow-up ticket.](https://app.zenhub.com/workspaces/streamline-ecr-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/715)
