### PR TITLE
fix: pin fhirpathpy in message parsing container

### DIFF
--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -4,7 +4,7 @@ azure-keyvault-secrets
 azure-storage-blob
 cryptography>=43.0.1
 fastapi>=0.109.1
-fhirpathpy
+fhirpathpy==1.2.1
 frozendict
 google-auth
 google-cloud-storage


### PR DESCRIPTION
# PULL REQUEST

## Summary

Pin `fhirpathpy` to fix test failures in message parser
