### PR TITLE
feat: Add Audit Logging to eCR Search

### DIFF
--- a/containers/ecr-viewer/src/app/components/table/ecr/EcrTableContent.tsx
+++ b/containers/ecr-viewer/src/app/components/table/ecr/EcrTableContent.tsx
@@ -41,7 +41,7 @@ const EcrTableContent = async ({
 }) => {
   const startIndex = (currentPage - 1) * itemsPerPage;
 
-  const data = await listEcrData(
+  const data = await listEcrData({
     startIndex,
     itemsPerPage,
     sortColumn,
@@ -49,7 +49,7 @@ const EcrTableContent = async ({
     filterDates,
     searchTerm,
     filterConditions,
-  );
+  });
 
   return (
     <LayoutGroup>

--- a/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
+++ b/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { ExpandMore } from "@/app/components/Icon";
 import { useLibraryQueryParam } from "@/app/hooks/useQueryParam";
 import { formatDate, formatDateTime } from "@/app/services/formatDateService";
-import { EcrDisplay, RelatedEcr } from "@/app/services/listEcrDataService";
+import { EcrDisplay, RelatedEcr } from "@/app/types";
 import { noData } from "@/app/utils/data-utils";
 import { makePlural, toSentenceCase } from "@/app/utils/format-utils";
 import { saveToSessionStorage } from "@/app/utils/storage-utils";

--- a/containers/ecr-viewer/src/app/services/auditLogService.ts
+++ b/containers/ecr-viewer/src/app/services/auditLogService.ts
@@ -75,7 +75,7 @@ export const audit = <
 
 /**
  * Create an audit record on a transaction. This is a lower level function and should rarely
- * directly be used. See `audit` for a wrapepr to use in most cases
+ * directly be used. See `audit` for a wrapper to use in most cases
  * @param trx kysely transaction
  * @param subject Subject of the action being audited (e.g. "user")
  * @param action Action being done (e.g. "create")

--- a/containers/ecr-viewer/src/app/services/auditLogService.ts
+++ b/containers/ecr-viewer/src/app/services/auditLogService.ts
@@ -8,8 +8,8 @@ import { cookies, headers } from "next/headers";
 import { dbIsValid } from "@/app/api/migrate-db/migrate";
 import { getDb } from "@/app/data/metadataDb/database";
 import { Core, NewAuditLog } from "@/app/data/metadataDb/types/core";
+import { EcrDisplay } from "@/app/types";
 
-import { EcrDisplay } from "./listEcrDataService";
 import { getLoggedInUser, getUserByEmail } from "./loggedInUserService";
 
 type Subject = "ecr" | "user" | "program_area";

--- a/containers/ecr-viewer/src/app/services/auditLogService.ts
+++ b/containers/ecr-viewer/src/app/services/auditLogService.ts
@@ -9,6 +9,7 @@ import { dbIsValid } from "@/app/api/migrate-db/migrate";
 import { getDb } from "@/app/data/metadataDb/database";
 import { Core, NewAuditLog } from "@/app/data/metadataDb/types/core";
 
+import { EcrDisplay } from "./listEcrDataService";
 import { getLoggedInUser, getUserByEmail } from "./loggedInUserService";
 
 type Subject = "ecr" | "user" | "program_area";
@@ -23,7 +24,7 @@ type Action =
 
 type AuditableFn<
   Params extends Record<string, unknown>,
-  Ret extends string | boolean | void,
+  Ret extends string | boolean | EcrDisplay[] | void,
 > = (params: Params, trx: Transaction<Core>) => Promise<Ret>;
 
 /**
@@ -37,7 +38,7 @@ type AuditableFn<
  */
 export const audit = <
   Params extends Record<string, unknown>,
-  Ret extends string | boolean | void,
+  Ret extends string | boolean | EcrDisplay[] | void,
 >(
   subject: Subject,
   action: Action,

--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -107,7 +107,7 @@ export const listEcrData = audit(
 );
 
 const createSearchQuery = async (
-  db: Kysely<Core>,
+  db: Transaction<Core>,
   user: User,
   startIndex: number,
   itemsPerPage: number,

--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -83,12 +83,9 @@ export const listEcrData = audit(
     },
     trx: Transaction<Core>,
   ): Promise<EcrDisplay[]> => {
-    const user = await getLoggedInUser();
-
     try {
-      const ecrList = await createSearchQuery(
+      const ecrList = await executeSearchQuery(
         trx,
-        user!,
         startIndex,
         itemsPerPage,
         sortColumn,
@@ -106,9 +103,8 @@ export const listEcrData = audit(
   },
 );
 
-const createSearchQuery = async (
+const executeSearchQuery = async (
   db: Transaction<Core>,
-  user: User,
   startIndex: number,
   itemsPerPage: number,
   sortColumn: string,
@@ -117,6 +113,7 @@ const createSearchQuery = async (
   searchTerm?: string,
   filterConditions?: string[],
 ) => {
+  const user = await getLoggedInUser(db);
   const mainQuery = db.with("ecr_sets", (db) =>
     db
       .selectFrom("ecr_data")

--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -9,19 +9,13 @@ import {
 import { getDb } from "@/app/data/metadataDb/database";
 import { getSql } from "@/app/data/metadataDb/dialects/common";
 import { ecr_data, Core, User } from "@/app/data/metadataDb/types/core";
+import { EcrDisplay, RelatedEcr } from "@/app/types";
 import { DateRangePeriod } from "@/app/utils/date-utils";
 
 import { audit } from "./auditLogService";
 import { UserFacingError } from "./errorService";
 import { formatDate, formatDateTime } from "./formatDateService";
 import { getLoggedInUser } from "./loggedInUserService";
-
-export interface RelatedEcr {
-  eicr_id: string;
-  date_created: Date;
-  eicr_version_number: string | undefined;
-  set_id: string;
-}
 
 export interface MetadataModel {
   eicr_id: string;
@@ -35,19 +29,6 @@ export interface MetadataModel {
   last_name: string | undefined;
   birth_date: Date | undefined;
   encounter_start_date: Date | undefined;
-}
-export interface EcrDisplay {
-  ecrId: string;
-  patient_first_name: string;
-  patient_last_name: string;
-  patient_date_of_birth: string | undefined;
-  reportable_conditions: string[];
-  rule_summaries: string[];
-  patient_report_date: string;
-  date_created: string;
-  eicr_set_id: string | undefined;
-  eicr_version_number: string | undefined;
-  related_ecrs: RelatedEcr[];
 }
 
 /**

--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -3,6 +3,7 @@ import {
   ExpressionBuilder,
   OrderByExpression,
   SelectQueryBuilder,
+  Transaction,
 } from "kysely";
 
 import { getDb } from "@/app/data/metadataDb/database";
@@ -10,6 +11,8 @@ import { getSql } from "@/app/data/metadataDb/dialects/common";
 import { ecr_data, Core, User } from "@/app/data/metadataDb/types/core";
 import { DateRangePeriod } from "@/app/utils/date-utils";
 
+import { audit } from "./auditLogService";
+import { UserFacingError } from "./errorService";
 import { formatDate, formatDateTime } from "./formatDateService";
 import { getLoggedInUser } from "./loggedInUserService";
 
@@ -57,7 +60,55 @@ export interface EcrDisplay {
  * @param filterConditions - The condition(s) to filter on
  * @returns A promise resolving to a list of eCR metadata
  */
-export async function listEcrData(
+export const listEcrData = audit(
+  "ecr",
+  "query",
+  async (
+    {
+      startIndex,
+      itemsPerPage,
+      sortColumn,
+      sortDirection,
+      filterDates,
+      searchTerm,
+      filterConditions,
+    }: {
+      startIndex: number;
+      itemsPerPage: number;
+      sortColumn: string;
+      sortDirection: string;
+      filterDates: DateRangePeriod;
+      searchTerm?: string;
+      filterConditions?: string[];
+    },
+    trx: Transaction<Core>,
+  ): Promise<EcrDisplay[]> => {
+    const user = await getLoggedInUser();
+
+    try {
+      const ecrList = await createSearchQuery(
+        trx,
+        user!,
+        startIndex,
+        itemsPerPage,
+        sortColumn,
+        sortDirection,
+        filterDates,
+        searchTerm,
+        filterConditions,
+      );
+      return processMetadata(ecrList);
+    } catch (error: unknown) {
+      const message = "Failed to query eCRs";
+      console.error({ message, error });
+      throw new UserFacingError(message);
+    }
+  },
+);
+
+const createSearchQuery = async (
+  db: Kysely<Core>,
+  user: User,
   startIndex: number,
   itemsPerPage: number,
   sortColumn: string,
@@ -65,63 +116,50 @@ export async function listEcrData(
   filterDates: DateRangePeriod,
   searchTerm?: string,
   filterConditions?: string[],
-): Promise<EcrDisplay[]> {
-  const user = await getLoggedInUser();
+) => {
+  const mainQuery = db.with("ecr_sets", (db) =>
+    db
+      .selectFrom("ecr_data")
+      .$call((qb) => limitEcrDataToUser(user, qb))
+      .select(({ eb }) => [
+        "ecr_data.set_id",
+        eb.fn
+          .max(eb.cast<number>("ecr_data.eicr_version_number", "integer"))
+          .as("max_version_number"),
+      ])
+      .groupBy(["ecr_data.set_id"])
+      .where((eb) =>
+        generateWhereStatement(eb, filterDates, searchTerm, filterConditions),
+      ),
+  );
 
-  const res = await getDb<Core>()
-    .transaction()
-    .execute(async (trx) => {
-      const mainQuery = trx.with("ecr_sets", (db) =>
-        db
-          .selectFrom("ecr_data")
-          .$call((qb) => limitEcrDataToUser(user, qb))
-          .select(({ eb }) => [
-            "ecr_data.set_id",
-            eb.fn
-              .max(eb.cast<number>("ecr_data.eicr_version_number", "integer"))
-              .as("max_version_number"),
-          ])
-          .groupBy(["ecr_data.set_id"])
-          .where((eb) =>
-            generateWhereStatement(
-              eb,
-              filterDates,
-              searchTerm,
-              filterConditions,
-            ),
+  const ecrQuery = mainQuery.with("ecrs", (db) =>
+    db
+      .selectFrom("ecr_sets")
+      .leftJoin("ecr_data", (join) =>
+        join
+          .onRef("ecr_data.set_id", "=", "ecr_sets.set_id")
+          .on("ecr_sets.max_version_number", "=", (eb) =>
+            eb.cast<number>("ecr_data.eicr_version_number", "integer"),
           ),
-      );
+      )
+      .select([
+        "ecr_data.eicr_id",
+        "ecr_data.first_name",
+        "ecr_data.last_name",
+        "ecr_data.birth_date",
+        "ecr_data.encounter_start_date",
+        "ecr_data.date_created",
+        "ecr_data.set_id",
+        "ecr_data.eicr_version_number",
+      ])
+      .orderBy(generateSortStatement(sortColumn, sortDirection))
+      .offset(startIndex)
+      .fetch(itemsPerPage),
+  );
 
-      const ecrQuery = mainQuery.with("ecrs", (db) =>
-        db
-          .selectFrom("ecr_sets")
-          .leftJoin("ecr_data", (join) =>
-            join
-              .onRef("ecr_data.set_id", "=", "ecr_sets.set_id")
-              .on("ecr_sets.max_version_number", "=", (eb) =>
-                eb.cast<number>("ecr_data.eicr_version_number", "integer"),
-              ),
-          )
-          .select([
-            "ecr_data.eicr_id",
-            "ecr_data.first_name",
-            "ecr_data.last_name",
-            "ecr_data.birth_date",
-            "ecr_data.encounter_start_date",
-            "ecr_data.date_created",
-            "ecr_data.set_id",
-            "ecr_data.eicr_version_number",
-          ])
-          .orderBy(generateSortStatement(sortColumn, sortDirection))
-          .offset(startIndex)
-          .fetch(itemsPerPage),
-      );
-
-      return await getMetaModelData(ecrQuery as unknown as Kysely<EcrsCte>);
-    });
-
-  return processMetadata(res);
-}
+  return await getMetaModelData(ecrQuery as unknown as Kysely<EcrsCte>);
+};
 
 const limitEcrDataToUser = (
   user: User | undefined,

--- a/containers/ecr-viewer/src/app/types.ts
+++ b/containers/ecr-viewer/src/app/types.ts
@@ -1,0 +1,20 @@
+export interface RelatedEcr {
+  eicr_id: string;
+  date_created: Date;
+  eicr_version_number: string | undefined;
+  set_id: string;
+}
+
+export interface EcrDisplay {
+  ecrId: string;
+  patient_first_name: string;
+  patient_last_name: string;
+  patient_date_of_birth: string | undefined;
+  reportable_conditions: string[];
+  rule_summaries: string[];
+  patient_report_date: string;
+  date_created: string;
+  eicr_set_id: string | undefined;
+  eicr_version_number: string | undefined;
+  related_ecrs: RelatedEcr[];
+}

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -22,7 +22,6 @@ import { dbNamespace } from "@/app/data/metadataDb/utils/db-config";
 import { formatDate, formatDateTime } from "@/app/services/formatDateService";
 import {
   MetadataModel,
-  EcrDisplay,
   generateFilterConditionsStatement,
   generateSearchStatement,
   generateWhereStatement,
@@ -31,6 +30,7 @@ import {
   listEcrData,
   generateFilterDateStatement,
 } from "@/app/services/listEcrDataService";
+import { EcrDisplay } from "@/app/types";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 const filterDates = {

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -179,7 +179,6 @@ describe("listEcrData - core", () => {
     sortColumn: string,
     sortDirection: string,
   ) => {
-    // Check audit log
     const log = await getLastAuditLog();
     expect(log.subject).toEqual("ecr");
     expect(log.action).toEqual("query");

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -191,12 +191,15 @@ describe("listEcrData - core", () => {
     const log = await getLastAuditLog();
     expect(log.subject).toEqual("ecr");
     expect(log.action).toEqual("query");
-    expect(JSON.parse(log.parameter_json)).toEqual({
+    expect(JSON.parse(log.parameter_json)).toStrictEqual({
       startIndex,
       itemsPerPage,
       sortColumn,
       sortDirection,
-      filterDates,
+      filterDates: {
+        startDate: filterDates.startDate,
+        endDate: filterDates.endDate,
+      },
     });
 
     expect(actual).toBeEmpty();

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -173,20 +173,12 @@ describe("process Metadata", () => {
 });
 
 describe("listEcrData - core", () => {
-  it("should return empty array when no data is found", async () => {
-    const startIndex = 0;
-    const itemsPerPage = 25;
-    const sortColumn = "date_created";
-    const sortDirection = "DESC";
-
-    const actual = await listEcrData({
-      startIndex,
-      itemsPerPage,
-      sortColumn,
-      sortDirection,
-      filterDates,
-    });
-
+  const checkAuditLog = async (
+    startIndex: number,
+    itemsPerPage: number,
+    sortColumn: string,
+    sortDirection: string,
+  ) => {
     // Check audit log
     const log = await getLastAuditLog();
     expect(log.subject).toEqual("ecr");
@@ -201,7 +193,22 @@ describe("listEcrData - core", () => {
         endDate: filterDates.endDate.toISOString(),
       },
     });
+  };
 
+  it("should return empty array when no data is found", async () => {
+    const startIndex = 0;
+    const itemsPerPage = 25;
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+
+    const actual = await listEcrData({
+      startIndex,
+      itemsPerPage,
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toBeEmpty();
 
     const actualCount = await getTotalEcrCount(filterDates);
@@ -233,6 +240,7 @@ describe("listEcrData - core", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -295,6 +303,7 @@ describe("listEcrData - core", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([]);
 
     const actualCount = await getTotalEcrCount(filterDates);
@@ -332,6 +341,7 @@ describe("listEcrData - core", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -386,6 +396,7 @@ describe("listEcrData - core", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([]);
 
     const actualCount = await getTotalEcrCount(filterDates);

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -12,6 +12,7 @@ import {
   createCoreEcr,
   createEcrCondition,
   createEcrRule,
+  getLastAuditLog,
 } from "../helpers/core";
 import { buildCore, dropExisting, clearEcrCore } from "../helpers/ddl";
 import { seedUserProgramData } from "../helpers/seed";
@@ -63,8 +64,8 @@ const getWhere = (
     | ExpressionWrapper<Core, "ecr_data", SqlBool>
     | AndWrapper<Core, "ecr_data", SqlBool>,
 ) => {
-  const coredb = getDb<Core>();
-  const rawRes = coredb.selectFrom("ecr_data").where(ebCallBack).compile();
+  const coreDb = getDb<Core>();
+  const rawRes = coreDb.selectFrom("ecr_data").where(ebCallBack).compile();
   const start = `select from "${dbNamespace()}"."ecr_data" where `;
   return { sql: rawRes.sql.slice(start.length), params: rawRes.parameters };
 };
@@ -179,6 +180,18 @@ describe("listEcrData - core", () => {
     const sortDirection = "DESC";
 
     const actual = await listEcrData({
+      startIndex,
+      itemsPerPage,
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
+
+    // Check audit log
+    const log = await getLastAuditLog();
+    expect(log.subject).toEqual("ecr");
+    expect(log.action).toEqual("query");
+    expect(JSON.parse(log.parameter_json)).toStrictEqual({
       startIndex,
       itemsPerPage,
       sortColumn,

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -197,8 +197,8 @@ describe("listEcrData - core", () => {
       sortColumn,
       sortDirection,
       filterDates: {
-        startDate: filterDates.startDate,
-        endDate: filterDates.endDate,
+        startDate: filterDates.startDate.toISOString(),
+        endDate: filterDates.endDate.toISOString(),
       },
     });
 

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -32,7 +32,7 @@ import {
 } from "@/app/services/listEcrDataService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
-const testDateRange = {
+const filterDates = {
   startDate: new Date("12-01-2024"),
   endDate: new Date("12-03-2024"),
 };
@@ -175,20 +175,20 @@ describe("listEcrData - core", () => {
   it("should return empty array when no data is found", async () => {
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
 
-    const actual = await listEcrData(
+    const actual = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
 
     expect(actual).toBeEmpty();
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
   });
 
@@ -208,15 +208,15 @@ describe("listEcrData - core", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -238,7 +238,7 @@ describe("listEcrData - core", () => {
       },
     ]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrCore();
@@ -270,18 +270,18 @@ describe("listEcrData - core", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrCore();
@@ -307,15 +307,15 @@ describe("listEcrData - core", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -337,7 +337,7 @@ describe("listEcrData - core", () => {
       },
     ]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrCore();
@@ -361,18 +361,18 @@ describe("listEcrData - core", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrCore();
@@ -390,19 +390,19 @@ describe("get total core ecr count", () => {
   });
 
   it("should call db to get all ecrs", async () => {
-    const actual = await getTotalEcrCount(testDateRange);
+    const actual = await getTotalEcrCount(filterDates);
     expect(actual).toEqual(1);
   });
   it("should use search term in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "blah", undefined);
+    const actual = await getTotalEcrCount(filterDates, "blah", undefined);
     expect(actual).toEqual(0);
   });
   it("should escape the search term in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "O'Riley", undefined);
+    const actual = await getTotalEcrCount(filterDates, "O'Riley", undefined);
     expect(actual).toEqual(0);
   });
   it("should use filter conditions in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "", [
+    const actual = await getTotalEcrCount(filterDates, "", [
       "Anthrax (disorder)",
     ]);
     expect(actual).toEqual(0);
@@ -502,7 +502,7 @@ describe("generate filter conditions statement", () => {
 
   it("should add date range in the filter statement", () => {
     const { sql, params } = getWhere((eb) =>
-      generateFilterDateStatement(eb, testDateRange),
+      generateFilterDateStatement(eb, filterDates),
     );
     if (process.env.METADATA_DATABASE_TYPE === "postgres") {
       expect(sql).toEqual(
@@ -514,15 +514,12 @@ describe("generate filter conditions statement", () => {
       );
     }
 
-    expect(params).toStrictEqual([
-      testDateRange.startDate,
-      testDateRange.endDate,
-    ]);
+    expect(params).toStrictEqual([filterDates.startDate, filterDates.endDate]);
   });
 
   it("should display all conditions in date range by default if no filter has been added", () => {
     const { sql, params } = getWhere((eb) =>
-      generateWhereStatement(eb, testDateRange, "", undefined),
+      generateWhereStatement(eb, filterDates, "", undefined),
     );
     if (process.env.METADATA_DATABASE_TYPE === "postgres") {
       expect(sql).toEqual(
@@ -537,8 +534,8 @@ describe("generate filter conditions statement", () => {
     expect(params).toStrictEqual([
       true,
       true,
-      testDateRange.startDate,
-      testDateRange.endDate,
+      filterDates.startDate,
+      filterDates.endDate,
       true,
       true,
     ]);
@@ -548,7 +545,7 @@ describe("generate filter conditions statement", () => {
 describe("generate where statement", () => {
   it("should generate where statement using search and filter statements", () => {
     const { sql, params } = getWhere((eb) =>
-      generateWhereStatement(eb, testDateRange, "blah", ["Anthrax (disorder)"]),
+      generateWhereStatement(eb, filterDates, "blah", ["Anthrax (disorder)"]),
     );
     if (process.env.METADATA_DATABASE_TYPE === "postgres") {
       expect(sql).toEqual(
@@ -563,14 +560,14 @@ describe("generate where statement", () => {
     expect(params).toStrictEqual([
       "%blah%",
       "%blah%",
-      testDateRange.startDate,
-      testDateRange.endDate,
+      filterDates.startDate,
+      filterDates.endDate,
       "%Anthrax (disorder)%",
     ]);
   });
   it("should generate where statement using search statement (no conditions filter provided)", () => {
     const { sql, params } = getWhere((eb) =>
-      generateWhereStatement(eb, testDateRange, "blah", undefined),
+      generateWhereStatement(eb, filterDates, "blah", undefined),
     );
     if (process.env.METADATA_DATABASE_TYPE === "postgres") {
       expect(sql).toEqual(
@@ -585,15 +582,15 @@ describe("generate where statement", () => {
     expect(params).toStrictEqual([
       "%blah%",
       "%blah%",
-      testDateRange.startDate,
-      testDateRange.endDate,
+      filterDates.startDate,
+      filterDates.endDate,
       true,
       true,
     ]);
   });
   it("should generate where statement using filter conditions statement (no search provided)", () => {
     const { sql, params } = getWhere((eb) =>
-      generateWhereStatement(eb, testDateRange, "", ["Anthrax (disorder)"]),
+      generateWhereStatement(eb, filterDates, "", ["Anthrax (disorder)"]),
     );
     if (process.env.METADATA_DATABASE_TYPE === "postgres") {
       expect(sql).toEqual(
@@ -608,8 +605,8 @@ describe("generate where statement", () => {
     expect(params).toStrictEqual([
       true,
       true,
-      testDateRange.startDate,
-      testDateRange.endDate,
+      filterDates.startDate,
+      filterDates.endDate,
       "%Anthrax (disorder)%",
     ]);
   });

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -191,7 +191,7 @@ describe("listEcrData - core", () => {
     const log = await getLastAuditLog();
     expect(log.subject).toEqual("ecr");
     expect(log.action).toEqual("query");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
+    expect(JSON.parse(log.parameter_json)).toEqual({
       startIndex,
       itemsPerPage,
       sortColumn,

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -2,7 +2,11 @@
  * @jest-environment node
  */
 
-import { createEcrCondition, createEcrRule } from "../helpers/core";
+import {
+  createEcrCondition,
+  createEcrRule,
+  getLastAuditLog,
+} from "../helpers/core";
 import { buildExtended, dropExisting, clearEcrExtended } from "../helpers/ddl";
 import { createExtendedEcr } from "../helpers/extended";
 import { seedUserProgramData } from "../helpers/seed";
@@ -93,6 +97,27 @@ afterAll(async () => {
 });
 
 describe("listEcrData - extended", () => {
+  const checkAuditLog = async (
+    startIndex: number,
+    itemsPerPage: number,
+    sortColumn: string,
+    sortDirection: string,
+  ) => {
+    // Check audit log
+    const log = await getLastAuditLog();
+    expect(log.subject).toEqual("ecr");
+    expect(log.action).toEqual("query");
+    expect(JSON.parse(log.parameter_json)).toStrictEqual({
+      startIndex,
+      itemsPerPage,
+      sortColumn,
+      sortDirection,
+      filterDates: {
+        startDate: filterDates.startDate.toISOString(),
+        endDate: filterDates.endDate.toISOString(),
+      },
+    });
+  };
   it("should return empty array when no data is found", async () => {
     const startIndex = 0;
     const itemsPerPage = 25;
@@ -106,7 +131,7 @@ describe("listEcrData - extended", () => {
       sortDirection,
       filterDates,
     });
-
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toBeEmpty();
 
     const actualCount = await getTotalEcrCount(filterDates);
@@ -128,14 +153,19 @@ describe("listEcrData - extended", () => {
     });
 
     // Act
+    const startIndex = 0;
+    const itemsPerPage = 10;
+    const sortColumn = "report_date";
+    const sortDirection = "DESC";
     const actual = await listEcrData({
-      startIndex: 0,
-      itemsPerPage: 10,
-      sortColumn: "report_date",
-      sortDirection: "DESC",
+      startIndex,
+      itemsPerPage,
+      sortColumn,
+      sortDirection,
       filterDates,
     });
     // Assert
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -197,6 +227,7 @@ describe("listEcrData - extended", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([]);
 
     const actualCount = await getTotalEcrCount(filterDates);
@@ -234,6 +265,7 @@ describe("listEcrData - extended", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -288,6 +320,7 @@ describe("listEcrData - extended", () => {
       sortDirection,
       filterDates,
     });
+    checkAuditLog(startIndex, itemsPerPage, sortColumn, sortDirection);
     expect(actual).toStrictEqual([]);
 
     const actualCount = await getTotalEcrCount(filterDates);

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@/app/services/listEcrDataService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
-const testDateRange = {
+const filterDates = {
   startDate: new Date("12-01-2024"),
   endDate: new Date("12-03-2024"),
 };
@@ -96,20 +96,20 @@ describe("listEcrData - extended", () => {
   it("should return empty array when no data is found", async () => {
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
 
-    const actual = await listEcrData(
+    const actual = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
 
     expect(actual).toBeEmpty();
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
   });
 
@@ -128,13 +128,13 @@ describe("listEcrData - extended", () => {
     });
 
     // Act
-    const actual = await listEcrData(
-      0,
-      10,
-      "report_date",
-      "DESC",
-      testDateRange,
-    );
+    const actual = await listEcrData({
+      startIndex: 0,
+      itemsPerPage: 10,
+      sortColumn: "report_date",
+      sortDirection: "DESC",
+      filterDates,
+    });
     // Assert
     expect(actual).toStrictEqual([
       {
@@ -157,7 +157,7 @@ describe("listEcrData - extended", () => {
       },
     ]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrExtended();
@@ -188,18 +188,18 @@ describe("listEcrData - extended", () => {
     });
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrExtended();
@@ -225,15 +225,15 @@ describe("listEcrData - extended", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([
       {
         date_created: "12/02/2024 7:00\u00A0AM\u00A0EST",
@@ -255,7 +255,7 @@ describe("listEcrData - extended", () => {
       },
     ]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrExtended();
@@ -279,18 +279,18 @@ describe("listEcrData - extended", () => {
 
     const startIndex = 0;
     const itemsPerPage = 25;
-    const columnName = "date_created";
-    const direction = "DESC";
-    const actual: EcrDisplay[] = await listEcrData(
+    const sortColumn = "date_created";
+    const sortDirection = "DESC";
+    const actual: EcrDisplay[] = await listEcrData({
       startIndex,
       itemsPerPage,
-      columnName,
-      direction,
-      testDateRange,
-    );
+      sortColumn,
+      sortDirection,
+      filterDates,
+    });
     expect(actual).toStrictEqual([]);
 
-    const actualCount = await getTotalEcrCount(testDateRange);
+    const actualCount = await getTotalEcrCount(filterDates);
     expect(actualCount).toEqual(actual.length);
 
     await clearEcrExtended();
@@ -306,19 +306,19 @@ describe("get total extended ecr count", () => {
   afterAll(async () => await clearEcrExtended());
 
   it("should call db to get all ecrs", async () => {
-    const actual = await getTotalEcrCount(testDateRange);
+    const actual = await getTotalEcrCount(filterDates);
     expect(actual).toEqual(1);
   });
   it("should use search term in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "blah", undefined);
+    const actual = await getTotalEcrCount(filterDates, "blah", undefined);
     expect(actual).toEqual(0);
   });
   it("should escape the search term in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "O'Riley", undefined);
+    const actual = await getTotalEcrCount(filterDates, "O'Riley", undefined);
     expect(actual).toEqual(0);
   });
   it("should use filter conditions in count query", async () => {
-    const actual = await getTotalEcrCount(testDateRange, "", [
+    const actual = await getTotalEcrCount(filterDates, "", [
       "Anthrax (disorder)",
     ]);
     expect(actual).toEqual(0);

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -12,10 +12,10 @@ import { createExtendedEcr } from "../helpers/extended";
 import { seedUserProgramData } from "../helpers/seed";
 import { NewExtendedECR } from "@/app/data/metadataDb/types/extended";
 import {
-  EcrDisplay,
   getTotalEcrCount,
   listEcrData,
 } from "@/app/services/listEcrDataService";
+import { EcrDisplay } from "@/app/types";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 const filterDates = {

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -103,7 +103,6 @@ describe("listEcrData - extended", () => {
     sortColumn: string,
     sortDirection: string,
   ) => {
-    // Check audit log
     const log = await getLastAuditLog();
     expect(log.subject).toEqual("ecr");
     expect(log.action).toEqual("query");

--- a/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
@@ -161,14 +161,14 @@ describe("EcrTableContent", () => {
     );
 
     expect(mockedListEcrData).toHaveBeenCalledTimes(1);
-    expect(mockedListEcrData).toHaveBeenCalledWith(
-      0,
-      25,
-      "date_created",
-      "DESC",
-      mockDateRange,
-      "blah",
-      ["Anthrax (disorder)"],
-    );
+    expect(mockedListEcrData).toHaveBeenCalledWith({
+      startIndex: 0,
+      itemsPerPage: 25,
+      sortColumn: "date_created",
+      sortDirection: "DESC",
+      filterDates: mockDateRange,
+      searchTerm: "blah",
+      filterConditions: ["Anthrax (disorder)"],
+    });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
@@ -4,7 +4,8 @@ import { axe } from "jest-axe";
 import router from "next-router-mock";
 
 import EcrTableContent from "@/app/components/table/ecr/EcrTableContent";
-import { EcrDisplay, listEcrData } from "@/app/services/listEcrDataService";
+import { listEcrData } from "@/app/services/listEcrDataService";
+import { EcrDisplay } from "@/app/types";
 import { range } from "@/app/utils/data-utils";
 
 jest.mock("@/app/data/metadataDb/database");


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add audit logging to eCR search.

## Related Issue

Fixes #963

## Acceptance Criteria

- [ ] When the library page is loaded `ecr` `query` audit log is also emitted (when db is available)
- [ ] Integration test is added to ensure the log is added when expected

