### PR TITLE
fix: string sorting should ignore case

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -19,7 +19,7 @@ import Modal from "@/app/components/modal/Modal";
 import { ToastContext } from "@/app/components/toast/ToastProvider";
 import { ServerActionResult } from "@/app/services/errorService";
 import { ListedCondition } from "@/app/services/listConditionsService";
-import { makePlural, toKebabCase } from "@/app/utils/format-utils";
+import { makePlural, stringSort, toKebabCase } from "@/app/utils/format-utils";
 import { AccordionItem } from "@/app/view-data/types";
 
 interface FormCondition extends ListedCondition {
@@ -39,7 +39,7 @@ const groupByCategory = (conditions: FormCondition[]) => {
     acc[category] ||= [] as FormCondition[];
     acc[category].push(cur);
     acc[category].sort((a, b) =>
-      a.condition_name < b.condition_name ? -1 : 1,
+      stringSort(a.condition_name, b.condition_name),
     );
     return acc;
   }, {} as ConditionCategories);
@@ -204,7 +204,7 @@ const ConditionFieldSet = ({
   };
 
   const accordionItems: AccordionItem[] = Object.keys(conditionCategories)
-    .sort()
+    .sort(stringSort)
     .filter((category) => filteredConditionCategories[category].length > 0)
     .map((category) => {
       const conditions = filteredConditionCategories[category];

--- a/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
@@ -14,7 +14,7 @@ import { ConditionReference } from "@/app/data/metadataDb/types/core";
 import { ServerActionResult } from "@/app/services/errorService";
 import { formatDateTime } from "@/app/services/formatDateService";
 import { ListedProgramArea } from "@/app/services/programAreaService";
-import { makePlural } from "@/app/utils/format-utils";
+import { makePlural, stringSort } from "@/app/utils/format-utils";
 
 /**
  *
@@ -89,7 +89,7 @@ export const ProgramTable = ({
                 <ul className="add-list-reset">
                   {selectedProgramArea?.conditions
                     .sort((a, b) =>
-                      a.condition_name < b.condition_name ? -1 : 1,
+                      stringSort(a.condition_name, b.condition_name),
                     )
                     .map(({ condition_name, code }) => (
                       <li

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -14,7 +14,12 @@ import { FormPageContent } from "@/app/components/forms/FormPageContent";
 import { ToastContext } from "@/app/components/toast/ToastProvider";
 import { ServerActionResult } from "@/app/services/errorService";
 import { ListedProgramArea } from "@/app/services/programAreaService";
-import { makePlural, toKebabCase, toTitleCase } from "@/app/utils/format-utils";
+import {
+  makePlural,
+  stringSort,
+  toKebabCase,
+  toTitleCase,
+} from "@/app/utils/format-utils";
 import { AccordionItem } from "@/app/view-data/types";
 
 export type UserType = "admin" | "standard";
@@ -62,7 +67,7 @@ export const UserForm = ({
     initValues.userType || "standard",
   );
   const [programs, setPrograms] = useState(
-    [...initValues.programs].sort((a, b) => (a.name < b.name ? -1 : 1)),
+    [...initValues.programs].sort((a, b) => stringSort(a.name, b.name)),
   );
 
   const { createToast } = React.useContext(ToastContext);

--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -24,7 +24,11 @@ import { ServerActionResult } from "@/app/services/errorService";
 import { formatDateTime } from "@/app/services/formatDateService";
 import { ListedProgramArea } from "@/app/services/programAreaService";
 import { ListedUser, NamedUserPogramArea } from "@/app/services/userService";
-import { makePlural, toSentenceCase } from "@/app/utils/format-utils";
+import {
+  makePlural,
+  stringSort,
+  toSentenceCase,
+} from "@/app/utils/format-utils";
 import { ForceClient } from "@/app/view-data/components/ForceClient";
 
 const USER_TYPE_OPTIONS: Record<string, string> = {
@@ -55,7 +59,7 @@ export const UserTable = ({
   deleteAction: (uuid: string) => Promise<ServerActionResult<void>>;
 }) => {
   const sortedProgramAreas = [...programAreas].sort((a, b) =>
-    a.name.localeCompare(b.name),
+    stringSort(a.name, b.name),
   );
   const initFilterProgramAreaState: FilterProgramAreasType = {
     [ALL_PROGRAM_AREAS_OPTION]: true,
@@ -132,7 +136,7 @@ export const UserTable = ({
           ? "All program areas"
           : pas
               .map(({ name }) => name)
-              .sort()
+              .sort(stringSort)
               .join(", ") || "No program areas assigned",
     },
     {

--- a/containers/ecr-viewer/src/app/components/table/PaginatedSortableTable.tsx
+++ b/containers/ecr-viewer/src/app/components/table/PaginatedSortableTable.tsx
@@ -8,6 +8,7 @@ import Cookies from "js-cookie";
 import PaginationBar from "@/app/components/pagination/PaginationBar";
 import { PAGE_SIZES } from "@/app/constants";
 import { noData } from "@/app/utils/data-utils";
+import { stringSort } from "@/app/utils/format-utils";
 
 import { NoDataRow } from "./NoDataRow";
 import { SortDirection, SortableHeader, TableHeader } from "./SortableHeader";
@@ -55,7 +56,14 @@ export const PaginatedSortableTable = <T extends { uuid: string }>({
   const sortedItems = [...items];
   if (!!sortColumn) {
     sortedItems.sort((a, b) => {
-      const diff = (a[sortColumn.id] || "") < (b[sortColumn.id] || "") ? -1 : 1;
+      const aVal = a[sortColumn.id] || "";
+      const bVal = b[sortColumn.id] || "";
+      const diff =
+        typeof aVal === "string" && typeof bVal === "string"
+          ? stringSort(aVal, bVal)
+          : aVal < bVal
+            ? -1
+            : 1;
       return sortColumn.sortDirection === "ASC" ? diff : diff * -1;
     });
   }

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -81,3 +81,12 @@ export function extractNumbersAndPeriods(inputValues: string[]): string[] {
 export const makePlural = (value: number): "s" | "" => {
   return value !== 1 ? "s" : "";
 };
+
+/**
+ * Function to pass to the `sort` method which will sort strings in a consistent, case
+ * insensitive order
+ * @param a first string
+ * @param b second string
+ * @returns number indicating order
+ */
+export const stringSort = (a: string, b: string) => a.localeCompare(b);

--- a/containers/ecr-viewer/tests/unit/app/components/table/PaginatedSortableTable.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/table/PaginatedSortableTable.test.tsx
@@ -15,7 +15,7 @@ describe("PaginatedSoratableTable", () => {
   const items = [
     {
       uuid: "123",
-      one: "one",
+      one: "One",
       two: 5,
       three: new Date("2012-01-01"),
       four: [1, 2, 3],
@@ -104,7 +104,7 @@ describe("PaginatedSoratableTable", () => {
         .getAllByRole("row")
         .slice(1)
         .map((row) => row.firstChild?.textContent),
-    ).toStrictEqual(["four", "one"]);
+    ).toStrictEqual(["four", "One"]);
 
     // reverse column one sort
     await user.click(screen.getByRole("button", { name: "Column One" }));
@@ -137,7 +137,7 @@ describe("PaginatedSoratableTable", () => {
         .getAllByRole("row")
         .slice(1)
         .map((row) => row.firstChild?.textContent),
-    ).toStrictEqual(["three", "one"]);
+    ).toStrictEqual(["three", "One"]);
   });
 
   it("paginates items", async () => {
@@ -156,7 +156,7 @@ describe("PaginatedSoratableTable", () => {
         .getAllByRole("row")
         .slice(1)
         .map((row) => row.firstChild?.textContent),
-    ).toStrictEqual(["four", "one"]);
+    ).toStrictEqual(["four", "One"]);
 
     const user = userEvent.setup();
     await user.selectOptions(
@@ -171,6 +171,6 @@ describe("PaginatedSoratableTable", () => {
         .getAllByRole("row")
         .slice(1)
         .map((row) => row.firstChild?.textContent),
-    ).toStrictEqual(["four", "one", "three", "two"]);
+    ).toStrictEqual(["four", "One", "three", "two"]);
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/components/table/__snapshots__/PaginatedSortableTable.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/components/table/__snapshots__/PaginatedSortableTable.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`PaginatedSoratableTable matches snapshot 1`] = `
         </tr>
         <tr>
           <td>
-            one
+            One
           </td>
           <td>
             01/01/2012


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add a `stringSort` helper function and use it everywhere we sort strings so that case is ignored (well, so local sorting conventions are respected)

## Related Issue

Fixes #904

## Additional Information

<img width="1173" alt="image" src="https://github.com/user-attachments/assets/d0a34e05-a7ba-42e7-a90e-b4a6822a93b0" />

