### PR TITLE
fix: reset condition search term when library filter resets

### DIFF
--- a/containers/ecr-viewer/src/app/components/EcrFilters.tsx
+++ b/containers/ecr-viewer/src/app/components/EcrFilters.tsx
@@ -162,6 +162,7 @@ const FilterReportableConditions = ({
       tag={`${numSelected}`}
       touched={touched}
       submitHandler={() => {
+        setSearchTerm("");
         updateQueryParam(ParamName.Condition, filterConditions, isAllSelected);
         pushQueryUpdate();
       }}


### PR DESCRIPTION
# PULL REQUEST

## Summary

What changes are being proposed?

Fix minor UX bug I noticed where the search term wasn't reseting with the condition filter closed
