### PR TITLE
feat: add workflow to trigger deploy to demo environment

### DIFF
--- a/.github/workflows/trigger_demo_workflow.yaml
+++ b/.github/workflows/trigger_demo_workflow.yaml
@@ -1,0 +1,50 @@
+name: Trigger Deploy to Demo
+run-name: Trigger Deploy ${{ inputs.version }} to Demo by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        type: string
+        description: "The service you want to deploy. dibbs-ecr-viewer"
+        required: true
+        default: dibbs-ecr-viewer
+      version:
+        type: string
+        description: "The version to deploy. Example: v2.6.0 or main"
+        required: true
+        default: main
+      event_type:
+        type: choice
+        options:
+          - trigger-demo-plan
+          - trigger-demo-deploy
+        description: "The event type to trigger the workflow."
+        required: true
+
+jobs:
+  trigger_demo_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Demo
+        run: |
+          repo_owner="skylight-hq"
+          repo_name="dibbs-tf-envs"
+          event_type=${{ github.event.inputs.event_type }}
+          service="${{ github.event.inputs.service }}"
+          version="${{ github.event.inputs.version }}"
+          response="$(curl -L -w '%{http_code}\n' -o /dev/null \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DIBBS_SKYLIGHT_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"service\": \"$service\"}}")"
+          if [ $response -ne 204 ]; then
+            echo "Failed to trigger the workflow."
+            exit 1
+          fi
+          echo "View your workflow run at: https://github.com/skylight-hq/dibbs-tf-envs/actions"
+          echo "Successfully triggered the workflow."
+          echo "Service: $service"
+          echo "Version: $version"


### PR DESCRIPTION
## Changes Proposed

- Added a new GitHub Actions workflow file (trigger_demo_workflow.yaml) to enable manual deployment to the demo environment.
- The workflow accepts inputs for the service name and version, and triggers a secondary GitHub Actions workflow in `dibbs-tf-env`

## Additional Information

- This initial PR is to test the permissions and integration with the `dibbs-tf-envs` repo. 
- I'll work directly with the team to customize the trigger as needed.

## Testing

Once this merges to main:
  - Manually trigger the workflow on GitHub.
  - Verify that the API call is correctly made with the appropriate payload.
  - Check the `dibbs-tf-envs` repo kicks off the appropriate job.