### PR TITLE
build: Update Node and npm engine requirements

### DIFF
--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -1,9 +1,11 @@
 {
   "name": "ecr-viewer",
-  "packageManager": "npm@11.1.0",
   "description": "The DIBBs eCR Viewer app offers a REST API for processing FHIR messages into an HTML page with key insights.",
-  "version": "1.0.1",
   "private": true,
+  "engines": { 
+    "node": "^24",
+    "npm": "^11"
+  },
   "scripts": {
     "docs": "typedoc --customCss guides/assets/styles.css",
     "dev": "next dev",

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -2,7 +2,7 @@
   "name": "ecr-viewer",
   "description": "The DIBBs eCR Viewer app offers a REST API for processing FHIR messages into an HTML page with key insights.",
   "private": true,
-  "engines": { 
+  "engines": {
     "node": "^24",
     "npm": "^11"
   },


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Set `Node` and `npm` versions in `package.json`
- Remove `version` since we aren't releasing `ecr-viewer` as a package

## Related Issue

Fixes N/A

(I had an older version of Node (~`20`), and I was experiencing random-ish? test failures locally