### PR TITLE
fix: page auth and azure profile

### DIFF
--- a/containers/ecr-viewer/.eslintrc.json
+++ b/containers/ecr-viewer/.eslintrc.json
@@ -74,7 +74,7 @@
     ],
     "jsdoc/check-tag-names": "off",
     "jsdoc/require-jsdoc": [
-      "error",
+      "warn",
       {
         "require": {
           "ArrowFunctionExpression": true

--- a/containers/ecr-viewer/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/admin-user.spec.ts
@@ -4,9 +4,9 @@ import { test, expect, Page } from "@playwright/test";
 import { logInToKeycloak } from "./utils";
 
 test.describe("user management page", () => {
-  test.beforeEach(logInToKeycloak);
-
   test("should pass accessiblity", async ({ page }) => {
+    await logInToKeycloak({ page });
+
     await page.goto("/ecr-viewer/admin/user");
 
     await expect(page.getByText("User Management")).toBeVisible();
@@ -36,6 +36,8 @@ test.describe("user management page", () => {
   });
 
   test("should create a new user", async ({ page, browserName }) => {
+    await logInToKeycloak({ page });
+
     // Create programs
     const program1 = await createRandomProgramArea(page);
     const program2 = await createRandomProgramArea(page);
@@ -97,6 +99,18 @@ test.describe("user management page", () => {
 
     await deleteProgramArea(page, program1);
     await deleteProgramArea(page, program2);
+  });
+
+  test("it should not show to non-admin", async ({ page }) => {
+    await logInToKeycloak({ page }, undefined, "ecr-viewer-standard");
+    await page.goto("/ecr-viewer/admin/user");
+
+    await expect(
+      page.getByRole("heading", { name: "Page not found" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "User management" }),
+    ).not.toBeVisible();
   });
 });
 

--- a/containers/ecr-viewer/e2e/dual/utils.ts
+++ b/containers/ecr-viewer/e2e/dual/utils.ts
@@ -1,6 +1,7 @@
 import {
   APIRequestContext,
   PlaywrightTestArgs,
+  TestInfo,
   expect,
 } from "@playwright/test";
 
@@ -8,16 +9,20 @@ import {
  * Helper to lot into via keycloak and go to the viewer page
  * @param props playwright test args
  * @param props.page page
+ * @param _t test info (unused, but passed from before each)
+ * @param userName user name to log in as. Default is `ecr-viewer-admin`
  */
-export const logInToKeycloak = async ({ page }: PlaywrightTestArgs) => {
+export const logInToKeycloak = async (
+  { page }: Pick<PlaywrightTestArgs, "page">,
+  _t?: TestInfo,
+  userName = "ecr-viewer-admin",
+) => {
   await page.goto("/ecr-viewer");
   await page.waitForURL("ecr-viewer/signin?callbackUrl=%2Fecr-viewer%2F");
 
   await page.getByRole("button").click();
 
-  await page
-    .getByRole("textbox", { name: "username" })
-    .fill("ecr-viewer-admin");
+  await page.getByRole("textbox", { name: "username" }).fill(userName);
   await page.getByRole("textbox", { name: "password" }).fill("pw");
   await page.getByRole("button", { name: "Sign in" }).click();
 

--- a/containers/ecr-viewer/jest.setup.ts
+++ b/containers/ecr-viewer/jest.setup.ts
@@ -33,6 +33,9 @@ jest.mock("next/navigation", () => ({
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useId: () => "r:id",
+  // Unclear why this doesn't work in tests
+  // https://github.com/vercel/next.js/discussions/49304
+  cache: <T>(fn: T): T => fn,
 }));
 
 // Mock tabable to avoid focus trap errors with modals

--- a/containers/ecr-viewer/keycloak/realm-export.json
+++ b/containers/ecr-viewer/keycloak/realm-export.json
@@ -643,6 +643,31 @@
       "realmRoles": ["admin", "default-roles-master"],
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "id": "1c3b6114-3c12-4ef7-95ba-a0091f506ed7",
+      "username": "ecr-viewer-standard",
+      "firstName": "Salome",
+      "lastName": "Standard",
+      "email": "ecr-viewer@standard.com",
+      "emailVerified": true,
+      "createdTimestamp": 1732143781849,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "c28534a5-f006-4c8d-9b2a-d1aa9b257abe",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1732143832209,
+          "value": "pw"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["admin", "default-roles-master"],
+      "notBefore": 0,
+      "groups": []
     }
   ],
   "localizationTexts": {},

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -24,7 +24,7 @@
     "test:integration:pg": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'METADATA_DATABASE_TYPE=postgres TEST_TYPE=integration TZ=America/New_York jest --runInBand --detectOpenHandles'",
     "test:integration:sqlserver": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'METADATA_DATABASE_TYPE=sqlserver TEST_TYPE=integration TZ=America/New_York jest --runInBand --detectOpenHandles'",
     "test:e2e:install": "playwright install --with-deps",
-    "test:e2e": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/dual'",
+    "test:e2e": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/dual/admin-user.spec.ts'",
     "test:e2e:migrations": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/migrations.spec.ts --project chromium'",
     "test:e2e:integrated": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/integrated'",
     "clear-local": "docker compose -f ./seed-scripts/docker-compose-seed.yaml --profile \"*\" down -v",

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -24,7 +24,7 @@
     "test:integration:pg": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'METADATA_DATABASE_TYPE=postgres TEST_TYPE=integration TZ=America/New_York jest --runInBand --detectOpenHandles'",
     "test:integration:sqlserver": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'METADATA_DATABASE_TYPE=sqlserver TEST_TYPE=integration TZ=America/New_York jest --runInBand --detectOpenHandles'",
     "test:e2e:install": "playwright install --with-deps",
-    "test:e2e": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/dual/admin-user.spec.ts'",
+    "test:e2e": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/dual'",
     "test:e2e:migrations": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/migrations.spec.ts --project chromium'",
     "test:e2e:integrated": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'playwright test ./e2e/integrated'",
     "clear-local": "docker compose -f ./seed-scripts/docker-compose-seed.yaml --profile \"*\" down -v",

--- a/containers/ecr-viewer/src/app/admin/program/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/create/page.tsx
@@ -2,7 +2,7 @@ import { revalidatePath } from "next/cache";
 
 import { ProgramForm } from "@/app/admin/program/ProgramForm";
 import { listConditionReferences } from "@/app/services/listConditionsService";
-import { createProgramAreaAction } from "@/app/services/programAreaService";
+import { createProgramAreaAction } from "@/app/services/serverActionService";
 import { notFoundUnlessAdmin } from "@/app/services/userService";
 
 /**

--- a/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
@@ -3,10 +3,8 @@ import { notFound } from "next/navigation";
 
 import { ProgramForm } from "@/app/admin/program/ProgramForm";
 import { listConditionReferences } from "@/app/services/listConditionsService";
-import {
-  getProgramArea,
-  updateProgramAreaAction,
-} from "@/app/services/programAreaService";
+import { getProgramArea } from "@/app/services/programAreaService";
+import { updateProgramAreaAction } from "@/app/services/serverActionService";
 import { notFoundUnlessAdmin } from "@/app/services/userService";
 import { PageSearchParams } from "@/app/utils/search-param-utils";
 

--- a/containers/ecr-viewer/src/app/admin/program/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/page.tsx
@@ -1,10 +1,8 @@
 import { revalidatePath } from "next/cache";
 import Link from "next/link";
 
-import {
-  deleteProgramAreaAction,
-  listProgramAreas,
-} from "@/app/services/programAreaService";
+import { listProgramAreas } from "@/app/services/programAreaService";
+import { deleteProgramAreaAction } from "@/app/services/serverActionService";
 import { notFoundUnlessAdmin } from "@/app/services/userService";
 
 import { ProgramTable } from "./ProgramTable";

--- a/containers/ecr-viewer/src/app/admin/user/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/create/page.tsx
@@ -4,9 +4,9 @@ import { UserForm } from "@/app/admin/user/UserForm";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import {
   createUserAction,
-  notFoundUnlessAdmin,
   updateUserProgramAreasAction,
-} from "@/app/services/userService";
+} from "@/app/services/serverActionService";
+import { notFoundUnlessAdmin } from "@/app/services/userService";
 
 /**
  * @returns Page to create a new user

--- a/containers/ecr-viewer/src/app/admin/user/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/page.tsx
@@ -2,11 +2,8 @@ import { revalidatePath } from "next/cache";
 import Link from "next/link";
 
 import { listProgramAreas } from "@/app/services/programAreaService";
-import {
-  deleteUserAction,
-  listUsers,
-  notFoundUnlessAdmin,
-} from "@/app/services/userService";
+import { deleteUserAction } from "@/app/services/serverActionService";
+import { listUsers, notFoundUnlessAdmin } from "@/app/services/userService";
 
 import { UserTable } from "./UserTable";
 

--- a/containers/ecr-viewer/src/app/api/auth/providers.ts
+++ b/containers/ecr-viewer/src/app/api/auth/providers.ts
@@ -31,6 +31,19 @@ const azure = () => {
       clientId: process.env.AUTH_CLIENT_ID,
       clientSecret: process.env.AUTH_CLIENT_SECRET,
       tenantId: process.env.AUTH_ISSUER,
+      // Override the default profile fetcher as 1) we don't care about images and 2)
+      // azure makes it look like you have an email, but it's really a UPN, so use that
+      // as a fall-back for email if needed and it looks email-like
+      async profile(profile) {
+        const altEmail = profile.upn?.includes("@") ? profile.upn : null;
+
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email || altEmail,
+          image: null,
+        };
+      },
     });
 };
 export const providers = [keycloak(), azure()].filter(

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -1,4 +1,4 @@
-"use server";
+import "server-only";
 import { randomUUID } from "node:crypto";
 
 import { getDb } from "@/app/data/metadataDb/database";
@@ -8,7 +8,7 @@ import {
   ProgramArea,
 } from "@/app/data/metadataDb/types/core";
 
-import { UserFacingError, makeServerAction } from "./errorService";
+import { UserFacingError } from "./errorService";
 import { getCheckAdmin } from "./userService";
 
 /**
@@ -56,7 +56,6 @@ export const createProgramArea = async (
     throw new UserFacingError(message);
   }
 };
-export const createProgramAreaAction = makeServerAction(createProgramArea);
 
 /**
  * Get program area with the given uuid
@@ -126,7 +125,6 @@ export const updateProgramArea = async (
     throw new UserFacingError(message);
   }
 };
-export const updateProgramAreaAction = makeServerAction(updateProgramArea);
 
 /**
  * Delete program area by id and remove any references in the conditions table.
@@ -159,7 +157,6 @@ export const deleteProgramArea = async (uuid: string): Promise<void> => {
     throw new UserFacingError(message);
   }
 };
-export const deleteProgramAreaAction = makeServerAction(deleteProgramArea);
 
 export type ListedProgramArea = ProgramArea & {
   conditions: ConditionReference[];

--- a/containers/ecr-viewer/src/app/services/serverActionService.ts
+++ b/containers/ecr-viewer/src/app/services/serverActionService.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { makeServerAction } from "./errorService";
+import {
+  createProgramArea,
+  deleteProgramArea,
+  updateProgramArea,
+} from "./programAreaService";
+import {
+  createUser,
+  deleteUser,
+  updateUser,
+  updateUserProgramAreas,
+} from "./userService";
+
+// The server actions are segregated from the general service as everything in a "use server"
+// file is turned into an action and we want to be more selective about what is compiled as such
+
+// user
+export const createUserAction = makeServerAction(createUser);
+export const updateUserAction = makeServerAction(updateUser);
+export const updateUserProgramAreasAction = makeServerAction(
+  updateUserProgramAreas,
+);
+export const deleteUserAction = makeServerAction(deleteUser);
+
+// program area
+export const createProgramAreaAction = makeServerAction(createProgramArea);
+export const updateProgramAreaAction = makeServerAction(updateProgramArea);
+export const deleteProgramAreaAction = makeServerAction(deleteProgramArea);

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -1,6 +1,5 @@
-"use server";
-
 import "server-only";
+import { cache } from "react";
 import { randomUUID } from "node:crypto";
 
 import { Kysely } from "kysely";
@@ -17,12 +16,11 @@ import {
 } from "@/app/data/metadataDb/types/core";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
-import { UserFacingError, makeServerAction } from "./errorService";
+import { UserFacingError } from "./errorService";
 
 const getUserByEmail = async (
   email: string | null | undefined,
 ): Promise<User | undefined> => {
-  console.log({ id: "getUserByEmail1", email });
   if (!email) return;
 
   return await getDb<Core>()
@@ -39,9 +37,8 @@ const getUserByEmail = async (
  * start using this and other crud in UI we re-use the db call.
  * @returns Logged in User or undefined
  */
-export const getLoggedInUser = async () => {
+export const getLoggedInUser = cache(async () => {
   const { email, name } = (await getLoggedInUserSession()) || {};
-  console.log({ id: "getLoggedInUser1", email, name });
   if (!email) return;
 
   // Update the last log in and user's name to match the IDP
@@ -51,29 +48,22 @@ export const getLoggedInUser = async () => {
     .where("email", "=", email)
     .execute();
 
-  console.log({ id: "getLoggedInUser2", email, name });
   return await getUserByEmail(email);
-};
+});
 
 /**
  * @param user User to check is an admin
  * @returns true is the user both exists and is an admin, false otherwise
  */
-export const isAdmin = (user: User | undefined): user is User => {
-  const res = !!user && user.user_type === "admin" && user.status === "active";
-  console.log({ id: "isAdmin1", user, res });
-  return res;
-};
+export const isAdmin = (user: User | undefined): user is User =>
+  !!user && user.user_type === "admin" && user.status === "active";
 
 /**
  * If the logged in user is not an admin, force the page calling this to 404.
  */
 export const notFoundUnlessAdmin = async () => {
   const admin = await getLoggedInUser();
-
-  console.log({ id: "notFoundUnlessAdmin1", admin });
   if (!isAdmin(admin)) {
-    console.log({ id: "notFoundUnlessAdmin2" });
     notFound();
   }
 };
@@ -86,9 +76,7 @@ export const notFoundUnlessAdmin = async () => {
  */
 export const getCheckAdmin = async (actionDesc: string): Promise<User> => {
   const loggedInUser = await getLoggedInUser();
-  console.log({ id: "getCheckAdmin1", loggedInUser });
   if (!isAdmin(loggedInUser)) {
-    console.log({ id: "getCheckAdmin2", loggedInUser });
     throw new UserFacingError(`Standard user cannot ${actionDesc}`);
   }
 
@@ -108,11 +96,9 @@ export const createUser = async (
   user_type: "admin" | "standard",
 ): Promise<string> => {
   const creatingUser = await getCheckAdmin("create new users");
-  console.log({ id: "createUser1", creatingUser });
 
   try {
     const uuid = randomUUID();
-    console.log({ id: "createUser2", creatingUser, uuid });
     return await createUserQuery(email, user_type, uuid, creatingUser.uuid);
   } catch (error: unknown) {
     const message = "Failed to create new user";
@@ -120,7 +106,6 @@ export const createUser = async (
     throw new UserFacingError(message);
   }
 };
-export const createUserAction = makeServerAction(createUser);
 
 /**
  * Create an initial admin user with the given email. If any active
@@ -154,7 +139,6 @@ const createUserQuery = async (
   author_uuid: string,
 ) => {
   const user = await getUserByEmail(email);
-  console.log({ id: "createUserQuery1", user });
   if (!!user) {
     if (user.status === "active") {
       throw new UserFacingError("User already exists and is active");
@@ -170,7 +154,6 @@ const createUserQuery = async (
     user_type,
     author_uuid,
   };
-  console.log({ id: "createUserQuery2", user, newUser });
 
   await getDb<Core>().insertInto("user").values(newUser).execute();
   return uuid;
@@ -195,7 +178,6 @@ export const updateUser = async (
     throw new UserFacingError(message);
   }
 };
-export const updateUserAction = makeServerAction(updateUser);
 
 const updateUserQuery = async (
   uuid: string,
@@ -263,9 +245,6 @@ export const updateUserProgramAreas = async (
     throw new UserFacingError(message);
   }
 };
-export const updateUserProgramAreasAction = makeServerAction(
-  updateUserProgramAreas,
-);
 
 const deleteUserProgramAreas = async (db: Kysely<Core>, uuid: string) => {
   await db
@@ -291,7 +270,6 @@ export const deleteUser = async (uuid: string): Promise<void> => {
     throw new UserFacingError(message);
   }
 };
-export const deleteUserAction = makeServerAction(deleteUser);
 
 export type NamedUserPogramArea = UserProgramArea & { name: string };
 export type ListedUser = User & { program_areas: NamedUserPogramArea[] };

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -22,6 +22,7 @@ import { UserFacingError, makeServerAction } from "./errorService";
 const getUserByEmail = async (
   email: string | null | undefined,
 ): Promise<User | undefined> => {
+  console.log({ id: "getUserByEmail1", email });
   if (!email) return;
 
   return await getDb<Core>()
@@ -40,6 +41,7 @@ const getUserByEmail = async (
  */
 export const getLoggedInUser = async () => {
   const { email, name } = (await getLoggedInUserSession()) || {};
+  console.log({ id: "getLoggedInUser1", email, name });
   if (!email) return;
 
   // Update the last log in and user's name to match the IDP
@@ -49,6 +51,7 @@ export const getLoggedInUser = async () => {
     .where("email", "=", email)
     .execute();
 
+  console.log({ id: "getLoggedInUser2", email, name });
   return await getUserByEmail(email);
 };
 
@@ -56,15 +59,21 @@ export const getLoggedInUser = async () => {
  * @param user User to check is an admin
  * @returns true is the user both exists and is an admin, false otherwise
  */
-export const isAdmin = (user: User | undefined): user is User =>
-  !!user && user.user_type === "admin" && user.status === "active";
+export const isAdmin = (user: User | undefined): user is User => {
+  const res = !!user && user.user_type === "admin" && user.status === "active";
+  console.log({ id: "isAdmin1", user, res });
+  return res;
+};
 
 /**
  * If the logged in user is not an admin, force the page calling this to 404.
  */
 export const notFoundUnlessAdmin = async () => {
   const admin = await getLoggedInUser();
+
+  console.log({ id: "notFoundUnlessAdmin1", admin });
   if (!isAdmin(admin)) {
+    console.log({ id: "notFoundUnlessAdmin2" });
     notFound();
   }
 };
@@ -77,7 +86,9 @@ export const notFoundUnlessAdmin = async () => {
  */
 export const getCheckAdmin = async (actionDesc: string): Promise<User> => {
   const loggedInUser = await getLoggedInUser();
+  console.log({ id: "getCheckAdmin1", loggedInUser });
   if (!isAdmin(loggedInUser)) {
+    console.log({ id: "getCheckAdmin2", loggedInUser });
     throw new UserFacingError(`Standard user cannot ${actionDesc}`);
   }
 
@@ -97,9 +108,11 @@ export const createUser = async (
   user_type: "admin" | "standard",
 ): Promise<string> => {
   const creatingUser = await getCheckAdmin("create new users");
+  console.log({ id: "createUser1", creatingUser });
 
   try {
     const uuid = randomUUID();
+    console.log({ id: "createUser2", creatingUser, uuid });
     return await createUserQuery(email, user_type, uuid, creatingUser.uuid);
   } catch (error: unknown) {
     const message = "Failed to create new user";
@@ -141,6 +154,7 @@ const createUserQuery = async (
   author_uuid: string,
 ) => {
   const user = await getUserByEmail(email);
+  console.log({ id: "createUserQuery1", user });
   if (!!user) {
     if (user.status === "active") {
       throw new UserFacingError("User already exists and is active");
@@ -156,6 +170,7 @@ const createUserQuery = async (
     user_type,
     author_uuid,
   };
+  console.log({ id: "createUserQuery2", user, newUser });
 
   await getDb<Core>().insertInto("user").values(newUser).execute();
   return uuid;


### PR DESCRIPTION
# PULL REQUEST


## Summary

Various fixes to get user/program management to work for real:
* If azure AD doesn't return an email, fall back to the upn if it looks email-like
* segregate the server actions to their own service, remove `"use server"` from the db-based services as it causes everything to become async even if you don't mark it as such
* add a test to make sure non-admins can't see admin things (add another keycloak user to enable this)
* make the jsdoc requirement a lint warning instead of error (because it was annoying me)
* Add back the react cache since it wasn't the culprit (apologies to react-cache)

## Related Issue

Fixes #765 
