### PR TITLE
fix: remove extra borders

### DIFF
--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -305,7 +305,6 @@ const FilterByProgramArea = ({
           onChange={handleCheckboxChange}
         />
       </div>
-      <div className="border-top-1px border-base-lighter margin-x-neg-105"></div>
     </Filter>
   );
 };

--- a/containers/ecr-viewer/src/app/components/EcrFilters.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrFilters.tsx
@@ -125,7 +125,7 @@ const FilterReportableConditions = ({
       icon={Coronavirus}
       tag={
         Object.keys(filterConditions).filter(
-          (key) => filterConditions[key] === true
+          (key) => filterConditions[key] === true,
         ).length || "0"
       }
       submitHandler={() => {

--- a/containers/ecr-viewer/src/app/components/EcrFilters.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrFilters.tsx
@@ -125,7 +125,7 @@ const FilterReportableConditions = ({
       icon={Coronavirus}
       tag={
         Object.keys(filterConditions).filter(
-          (key) => filterConditions[key] === true,
+          (key) => filterConditions[key] === true
         ).length || "0"
       }
       submitHandler={() => {
@@ -140,7 +140,9 @@ const FilterReportableConditions = ({
           onToggle={handleSelectAll}
           isAllSelected={isAllSelected}
         />
-        <div className="border-top-1px border-base-lighter margin-x-105"></div>
+        {allConditions.length > 0 && (
+          <div className="border-top-1px border-base-lighter margin-x-105"></div>
+        )}
         {/* Filter Conditions checkboxes */}
         <CheckboxOptions
           groupName="condition"


### PR DESCRIPTION
# PULL REQUEST

## Summary

Tiny fix to remove extra borders in filtering components.

## Related Issue

Fixes #955

## Screenshots
Filter by program area (user management) - Before/After
<img width="500" height="819" alt="Screenshot 2025-07-10 at 10 40 05" src="https://github.com/user-attachments/assets/0ea9a551-c335-4ead-82f7-7117ea24d97e" />
<img width="500" height="711" alt="Screenshot 2025-07-10 at 10 39 37" src="https://github.com/user-attachments/assets/5609caca-9322-481b-b373-b0409317b67b" />

Filter by conditions (eCR Library) (when there are no conditions to filter on) - Before/After 
<img width="500" height="325" alt="Screenshot 2025-07-10 at 10 51 39" src="https://github.com/user-attachments/assets/cb215545-3538-4635-b7a2-e0d41960c455" />
<img width="500" height="368" alt="Screenshot 2025-07-10 at 10 51 50" src="https://github.com/user-attachments/assets/62fb3505-1a6e-4620-9c7b-b91085cf330d" />
