### PR TITLE
fix: design review broswer launch step

### DIFF
--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -104,8 +104,8 @@ else
   echo "Skipping seed data FHIR conversion..."
 fi
 
-# Run ecr viewer
-npm run local-docker
+# Run ecr viewer in the background
+npm run local-docker:silent
 
 # Wait for eCR Viewer to be available
 while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -q "200"; do


### PR DESCRIPTION
# PULL REQUEST

## Summary

Run the ecr viewer in the background instead of foreground so the step where we check if the url is up and then launch when ready actually works