### PR TITLE
fix: display unavailable data uniformly

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
@@ -118,9 +118,9 @@ const UnavailableSection = ({
   return (
     data.length > 0 && (
       <AccordionSubSection title={title} idPrefix="unavailable-">
-        {data.map((item, index) => (
+        {data.map(({ title, toolTip }, index) => (
           <DataDisplay
-            item={{ ...item, value: "No data" }}
+            item={{ title, toolTip, value: "No data" }}
             className="text-italic text-base"
             key={index}
           />

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -738,7 +738,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                     </div>
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -746,7 +746,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Occupation History
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>
@@ -833,7 +833,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                     </div>
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -841,7 +841,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Disability Status
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>
@@ -1468,7 +1468,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                   >
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -1476,7 +1476,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Procedures
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>
@@ -1487,7 +1487,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                     </div>
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -1495,7 +1495,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Plan of Treatment
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>
@@ -1506,7 +1506,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                     </div>
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -1514,7 +1514,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Administered Medications
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>
@@ -1525,7 +1525,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                     </div>
                     <div>
                       <div
-                        class="grid-row flex-column"
+                        class="grid-row"
                       >
                         <div
                           class="data-title padding-right-1"
@@ -1533,7 +1533,7 @@ exports[`Snapshot test for ECR Document Given no data, info message for empty se
                           Care Team
                         </div>
                         <div
-                          class="grid-col width-full text-pre-line p-list text-italic text-base"
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
                         >
                           No data
                         </div>


### PR DESCRIPTION
# PULL REQUEST

## Summary

Only bring over the `title` and `toolTip` props when displaying an unavailable item. This avoids strange full width handling (and future proofs us against other such shenanigans) 

## Related Issue

Fixes #951

## Additional Information

<img width="979" height="1011" alt="image" src="https://github.com/user-attachments/assets/e9cc57f8-4e7f-498d-a56a-46761542c5ef" />
