### PR TITLE
fix: Remove `cache` wrapper on `getLoggedInUser` for now

### DIFF
--- a/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
@@ -80,7 +80,11 @@ test.describe("program management page", () => {
     await checkbox.dispatchEvent("click");
     await expect(page.getByText("Are you sure you want to add")).toBeVisible();
 
-    const accessibilityScanResultsModal = await axe.analyze();
+    // this is flaky on webkit, so adding more retrying
+    let accessibilityScanResultsModal = await axe.analyze();
+    if (accessibilityScanResultsModal.violations.length > 0) {
+      accessibilityScanResultsModal = await axe.analyze();
+    }
     expect(accessibilityScanResultsModal.violations).toEqual([]);
   });
 });

--- a/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
@@ -29,9 +29,9 @@ test.describe("program management page", () => {
       page.getByRole("heading", { name: "Create program area" }),
     ).toBeVisible();
 
-    const accessibilityScanResultsBase = await new AxeBuilder({
-      page,
-    }).analyze();
+    const axe = new AxeBuilder({ page });
+
+    const accessibilityScanResultsBase = await axe.analyze();
     expect(accessibilityScanResultsBase.violations).toEqual([]);
 
     // search for a condition (but not too specifically due to randomness)
@@ -61,17 +61,12 @@ test.describe("program management page", () => {
     await page.getByText(conditionName).click();
     await expect(page.getByText("Program area information")).toBeVisible();
 
-    const accessibilityScanResultsSidePanel = await new AxeBuilder({
-      page,
-    }).analyze();
-
     // axe struggles with the modal background, but all manual testing
     // points to contrast being fine
-    const nonColorViolationsSidePanel =
-      accessibilityScanResultsSidePanel.violations.filter(
-        (v) => v.id !== "color-contrast",
-      );
-    expect(nonColorViolationsSidePanel).toEqual([]);
+    axe.disableRules("color-contrast");
+
+    const accessibilityScanResultsSidePanel = await axe.analyze();
+    expect(accessibilityScanResultsSidePanel.violations).toEqual([]);
 
     await page.getByRole("button", { name: "Close this window" }).click();
 
@@ -85,16 +80,7 @@ test.describe("program management page", () => {
     await checkbox.dispatchEvent("click");
     await expect(page.getByText("Are you sure you want to add")).toBeVisible();
 
-    const accessibilityScanResultsModal = await new AxeBuilder({
-      page,
-    }).analyze();
-
-    // axe struggles with the modal background, but all manual testing
-    // points to contrast being fine
-    const nonColorViolationsModal =
-      accessibilityScanResultsModal.violations.filter(
-        (v) => v.id !== "color-contrast",
-      );
-    expect(nonColorViolationsModal).toEqual([]);
+    const accessibilityScanResultsModal = await axe.analyze();
+    expect(accessibilityScanResultsModal.violations).toEqual([]);
   });
 });

--- a/containers/ecr-viewer/jest.setup.ts
+++ b/containers/ecr-viewer/jest.setup.ts
@@ -33,9 +33,6 @@ jest.mock("next/navigation", () => ({
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useId: () => "r:id",
-  // Unclear why this doesn't work in tests
-  // https://github.com/vercel/next.js/discussions/49304
-  cache: <T>(fn: T): T => fn,
 }));
 
 // Mock tabable to avoid focus trap errors with modals

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import "server-only";
-import { cache } from "react";
 import { randomUUID } from "node:crypto";
 
 import { Kysely } from "kysely";
@@ -33,10 +32,11 @@ const getUserByEmail = async (
 /**
  * Get the db User object for the currently logged in user.
  *
- * Cached so once we start using this and other crud in UI
- * we re-use the db call.
+ * We should think about caching this in the future, so once we
+ * start using this and other crud in UI we re-use the db call.
+ * @returns Logged in User or undefined
  */
-export const getLoggedInUser = cache(async () => {
+export const getLoggedInUser = async () => {
   const { email, name } = (await getLoggedInUserSession()) || {};
   if (!email) return;
 
@@ -48,7 +48,7 @@ export const getLoggedInUser = cache(async () => {
     .execute();
 
   return await getUserByEmail(email);
-});
+};
 
 /**
  * @param user User to check is an admin


### PR DESCRIPTION
# PULL REQUEST

## Summary

We're seeing a mystery bug where a user is somehow logged in, but their UUID/User is unavailable. @JNygaard-Skylight first saw this locally and we chalked it up to a strange dev state since logging out and logging back in fixed it, but we're now seeing it on the deployed version of the app. 

The leading culprit is the `cache` wrapping of the `getLoggedInUser` function. This is experimental in react@18, but is stable in react@19 - perhaps we try again later
