### PR TITLE
feat: add warning banner when no programs created

### DIFF
--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 
 import {
   Button,
@@ -47,12 +47,14 @@ const sortedIds = (programs: FormProgram[]) => {
  * @param props.initValues Initial values the form is set to
  * @param props.action Action of the form (e.g. "Create", "Edit")
  * @param props.submitAction Handler for the submitted data
+ * @param props.banner markup to display as a banner above the form title
  * @returns Program area add/edit form
  */
 export const UserForm = ({
   action,
   initValues,
   submitAction,
+  banner,
 }: {
   action: string;
   initValues: FormValues;
@@ -61,6 +63,7 @@ export const UserForm = ({
     userType: UserType,
     programs: string[],
   ) => Promise<ServerActionResult<void>>;
+  banner?: ReactNode;
 }) => {
   const [email, setEmail] = useState(initValues.email || "");
   const [userType, setUserType] = useState<UserType>(
@@ -91,6 +94,7 @@ export const UserForm = ({
       itemHomeRoute="/admin/user"
       formValid={valid}
       formTouched={touched}
+      banner={banner}
       submitAction={async () => {
         const res = await submitAction(
           email.trim(),

--- a/containers/ecr-viewer/src/app/admin/user/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/create/page.tsx
@@ -1,3 +1,4 @@
+import { Alert, Link } from "@trussworks/react-uswds";
 import { revalidatePath } from "next/cache";
 
 import { UserForm } from "@/app/admin/user/UserForm";
@@ -24,6 +25,21 @@ const CreateUserPage = async () => {
         const res = await createUserAction({ email, userType, programs });
         return { error: res.error };
       }}
+      banner={
+        programs.length === 0 && (
+          <Alert
+            type="warning"
+            heading="You haven't made any program areas"
+            headingLevel="h4"
+          >
+            When you create a user, they won't have access to any eCRs until you
+            create a program area.{" "}
+            <Link href="/ecr-viewer/admin/program/create">
+              Create a program area
+            </Link>
+          </Alert>
+        )
+      }
     />
   );
 };

--- a/containers/ecr-viewer/src/app/admin/user/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/create/page.tsx
@@ -31,6 +31,7 @@ const CreateUserPage = async () => {
             type="warning"
             heading="You haven't made any program areas"
             headingLevel="h4"
+            noIcon={true}
           >
             When you create a user, they won't have access to any eCRs until you
             create a program area.{" "}

--- a/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
+++ b/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
@@ -18,6 +18,7 @@ import { ServerActionResult } from "@/app/services/errorService";
  * @param props.formTouched Whether the form has been touched (editted)
  * @param props.itemType The type of item the form is about (e.g. "user")
  * @param props.itemHomeRoute Route to redirect to upon successful submission or to go back to
+ * @param props.banner markup to display as a banner above the form title
  * @returns form with header and submit buttons
  */
 export const FormPageContent = <T,>({
@@ -26,6 +27,7 @@ export const FormPageContent = <T,>({
   formValid,
   formTouched,
   itemHomeRoute,
+  banner,
   children,
   submitAction,
 }: {
@@ -34,6 +36,7 @@ export const FormPageContent = <T,>({
   formValid: boolean;
   formTouched: boolean;
   itemHomeRoute: string;
+  banner?: ReactNode;
   children: ReactNode;
   submitAction: () => Promise<ServerActionResult<T>>;
 }) => {
@@ -58,6 +61,8 @@ export const FormPageContent = <T,>({
         </Link>
         <div className="border-bottom border-base-lighter position-sticky top-0 isolate z-500 padding-top-1 bg-container">
           <div className="minh-5 margin-bottom-1">
+            {banner}
+
             {formTouched && !submitting && !error && (
               <Alert
                 type="warning"

--- a/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
+++ b/containers/ecr-viewer/src/app/components/forms/FormPageContent.tsx
@@ -67,6 +67,7 @@ export const FormPageContent = <T,>({
               <Alert
                 type="warning"
                 slim={true}
+                noIcon={true}
                 headingLevel="h4"
                 aria-live="polite"
               >
@@ -87,7 +88,7 @@ export const FormPageContent = <T,>({
             )}
           </div>
 
-          <div className="display-flex flex-justify margin-bottom-2">
+          <div className="display-flex flex-justify flex-align-center margin-bottom-2">
             <h2 className="margin-0">{actionPhrase}</h2>
             <div>
               <SubmitButton

--- a/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
@@ -46,7 +46,7 @@
 }
 
 .usa-alert {
-  box-shadow: 0 2px 4px color("base-light");
+  box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.15);
 
   &.toast {
     display: flex;

--- a/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-uswds-styles.scss
@@ -45,37 +45,41 @@
   }
 }
 
-.usa-alert.toast {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.usa-alert {
+  box-shadow: 0 2px 4px color("base-light");
 
-  &::before {
-    content: "";
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 2px;
-    width: 100%;
-    background-color: #4070f4;
-    animation: progress var(--toast-timeout) linear forwards;
-    z-index: 2;
-  }
+  &.toast {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
-  &.usa-alert--success::before {
-    background-color: color("success");
-  }
+    &::before {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      height: 2px;
+      width: 100%;
+      background-color: #4070f4;
+      animation: progress var(--toast-timeout) linear forwards;
+      z-index: 2;
+    }
 
-  &.usa-alert--warning::before {
-    background-color: color("warning");
-  }
+    &.usa-alert--success::before {
+      background-color: color("success");
+    }
 
-  &.usa-alert--error::before {
-    background-color: color("error");
-  }
+    &.usa-alert--warning::before {
+      background-color: color("warning");
+    }
 
-  &.usa-alert--info::before {
-    background-color: color("info");
+    &.usa-alert--error::before {
+      background-color: color("error");
+    }
+
+    &.usa-alert--info::before {
+      background-color: color("info");
+    }
   }
 }
 

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -155,6 +155,17 @@ describe("User Admin Page", () => {
       expect(results).toHaveNoViolations();
     });
 
+    it("should render a create user page with no programs", async () => {
+      (listProgramAreas as jest.Mock).mockResolvedValue([]);
+      const { container } = render(await CreateUserPage());
+      expect(container).toMatchSnapshot();
+      let results;
+      await act(async () => {
+        results = await axe(container);
+      });
+      expect(results).toHaveNoViolations();
+    });
+
     it("when creating an admin user, should not be able to choose program area access", async () => {
       const setPrograms = jest.fn();
       const numProgramsSelected = mockPrograms.filter((p) => p.checked).length;

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/ProgramAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/ProgramAdminPage.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Program Admin Page Creating programs should render a create program pag
           class="minh-5 margin-bottom-1"
         />
         <div
-          class="display-flex flex-justify margin-bottom-2"
+          class="display-flex flex-justify flex-align-center margin-bottom-2"
         >
           <h2
             class="margin-0"

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -368,6 +368,288 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
 </div>
 `;
 
+exports[`User Admin Page Creating users should render a create user page with no programs 1`] = `
+<div>
+  <main
+    class="main-container"
+  >
+    <div
+      class="content-container margin-top-3 position-relative"
+    >
+      <a
+        class="action-text display-inline-flex flex-align-center"
+        href="/admin/user"
+      >
+        <svg
+          aria-hidden="true"
+          class="usa-icon square-3"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+          />
+        </svg>
+        Back to 
+        user
+         management
+      </a>
+      <div
+        class="border-bottom border-base-lighter position-sticky top-0 isolate z-500 padding-top-1 bg-container"
+      >
+        <div
+          class="minh-5 margin-bottom-1"
+        >
+          <div
+            class="usa-alert usa-alert--warning"
+            data-testid="alert"
+          >
+            <div
+              class="usa-alert__body"
+            >
+              <h4
+                class="usa-alert__heading"
+              >
+                You haven't made any program areas
+              </h4>
+              <p
+                class="usa-alert__text"
+              >
+                When you create a user, they won't have access to any eCRs until you create a program area. 
+                <a
+                  class="usa-link"
+                  href="/ecr-viewer/admin/program/create"
+                >
+                  Create a program area
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="display-flex flex-justify margin-bottom-2"
+        >
+          <h2
+            class="margin-0"
+          >
+            Create user
+          </h2>
+          <div>
+            <button
+              class="usa-button margin-0"
+              data-testid="button"
+              disabled=""
+              form="r:id"
+              type="submit"
+            >
+              Save 
+              user
+            </button>
+          </div>
+        </div>
+      </div>
+      <form
+        class="margin-top-3 isolate"
+        id="r:id"
+      >
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            Email
+          </legend>
+          <span>
+            Add the new user by their login email
+          </span>
+          <label
+            class="usa-label"
+          >
+            Email
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+            <input
+              class="usa-input"
+              data-testid="textInput"
+              id="email"
+              name="email"
+              required=""
+              type="email"
+              value=""
+            />
+          </label>
+        </fieldset>
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            User type
+          </legend>
+          <span>
+            Select the user type
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+          </span>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
+              class="usa-radio__input"
+              id="userType-admin"
+              name="userType"
+              required=""
+              type="radio"
+              value="admin"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-admin"
+            >
+              Admin
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Admins have full access to user management, program management, and the eCR Library
+              </span>
+            </label>
+          </div>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
+              checked=""
+              class="usa-radio__input"
+              id="userType-standard"
+              name="userType"
+              required=""
+              type="radio"
+              value="standard"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-standard"
+            >
+              Standard
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Standard users can only use the eCR Library with limited access to program area(s)
+              </span>
+            </label>
+          </div>
+        </fieldset>
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            Program area access
+          </legend>
+          <span>
+            Select one or more program areas
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+          </span>
+          <p
+            class="text-bold font-size-md"
+          >
+            0
+             program area
+            s
+             
+            selected
+          </p>
+          <div
+            class="margin-right-auto"
+          >
+            <button
+              aria-controls=""
+              class="usa-button usa-button--outline margin-top-0"
+              data-testid="button"
+              type="button"
+            >
+              Select
+               all
+            </button>
+            <button
+              aria-controls=""
+              class="usa-button usa-button--outline margin-top-0"
+              data-testid="button"
+              type="button"
+            >
+              Deselect
+               all
+            </button>
+          </div>
+          <div
+            class="display-flex"
+          >
+            <div
+              class="margin-left-auto padding-top-1"
+            >
+              <button
+                class="usa-button usa-button--unstyled"
+                data-testid="button"
+                type="button"
+              >
+                Expand all 
+                program areas
+              </button>
+              <span
+                class="vertical-line"
+              />
+              <button
+                class="usa-button usa-button--unstyled"
+                data-testid="button"
+                type="button"
+              >
+                Collapse all 
+                program areas
+              </button>
+            </div>
+          </div>
+          <div
+            class="usa-accordion accordion-dibbs margin-top-3"
+            data-allow-multiple="true"
+            data-testid="accordion"
+          />
+        </fieldset>
+        <div
+          class="display-flex flex-justify-end margin-y-4"
+        >
+          <button
+            class="usa-button margin-0"
+            data-testid="button"
+            disabled=""
+            form="r:id"
+            type="submit"
+          >
+            Save 
+            user
+          </button>
+        </div>
+      </form>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`User Admin Page should list users when available 1`] = `
 <div>
   <main

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
           class="minh-5 margin-bottom-1"
         />
         <div
-          class="display-flex flex-justify margin-bottom-2"
+          class="display-flex flex-justify flex-align-center margin-bottom-2"
         >
           <h2
             class="margin-0"
@@ -405,7 +405,7 @@ exports[`User Admin Page Creating users should render a create user page with no
           class="minh-5 margin-bottom-1"
         >
           <div
-            class="usa-alert usa-alert--warning"
+            class="usa-alert usa-alert--warning usa-alert--no-icon"
             data-testid="alert"
           >
             <div
@@ -432,7 +432,7 @@ exports[`User Admin Page Creating users should render a create user page with no
           </div>
         </div>
         <div
-          class="display-flex flex-justify margin-bottom-2"
+          class="display-flex flex-justify flex-align-center margin-bottom-2"
         >
           <h2
             class="margin-0"

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -419,7 +419,8 @@ exports[`User Admin Page Creating users should render a create user page with no
               <p
                 class="usa-alert__text"
               >
-                When you create a user, they won't have access to any eCRs until you create a program area. 
+                When you create a user, they won't have access to any eCRs until you create a program area.
+                 
                 <a
                   class="usa-link"
                   href="/ecr-viewer/admin/program/create"


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add warning banner when creating a user and no program areas exist. Tweak the banner styling a bit per dibbs style and @ashton-skylight

## Related Issue

Fixes #900

## Additional Information

<img width="1199" height="695" alt="image" src="https://github.com/user-attachments/assets/db26dcdc-2845-429f-b6c2-2ae590f1331d" />
