### PR TITLE
fix: Add program areas to confirmation modal

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -430,15 +430,17 @@ const ConfirmationModal = ({
   onConfirm: () => void;
   modalRef: RefObject<ModalRef>;
 }) => {
-  const prevProgramAreas = Array.from(new Set(categoryConditions.map(c => c.program_area_name)));
+  const prevProgramAreas = Array.from(
+    new Set(categoryConditions.map((c) => c.program_area_name)),
+  );
   const prevProgramAreasStr = (() => {
     if (prevProgramAreas.length === 1) {
       return prevProgramAreas[0];
     } else if (prevProgramAreas.length === 2) {
       return prevProgramAreas.join(" and ");
     } else if (prevProgramAreas.length > 2) {
-      return `${(prevProgramAreas.slice(0, -1)).join(", ")}, and ${prevProgramAreas[prevProgramAreas.length - 1]}`;
-    };
+      return `${prevProgramAreas.slice(0, -1).join(", ")}, and ${prevProgramAreas[prevProgramAreas.length - 1]}`;
+    }
   })();
 
   return (
@@ -485,7 +487,7 @@ const ConfirmationModal = ({
                     <li key={condition_name}>
                       {condition_name}, {program_area_name}
                     </li>
-                  )
+                  ),
                 )}
               </ul>
             </div>

--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -20,7 +20,12 @@ import { ToastContext } from "@/app/components/toast/ToastProvider";
 import { ServerActionResult } from "@/app/services/errorService";
 import { ListedCondition } from "@/app/services/listConditionsService";
 import { AccordionItem } from "@/app/types";
-import { makePlural, stringSort, toKebabCase, toReadableListString } from "@/app/utils/format-utils";
+import {
+  makePlural,
+  stringSort,
+  toKebabCase,
+  toReadableListString,
+} from "@/app/utils/format-utils";
 
 interface FormCondition extends ListedCondition {
   checked?: boolean;
@@ -434,7 +439,7 @@ const ConfirmationModal = ({
     ...new Set(
       categoryConditions
         .map((c) => c?.program_area_name)
-        .filter((p) => p !== null)
+        .filter((p) => p !== null),
     ),
   ].sort(stringSort);
 

--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -430,6 +430,17 @@ const ConfirmationModal = ({
   onConfirm: () => void;
   modalRef: RefObject<ModalRef>;
 }) => {
+  const prevProgramAreas = Array.from(new Set(categoryConditions.map(c => c.program_area_name)));
+  const prevProgramAreasStr = (() => {
+    if (prevProgramAreas.length === 1) {
+      return prevProgramAreas[0];
+    } else if (prevProgramAreas.length === 2) {
+      return prevProgramAreas.join(" and ");
+    } else if (prevProgramAreas.length > 2) {
+      return `${(prevProgramAreas.slice(0, -1)).join(", ")}, and ${prevProgramAreas[prevProgramAreas.length - 1]}`;
+    };
+  })();
+
   return (
     <Modal
       id="confirm-condition"
@@ -464,8 +475,8 @@ const ConfirmationModal = ({
             <div id="confirm-condition-description">
               <p>
                 A condition can only live in one program area. If you add the
-                below conditions to this program area, they will be removed from
-                their current program area.
+                below conditions to this program area, they will be removed
+                {prevProgramAreasStr && <> from {prevProgramAreasStr}</>}.
               </p>
 
               <ul>
@@ -474,7 +485,7 @@ const ConfirmationModal = ({
                     <li key={condition_name}>
                       {condition_name}, {program_area_name}
                     </li>
-                  ),
+                  )
                 )}
               </ul>
             </div>

--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -20,7 +20,7 @@ import { ToastContext } from "@/app/components/toast/ToastProvider";
 import { ServerActionResult } from "@/app/services/errorService";
 import { ListedCondition } from "@/app/services/listConditionsService";
 import { AccordionItem } from "@/app/types";
-import { makePlural, stringSort, toKebabCase } from "@/app/utils/format-utils";
+import { makePlural, stringSort, toKebabCase, toReadableListString } from "@/app/utils/format-utils";
 
 interface FormCondition extends ListedCondition {
   checked?: boolean;
@@ -430,16 +430,13 @@ const ConfirmationModal = ({
   onConfirm: () => void;
   modalRef: RefObject<ModalRef>;
 }) => {
-  const prevProgramAreas = Array.from(new Set(categoryConditions.map(c => c.program_area_name)));
-  const prevProgramAreasStr = (() => {
-    if (prevProgramAreas.length === 1) {
-      return prevProgramAreas[0];
-    } else if (prevProgramAreas.length === 2) {
-      return prevProgramAreas.join(" and ");
-    } else if (prevProgramAreas.length > 2) {
-      return `${(prevProgramAreas.slice(0, -1)).join(", ")}, and ${prevProgramAreas[prevProgramAreas.length - 1]}`;
-    };
-  })();
+  const prevProgramAreas = [
+    ...new Set(
+      categoryConditions
+        .map((c) => c?.program_area_name)
+        .filter((p) => p !== null)
+    ),
+  ].sort(stringSort);
 
   return (
     <Modal
@@ -475,8 +472,8 @@ const ConfirmationModal = ({
             <div id="confirm-condition-description">
               <p>
                 A condition can only live in one program area. If you add the
-                below conditions to this program area, they will be removed
-                {prevProgramAreasStr && <> from {prevProgramAreasStr}</>}.
+                below conditions to this program area, they will be removed from{" "}
+                {toReadableListString(prevProgramAreas)}.
               </p>
 
               <ul>

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -106,5 +106,5 @@ export const toReadableListString = (arr: Array<string>) => {
   } else if (arr.length > 2) {
     return `${arr.slice(0, -1).join(", ")}, and ${arr[arr.length - 1]}`;
   }
-  return ""
+  return "";
 };

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -98,7 +98,7 @@ export const stringSort = (a: string, b: string) => a.localeCompare(b);
  * @param arr - An array of strings.
  * @returns A readable string list using commas and 'and', or empty string if array is empty.
  */
-export const toReadableListString = (arr: Array<string>) => {
+export const toReadableListString = (arr: string[]) => {
   if (arr.length === 1) {
     return arr[0];
   } else if (arr.length === 2) {

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -90,3 +90,21 @@ export const makePlural = (value: number): "s" | "" => {
  * @returns number indicating order
  */
 export const stringSort = (a: string, b: string) => a.localeCompare(b);
+
+/**
+ * Converts an array of strings into a human-readable list.
+ * [a, b] => "a and b"
+ * [a, b, c] => "a, b, and c"
+ * @param arr - An array of strings.
+ * @returns A readable string list using commas and 'and', or empty string if array is empty.
+ */
+export const toReadableListString = (arr: Array<string>) => {
+  if (arr.length === 1) {
+    return arr[0];
+  } else if (arr.length === 2) {
+    return arr.join(" and ");
+  } else if (arr.length > 2) {
+    return `${arr.slice(0, -1).join(", ")}, and ${arr[arr.length - 1]}`;
+  }
+  return ""
+};

--- a/containers/ecr-viewer/tests/unit/app/utils/format-utils.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/utils/format-utils.test.tsx
@@ -105,11 +105,15 @@ describe("FormatService tests", () => {
     });
 
     it("joins items with 'and' if array has two items", () => {
-      expect(toReadableListString(["apples", "bananas"])).toBe("apples and bananas");
+      expect(toReadableListString(["apples", "bananas"])).toBe(
+        "apples and bananas",
+      );
     });
 
     it("joins items with commas and 'and' if array has 3 or more items", () => {
-      expect(toReadableListString(["apples", "bananas", "carrots", "dahlias"])).toBe("apples, bananas, carrots, and dahlias");
+      expect(
+        toReadableListString(["apples", "bananas", "carrots", "dahlias"]),
+      ).toBe("apples, bananas, carrots, and dahlias");
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/utils/format-utils.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/utils/format-utils.test.tsx
@@ -1,6 +1,7 @@
 import {
   toKebabCase,
   extractNumbersAndPeriods,
+  toReadableListString,
   toSentenceCase,
   toTitleCase,
 } from "@/app/utils/format-utils";
@@ -91,6 +92,24 @@ describe("FormatService tests", () => {
     it("should return undefined if string is empty", () => {
       const result = toTitleCase(undefined);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("toReadableListString", () => {
+    it("returns an empty string for an empty array", () => {
+      expect(toReadableListString([])).toBe("");
+    });
+
+    it("returns the single string if array has one item", () => {
+      expect(toReadableListString(["apples"])).toBe("apples");
+    });
+
+    it("joins items with 'and' if array has two items", () => {
+      expect(toReadableListString(["apples", "bananas"])).toBe("apples and bananas");
+    });
+
+    it("joins items with commas and 'and' if array has 3 or more items", () => {
+      expect(toReadableListString(["apples", "bananas", "carrots", "dahlias"])).toBe("apples, bananas, carrots, and dahlias");
     });
   });
 });


### PR DESCRIPTION
# PULL REQUEST
## Summary

Lists program area(s) when a user moves multiple reportable conditions 

## Related Issue
Fixes #909 

## Screenshots
When moving multiple reportable conditions & reportable conditions come from 1 other program area:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/574a60ff-5c53-41f1-bb67-8d32cf8b80a7" />

When moving multiple reportable conditions & reportable conditions come from 2 program areas:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/e46c6f4c-5da8-484a-810d-9a8992221317" />

When moving multiple reportable conditions & reportable conditions come from 2+ program areas:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/5eed572b-9523-4911-9a99-33304a9b37a6" />

## Acceptance Criteria

When a user moves multiple reportable conditions, these reportable conditions can come from different program areas.
- [ ] When there are 2 program areas, the format in the modal should look like: `Program area and program area'
- [ ] When there are 2+ program areas, the format in the modal should like: 'Program area, program area, and program area'

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
