### PR TITLE
fix: safe parsing update and arrayToElement fix for modern times

### DIFF
--- a/containers/ecr-viewer/package-lock.json
+++ b/containers/ecr-viewer/package-lock.json
@@ -17,7 +17,7 @@
         "classnames": "^2.5.1",
         "fhirpath": "^4.5.1",
         "focus-trap-react": "^11.0.4",
-        "html-react-parser": "^5.2.5",
+        "html-react-parser": "^5.2.6",
         "jose": "6.0.11",
         "js-cookie": "^3.0.5",
         "kysely": "^0.27.6",
@@ -12288,15 +12288,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "node_modules/html-react-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.5.tgz",
-      "integrity": "sha512-bRPdv8KTqG9CEQPMNGksDqmbiRfVQeOidry8pVetdh/1jQ1Edx4KX5m0lWvDD89Pt4CqTYjK1BLz6NoNVxN/Uw==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
+      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
         "html-dom-parser": "5.1.1",
         "react-property": "2.0.2",
-        "style-to-js": "1.1.16"
+        "style-to-js": "1.1.17"
       },
       "peerDependencies": {
         "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
@@ -12503,7 +12503,8 @@
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
-      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -20248,17 +20249,19 @@
       "license": "MIT"
     },
     "node_modules/style-to-js": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
-      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "license": "MIT",
       "dependencies": {
-        "style-to-object": "1.0.8"
+        "style-to-object": "1.0.9"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.4"
       }

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -44,7 +44,7 @@
     "classnames": "^2.5.1",
     "fhirpath": "^4.5.1",
     "focus-trap-react": "^11.0.4",
-    "html-react-parser": "^5.2.5",
+    "html-react-parser": "^5.2.6",
     "jose": "6.0.11",
     "js-cookie": "^3.0.5",
     "kysely": "^0.27.6",

--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -117,7 +117,7 @@ export const arrayToElement = (vals: RenderableNode[]) => {
         return typeof item !== "object" ? (
           <Fragment key={key}>{item}</Fragment>
         ) : (
-          { ...item, key }
+          item
         );
       })}
     </>


### PR DESCRIPTION
# PULL REQUEST

## Summary

Change array to element to not add a key if it's an object (this seems to already be happening by safe parse now). Also, update `html-react-parser` (not the issue, but might as well)