### PR TITLE
fix: Allow user creation/edits with no program areas assigned

### DIFF
--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -72,9 +72,7 @@ export const UserForm = ({
 
   const initSelectedPrograms = sortedIds(initValues.programs);
 
-  const valid =
-    !!email &&
-    (userType === "admin" || userType === "standard");
+  const valid = !!email && (userType === "admin" || userType === "standard");
   const touched =
     (email && email !== initValues.email) ||
     userType !== (initValues.userType || "standard") ||

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -74,8 +74,7 @@ export const UserForm = ({
 
   const valid =
     !!email &&
-    (userType === "admin" || userType === "standard") &&
-    (userType === "admin" || numProgramsSelected > 0);
+    (userType === "admin" || userType === "standard");
   const touched =
     (email && email !== initValues.email) ||
     userType !== (initValues.userType || "standard") ||

--- a/containers/ecr-viewer/src/app/tests/components/UserForm.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/UserForm.test.tsx
@@ -79,8 +79,8 @@ describe("UserForm", () => {
     const emailInput = screen.getByLabelText(/Email/i);
     await user.type(emailInput, "test@test.test");
 
-    // still disabled
-    expect(submitButtons[0]).toBeDisabled();
+    // no longer disabled (users don't need to be assigned to any program areas)
+    expect(submitButtons[0]).not.toBeDisabled();
 
     // change user type to admin
     const buttonAdminUser = screen.getAllByRole("radio", {


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Allow users to be created/edited with no program areas assigned
- Update unit test

## Related Issue

Fixes #910

## Screenshot
<img width="759" alt="Screenshot 2025-06-23 at 11 55 56" src="https://github.com/user-attachments/assets/bd4c6051-9df0-4e12-96bd-9514c0c2f0a9" />

## Acceptance Criteria

WHEN creating/editing a user
THEN user should be able to be saved with no program areas assigned

In the user management table, users with no program areas assigned should display `No program areas assigned`

## Additional Information

Need this for #898 