### PR TITLE
fix: report_date => encounter_date

### DIFF
--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -355,7 +355,7 @@ export const generateSortStatement = (
   const validColumns: { [key: string]: string } = {
     patient: "patient",
     date_created: "date_created",
-    report_date: "encounter_start_date",
+    encounter_date: "encounter_start_date",
   };
   const validDirections = ["ASC", "DESC"];
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Our encounter date sorting has been sorting by create date for some time now, but our test data is so small that often turns out to be right 😬 

## Related Issue

Fixes e2e test flakiness

<img width="470" alt="image" src="https://github.com/user-attachments/assets/0c8c88c5-fcb0-461d-9d00-1a78baadff90" />
