### PR TITLE
test: fix expected num of conditions on e2e search

### DIFF
--- a/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/e2e/dual/admin-program.spec.ts
@@ -40,7 +40,7 @@ test.describe("program management page", () => {
 
     // search for a condition (but not too specifically due to randomness)
     await page.getByPlaceholder("Search conditions").fill("i");
-    await expect(page.getByText("216 results")).toBeVisible();
+    await expect(page.getByText("232 results")).toBeVisible();
 
     // Find a random condition (avoid clashes in parallel tests)
     const checkboxes = await page.getByRole("checkbox").all();
@@ -84,7 +84,7 @@ test.describe("program management page", () => {
     await page.getByText("Create program area").click();
     // search for a condition again so checkbox is correct
     await page.getByPlaceholder("Search conditions").fill("i");
-    await expect(page.getByText("216 results")).toBeVisible();
+    await expect(page.getByText("232 results")).toBeVisible();
     await expect(page.getByText(`Condition in ${conditionName}`)).toBeVisible();
     await checkbox.scrollIntoViewIfNeeded();
     await checkbox.dispatchEvent("click");


### PR DESCRIPTION
# PULL REQUEST

## Summary

Introduced with the TES update as that doesn't trigger ecr-viewer tests to run
