### PR TITLE
fix: don't update session when update changes

### DIFF
--- a/containers/ecr-viewer/src/app/components/AutoSignout.tsx
+++ b/containers/ecr-viewer/src/app/components/AutoSignout.tsx
@@ -53,7 +53,7 @@ export const AutoSignout = () => {
         clearTimeout(updateTimeout);
       };
     }
-  }, [isActive, update]);
+  }, [isActive]);
 
   // Keep track of seconds left until the session expires
   useEffect(() => {


### PR DESCRIPTION
# PULL REQUEST

## Summary

I noticed when working on another PR that the `/session` and `/csrf` endpoints were getting called waaaay tooo much. The auth component was updating the session when the `update` function changed, which isn't what we want - so this removes that from the dependency list
