### PR TITLE
test: fix login/out audit log check

### DIFF
--- a/containers/ecr-viewer/playwright.config.ts
+++ b/containers/ecr-viewer/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: false && !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */

--- a/containers/ecr-viewer/playwright.config.ts
+++ b/containers/ecr-viewer/playwright.config.ts
@@ -17,8 +17,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  // TODO PR: undo this
-  forbidOnly: false && !!process.env.CI,
+  forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */

--- a/containers/ecr-viewer/playwright.config.ts
+++ b/containers/ecr-viewer/playwright.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
+  // TODO PR: undo this
   forbidOnly: false && !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,

--- a/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
@@ -10,7 +10,7 @@ test.describe("auth", () => {
     page,
   }) => {
     const logInStartTime = Date.now();
-    await logIn(page);
+    await logIn(page, { useCookies: false });
     const logInEndTime = Date.now();
 
     await page

--- a/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
@@ -6,7 +6,7 @@ import { Core } from "@/app/data/metadataDb/types/core";
 import { setupConfigurationVariables } from "@/instrumentation";
 
 test.describe("auth", () => {
-  test.only("should require a login on main page and allow sign out", async ({
+  test("should require a login on main page and allow sign out", async ({
     page,
   }) => {
     const logInStartTime = Date.now();

--- a/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
@@ -6,7 +6,7 @@ import { Core } from "@/app/data/metadataDb/types/core";
 import { setupConfigurationVariables } from "@/instrumentation";
 
 test.describe("auth", () => {
-  test("should require a login on main page and allow sign out", async ({
+  test.only("should require a login on main page and allow sign out", async ({
     page,
   }) => {
     const logInStartTime = Date.now();
@@ -36,6 +36,9 @@ test.describe("auth", () => {
     const logOutEndTime = Date.now();
     await expect(page.getByText("You need to sign in")).toBeVisible();
 
+    // sleep for a second to give time for logs to settle
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
     setupConfigurationVariables();
     const signinLogs = await getDb<Core>()
       .selectFrom("audit_log")
@@ -49,6 +52,20 @@ test.describe("auth", () => {
       .where("subject", "=", "user")
       .where("action", "=", "signout")
       .execute();
+
+    console.log({
+      logInStartTime,
+      logInEndTime,
+      signinLogs: signinLogs
+        .filter(
+          ({ parameter_json, date }) =>
+            JSON.parse(parameter_json).user.email ===
+              process.env.AUTH_ADMIN_USER &&
+            date.valueOf() >= logInStartTime &&
+            date.valueOf() <= logInEndTime + 5000,
+        )
+        .map(({ date }) => date.valueOf()),
+    });
 
     // Log in and logout for our user within 5 seconds of the recorded time
     expect(

--- a/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
@@ -37,7 +37,7 @@ test.describe("auth", () => {
     await expect(page.getByText("You need to sign in")).toBeVisible();
 
     // sleep for a second to give time for logs to settle
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 4000));
 
     setupConfigurationVariables();
     const signinLogs = await getDb<Core>()
@@ -61,8 +61,8 @@ test.describe("auth", () => {
           ({ parameter_json, date }) =>
             JSON.parse(parameter_json).user.email ===
               process.env.AUTH_ADMIN_USER &&
-            date.valueOf() >= logInStartTime &&
-            date.valueOf() <= logInEndTime + 5000,
+            date.valueOf() >= logInStartTime - 5000 &&
+            date.valueOf() <= logInEndTime + 10000,
         )
         .map(({ date }) => date.valueOf()),
     });

--- a/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/authn.spec.ts
@@ -10,6 +10,7 @@ test.describe("auth", () => {
     page,
   }) => {
     const logInStartTime = Date.now();
+    // make sure we actually log in and don't reuse an old session
     await logIn(page, { useCookies: false });
     const logInEndTime = Date.now();
 
@@ -36,9 +37,6 @@ test.describe("auth", () => {
     const logOutEndTime = Date.now();
     await expect(page.getByText("You need to sign in")).toBeVisible();
 
-    // sleep for a second to give time for logs to settle
-    await new Promise((resolve) => setTimeout(resolve, 4000));
-
     setupConfigurationVariables();
     const signinLogs = await getDb<Core>()
       .selectFrom("audit_log")
@@ -52,20 +50,6 @@ test.describe("auth", () => {
       .where("subject", "=", "user")
       .where("action", "=", "signout")
       .execute();
-
-    console.log({
-      logInStartTime,
-      logInEndTime,
-      signinLogs: signinLogs
-        .filter(
-          ({ parameter_json, date }) =>
-            JSON.parse(parameter_json).user.email ===
-              process.env.AUTH_ADMIN_USER &&
-            date.valueOf() >= logInStartTime - 5000 &&
-            date.valueOf() <= logInEndTime + 10000,
-        )
-        .map(({ date }) => date.valueOf()),
-    });
 
     // Log in and logout for our user within 5 seconds of the recorded time
     expect(

--- a/containers/ecr-viewer/tests/e2e/utils.ts
+++ b/containers/ecr-viewer/tests/e2e/utils.ts
@@ -14,6 +14,7 @@ const cookies: { [key in UserType]?: Cookie[] } = {};
  * @param config.url optionally, the url to go to to force login
  * @param config.expectedHeading optionally, the heading text to expect upon successful login
  * @param config.userType optionally, the user type to log in with. Default "ADMIN"
+ * @param config.useCookies optionally, whether to use the pre-saved cookie if available. Default true
  */
 export const logIn = async (
   page: Page,
@@ -21,22 +22,24 @@ export const logIn = async (
     url?: string;
     expectedHeading?: string;
     userType?: UserType;
+    useCookies?: boolean;
   } = {},
 ) => {
   const {
     url = "/ecr-viewer/",
     expectedHeading = "eCR library",
     userType = "ADMIN",
+    useCookies = cookies[userType],
   } = config;
 
-  if (cookies[userType]) {
+  if (useCookies) {
     // set cookies to previously saved ones
     await page.context().addCookies(cookies[userType]!);
   }
 
   await page.goto(url);
 
-  if (!cookies[userType]) {
+  if (!useCookies) {
     // Not using NBS auth, strip out search param token
     let newUrl = url.replace(/&?auth\=[^&]+/, "");
     if (newUrl.endsWith("?")) {
@@ -67,7 +70,7 @@ export const logIn = async (
     page.getByRole("heading", { name: expectedHeading }).first(),
   ).toBeVisible();
 
-  if (!cookies[userType]) {
+  if (!useCookies) {
     // save cookies
     cookies[userType] = await page.context().cookies();
   }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add an option to not use cookies, so that when we do the test that checks the audit logging on logging in and out we ensure that we actually do log in and not re-use an old session.

This was consistently flaking as it would fail the first time, playwright would run it in a new process at which point the log in would happen and it would pass

## Related Issue

Fixes #1075
