### PR TITLE
feat(github-actions): update AWS dev deploy workflow

### DIFF
--- a/.github/workflows/trigger-dev-workflow.yaml
+++ b/.github/workflows/trigger-dev-workflow.yaml
@@ -8,20 +8,6 @@ on:
         type: string
         description: "The container tag to deploy. Example: `5.0.0`"
         required: true
-      dev_id:
-        type: choice
-        description: "The unique ID for the dev environment. `42` is typically used for dual/non-integrated deployments and `7` is typically used for integrated."
-        options:
-          - "7"
-          - "42"
-      config_name:
-        type: choice
-        description: "Sets CONFIG_NAME on dibbs-ecr-viewer"
-        required: true
-        options: # not supported yet: AWS_SQLSERVER_NON_INTEGRATED, AWS_SQLSERVER_DUAL
-          - AWS_PG_NON_INTEGRATED
-          - AWS_PG_DUAL
-          - AWS_INTEGRATED
       tf_branch:
         type: string
         description: "The branch to use for the Terraform code. Default is main. (experimental, may be removed)"
@@ -30,47 +16,40 @@ on:
       event_type:
         type: choice
         options:
-          - trigger-dev-plan
-          - trigger-dev-deploy
+          - trigger-dibbs-ecr-viewer-aws-dev-deploys
         description: "The event type to trigger the workflow."
         required: true
 
 jobs:
-  trigger_dev_workflow:
+  trigger_aws_dev_workflow:
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to AWS Dev
+      - name: Deploy to AWS dev
         env:
-          CONTAINER_TAG: ${{ inputs.container_tag }}
-          DEV_ID: ${{ inputs.dev_id }}
-          CONFIG_NAME: ${{ inputs.config_name }}
-          TF_BRANCH: ${{ inputs.tf_branch }}
-          EVENT_TYPE: ${{ inputs.event_type }}
+          TF_BRANCH: ${{ github.event.inputs.tf_branch }}
+          EVENT_TYPE: ${{ github.event.inputs.event_type }}
+          CONTAINER_TAG: ${{ github.event.inputs.container_tag }}
         run: |
-          repo_owner="CDCgov"
-          repo_name="dibbs-aws"
           service="dibbs-ecr-viewer"
-          version="$CONTAINER_TAG"
-          dev_id="$DEV_ID"
-          config_name="$CONFIG_NAME"
+          repo_owner="skylight-hq"
+          repo_name="dibbs-tf-envs"
           tf_branch="$TF_BRANCH"
           event_type="$EVENT_TYPE"
+          container_tag="$CONTAINER_TAG"
           response="$(curl -L -w '%{http_code}\n' -o /dev/null \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Authorization: Bearer ${{ secrets.DIBBS_SKYLIGHT_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"service\": \"$service\", \"dev_id\": \"$dev_id\", \"config_name\": \"$config_name\", \"tf_branch\": \"$tf_branch\"}}")"
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$container_tag\", \"tf_branch\": \"$tf_branch\"}}")"
           if [ $response -ne 204 ]; then
             echo "Failed to trigger the workflow."
             exit 1
           fi
-          echo "View your workflow run at: https://github.com/$repo_owner/$repo_name/actions"
-          echo "Successfully triggered the workflow."
+          echo "View your workflow run at: https://github.com/skylight-hq/dibbs-tf-envs/actions"
+          echo "Successfully triggered the workflow"
           echo "Service: $service"
-          echo "Version: $version"
-          echo "Dev ID: $dev_id"
-          echo "Config Name: $config_name"
+          echo "Repository: $repo_owner/$repo_name"
+          echo "Container Tag: $container_tag"
           echo "Terraform Branch: $tf_branch"
-          echo "Event Type: $event_type"

--- a/.github/workflows/trigger-dev-workflow.yaml
+++ b/.github/workflows/trigger-dev-workflow.yaml
@@ -1,5 +1,5 @@
 name: Trigger Deploy to AWS Dev
-run-name: "Trigger Deploy - Container Tag: ${{ inputs.container_tag }}, Dev ID: dev${{ inputs.dev_id }}, Config Name: ${{ inputs.config_name }}, Terraform Branch: ${{ inputs.tf_branch }}, Event Type: ${{ inputs.event_type }} to AWS Dev by @${{ github.actor }}"
+run-name: "Trigger Deploy - Container Tag: ${{ inputs.container_tag }}, Terraform Branch: ${{ inputs.tf_branch }}, Event Type: ${{ inputs.event_type }} to AWS Dev by @${{ github.actor }}"
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ jobs:
   trigger_aws_dev_workflow:
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to AWS dev
+      - name: Deploy to AWS Dev
         env:
           TF_BRANCH: ${{ github.event.inputs.tf_branch }}
           EVENT_TYPE: ${{ github.event.inputs.event_type }}
@@ -48,7 +48,7 @@ jobs:
             exit 1
           fi
           echo "View your workflow run at: https://github.com/skylight-hq/dibbs-tf-envs/actions"
-          echo "Successfully triggered the workflow"
+          echo "Successfully triggered the workflow."
           echo "Service: $service"
           echo "Repository: $repo_owner/$repo_name"
           echo "Container Tag: $container_tag"


### PR DESCRIPTION
## Changes Proposed

- Updated the GitHub workflow for triggering AWS Dev deployments.
- Removed the inputs and internal references for several variables. (dibbs-tf-envs handles this now, keeps it simple and means we don't have to always know what's going on in the other repo)
- Revised the event_type options to a single specific value.
- Modified variable references to use github.event.inputs for container_tag, tf_branch, and event_type.
- Updated to use the DIBBS_SKYLIGHT_PAT like the dibbs-vm trigger workflow.

## Additional Information

- The original workflow intended for dual deployments (integrated and non-integrated) has been simplified to a single deployment path, dibbs-tf-envs will deploy the correct config to each environment.

## Testing

- Trigger the workflow_dispatch event with valid inputs (run workflow, select this branch `alis/trigger-update`, put `6.0.0` as the container tag, deploy! https://github.com/CDCgov/dibbs-ecr-viewer/actions/workflows/trigger-dev-workflow.yaml
- Verify that the workflow sends a dispatch to the dibbs-tf-envs using the updated parameters; it should deploy the correct version to dev7 and dev42. https://github.com/skylight-hq/dibbs-tf-envs/actions/workflows/deploy_dibbs_services_aws_dev.yaml
- Confirm this dibbs-tf-envs deploys to dev42 and dev7 correctly.