### PR TITLE
fix: FHIR Converter ID Update

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-16 --depth 1 /build/FHIR-Converter
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch josh/id-conversion --depth 1 /build/FHIR-Converter
 
 WORKDIR /build/FHIR-Converter
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch josh/id-conversion --depth 1 /build/FHIR-Converter
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-18 --depth 1 /build/FHIR-Converter
 
 WORKDIR /build/FHIR-Converter
 

--- a/containers/fhir-converter/tests/integration/__snapshots__/test_FHIR-Converter.ambr
+++ b/containers/fhir-converter/tests/integration/__snapshots__/test_FHIR-Converter.ambr
@@ -474,7 +474,7 @@
             'identifier': list([
               dict({
                 'system': 'urn:ietf:rfc:3986',
-                'value': 'urn:uuid:2.16.540.1.113883.19.2',
+                'value': 'urn:oid:2.16.540.1.113883.19.2',
               }),
             ]),
             'meta': dict({
@@ -643,6 +643,7 @@
                     'valueCoding': dict({
                       'code': '1966-1',
                       'display': 'Aleut',
+                      'system': 'urn:oid:2.16.840.1.113883.6.238',
                     }),
                   }),
                   dict({
@@ -659,6 +660,7 @@
                     'valueCoding': dict({
                       'code': '2186-5',
                       'display': 'Not Hispanic or Latino',
+                      'system': 'urn:oid:2.16.840.1.113883.6.238',
                     }),
                   }),
                   dict({


### PR DESCRIPTION
# PULL REQUEST

## Summary

Updates the FHIR Converter version so that the ecr-viewer uses the updates to ID conversion

## Related Issue

Fixes #1053 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

See the corresponding PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/40

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
