### PR TITLE
fix: eCR library table header z-index

### DIFF
--- a/containers/ecr-viewer/src/app/components/table/ecr/EcrTableHeader.tsx
+++ b/containers/ecr-viewer/src/app/components/table/ecr/EcrTableHeader.tsx
@@ -37,7 +37,7 @@ export const EcrTableHeader = ({
 
   return (
     <SortableHeader
-      className="position-sticky top-0"
+      className="position-sticky top-0 z-100"
       headers={headers}
       disabled={disabled}
       handleSort={handleSort}

--- a/containers/ecr-viewer/src/app/tests/components/table/__snapshots__/EcrTableHeader.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/table/__snapshots__/EcrTableHeader.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EcrTableHeader disabled should match snapshot 1`] = `
 <table>
   <thead
-    class="position-sticky top-0"
+    class="position-sticky top-0 z-100"
   >
     <tr>
       <th
@@ -148,7 +148,7 @@ exports[`EcrTableHeader disabled should match snapshot 1`] = `
 exports[`EcrTableHeader enabled should match snapshot 1`] = `
 <table>
   <thead
-    class="position-sticky top-0"
+    class="position-sticky top-0 z-100"
   >
     <tr>
       <th

--- a/containers/ecr-viewer/src/styles/ecr-library.scss
+++ b/containers/ecr-viewer/src/styles/ecr-library.scss
@@ -40,6 +40,7 @@
   font-size: 1rem;
   border-collapse: separate;
   font-family: "Source Sans Pro Web";
+  isolation: isolate;
 
   // Hide highlight color by matching th color on sorted column - per design
   &.usa-table th {


### PR DESCRIPTION
# PULL REQUEST

## Summary

The table content was scrolling in front of the header instead of behind. Fix it.

## Related Issue

Fixes #838

## Additional Information

<img width="896" alt="image" src="https://github.com/user-attachments/assets/31f0deb8-c1df-409c-82a0-b005764a7303" />
