### PR TITLE
fix: make space for error alert on forms

### DIFF
--- a/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
+++ b/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
@@ -71,7 +71,7 @@ export const FormPageContent = <T,>({
           Back to {itemType} management
         </Link>
         <div className="border-bottom border-base-lighter position-sticky top-0 bg-white isolate z-500 padding-top-1">
-          <div className="height-5 margin-bottom-1">
+          <div className="minh-5 margin-bottom-1">
             {formTouched && !submitting && !error && (
               <Alert
                 type="warning"

--- a/containers/ecr-viewer/src/app/tests/__snapshots__/ProgramAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/__snapshots__/ProgramAdminPage.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Program Admin Page Creating programs should render a create program pag
         class="border-bottom border-base-lighter position-sticky top-0 bg-white isolate z-500 padding-top-1"
       >
         <div
-          class="height-5 margin-bottom-1"
+          class="minh-5 margin-bottom-1"
         />
         <div
           class="display-flex flex-justify margin-bottom-2"

--- a/containers/ecr-viewer/src/app/tests/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/__snapshots__/UserAdminPage.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
         class="border-bottom border-base-lighter position-sticky top-0 bg-white isolate z-500 padding-top-1"
       >
         <div
-          class="height-5 margin-bottom-1"
+          class="minh-5 margin-bottom-1"
         />
         <div
           class="display-flex flex-justify margin-bottom-2"


### PR DESCRIPTION
# PULL REQUEST

## Summary

Change the div which saves space for the alerts to min height instead of height as the error alert is taller than the unsaved changes warning.

## Related Issue

Fixes #841

## Additional Information

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/71e3f606-7eff-452c-b442-b1986e91198c" />
