### PR TITLE
feat: add subtitle to condition if duplicate

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
@@ -14,7 +14,7 @@ import { ConditionReference } from "@/app/data/metadataDb/types/core";
 import { ServerActionResult } from "@/app/services/errorService";
 import { formatDateTime } from "@/app/services/formatDateService";
 import { ListedProgramArea } from "@/app/services/programAreaService";
-import { makePlural, stringSort } from "@/app/utils/format-utils";
+import { makePlural } from "@/app/utils/format-utils";
 
 /**
  *
@@ -87,18 +87,23 @@ export const ProgramTable = ({
                 "No conditions assigned"
               ) : (
                 <ul className="add-list-reset">
-                  {selectedProgramArea?.conditions
-                    .sort((a, b) =>
-                      stringSort(a.condition_name, b.condition_name),
-                    )
-                    .map(({ condition_name, code }) => (
+                  {selectedProgramArea?.conditions.map(
+                    ({ condition_name, code, is_duplicate, concept_name }) => (
                       <li
                         key={code}
                         className="border-bottom border-base-lightest padding-y-1"
                       >
-                        {condition_name}
+                        <p className="margin-0">{condition_name}</p>
+                        {is_duplicate && (
+                          <p className="margin-0">
+                            <i className="text-base">
+                              {concept_name || `SNOMED ${code}`}
+                            </i>
+                          </p>
+                        )}
                       </li>
-                    ))}
+                    ),
+                  )}
                 </ul>
               ),
           },

--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -58,13 +58,10 @@ export const UserTable = ({
   programAreas: ListedProgramArea[];
   deleteAction: (uuid: string) => Promise<ServerActionResult<void>>;
 }) => {
-  const sortedProgramAreas = [...programAreas].sort((a, b) =>
-    stringSort(a.name, b.name),
-  );
   const initFilterProgramAreaState: FilterProgramAreasType = {
     [ALL_PROGRAM_AREAS_OPTION]: true,
     [NO_PROGRAM_AREA_OPTION]: true,
-    ...sortedProgramAreas.reduce((acc, program) => {
+    ...programAreas.reduce((acc, program) => {
       acc[program.name] = true;
       return acc;
     }, {} as FilterProgramAreasType),

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -7,6 +7,7 @@ import {
   Core,
   ProgramArea,
 } from "@/app/data/metadataDb/types/core";
+import { stringSort } from "@/app/utils/format-utils";
 
 import { UserFacingError } from "./errorService";
 import { getCheckAdmin } from "./userService";
@@ -159,7 +160,7 @@ export const deleteProgramArea = async (uuid: string): Promise<void> => {
 };
 
 export type ListedProgramArea = ProgramArea & {
-  conditions: ConditionReference[];
+  conditions: (ConditionReference & { is_duplicate: boolean })[];
 };
 
 /**
@@ -181,12 +182,25 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
           .selectFrom("condition_reference")
           .selectAll()
           .execute();
-        return programAreas.map((pa) => ({
-          ...pa,
-          conditions: conditionRefs.filter(
-            ({ program_area_uuid }) => program_area_uuid === pa.uuid,
-          ),
-        }));
+
+        const conditions = conditionRefs
+          .map((c) => ({
+            ...c,
+            is_duplicate: conditionRefs.some(
+              ({ condition_name, code }) =>
+                c.condition_name === condition_name && c.code !== code,
+            ),
+          }))
+          .sort((a, b) => stringSort(a.condition_name, b.condition_name));
+
+        return programAreas
+          .map((pa) => ({
+            ...pa,
+            conditions: conditions.filter(
+              ({ program_area_uuid }) => program_area_uuid === pa.uuid,
+            ),
+          }))
+          .sort((a, b) => stringSort(a.name, b.name));
       });
   } catch (error: unknown) {
     const message = "Failed to list program areas";

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -85,8 +85,8 @@ describe("program area service", () => {
         author_uuid: expect.any(String),
         date_created: expect.any(Date),
         conditions: [
-          { ...cond123, program_area_uuid: progId },
-          { ...cond456, program_area_uuid: progId },
+          { ...cond123, program_area_uuid: progId, is_duplicate: false },
+          { ...cond456, program_area_uuid: progId, is_duplicate: false },
         ],
       },
     ]);

--- a/containers/ecr-viewer/tests/unit/app/admin/ProgramAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/ProgramAdminPage.test.tsx
@@ -65,6 +65,7 @@ describe("Program Admin Page", () => {
             condition_name: "condition",
             condition_category: "category",
             program_area_uuid: "456",
+            is_duplicate: false,
           },
         ],
       },
@@ -77,9 +78,10 @@ describe("Program Admin Page", () => {
           {
             code: "456",
             concept_name: "condition 1 (disease)",
-            condition_name: "condition 1",
+            condition_name: "condition 1 (condition)",
             condition_category: "category",
             program_area_uuid: "789",
+            is_duplicate: true,
           },
           {
             code: "789",
@@ -87,6 +89,7 @@ describe("Program Admin Page", () => {
             condition_name: "condition 2",
             condition_category: "category",
             program_area_uuid: "789",
+            is_duplicate: false,
           },
         ],
       },
@@ -104,7 +107,9 @@ describe("Program Admin Page", () => {
       screen.getByRole("button", { name: "Program Area Three" }),
     );
     expect(screen.getByText("Program area information")).toBeInTheDocument();
-    expect(screen.getByText("condition 1")).toBeInTheDocument();
+    expect(screen.getByText("condition 1 (condition)")).toBeInTheDocument();
+    // subtitle due to duplicate status
+    expect(screen.getByText("condition 1 (disease)")).toBeInTheDocument();
   });
 
   describe("Creating programs", () => {

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -92,6 +92,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "456",
+        is_duplicate: false,
       },
     ],
   },
@@ -107,6 +108,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "789",
+        is_duplicate: false,
       },
       {
         code: "789",
@@ -114,6 +116,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "789",
+        is_duplicate: false,
       },
     ],
   },

--- a/containers/ecr-viewer/tests/unit/app/admin/components/UserForm.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/components/UserForm.test.tsx
@@ -26,6 +26,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "456",
+        is_duplicate: false,
       },
     ],
   },
@@ -41,6 +42,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "789",
+        is_duplicate: false,
       },
       {
         code: "789",
@@ -48,6 +50,7 @@ const mockPrograms: FormProgram[] = [
         condition_name: "condition",
         condition_category: "category",
         program_area_uuid: "789",
+        is_duplicate: false,
       },
     ],
   },


### PR DESCRIPTION
# PULL REQUEST

## Summary

In the program area side panel, add a subtitle with the condition's concept name or snomed code if that condition is one that's name is duplicated across the entire set of condition references.

I added the `is_duplicate` on the data here as we're going to need to do something similar in a couple other places that use the listed program areas

## Related Issue

Fixes #978

## Additional Information

<img width="636" height="720" alt="image" src="https://github.com/user-attachments/assets/553b2e19-352e-4b85-9cd1-013ff22b6654" />

