### PR TITLE
fix: Lab Tags - Abnormal Lab Tags

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -156,6 +156,8 @@ export type PathTypes = {
   observationDeviceReference: Reference;
   observationOrganismMethod: ValueX;
   observationResultStatus: string;
+  labReportInterpretation: ValueX;
+  observationInterpretation: Coding;
   organizations: Organization;
   patientTravelHistory: Observation;
   travelHistoryLocation: string;
@@ -653,6 +655,14 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   observationResultStatus: {
     type: "string",
     path: "iif(extension('http://terminology.hl7.org/ValueSet/v2-0085').valueCodeableConcept.coding.display.exists(), extension('http://terminology.hl7.org/ValueSet/v2-0085').valueCodeableConcept.coding.display, status)",
+  },
+  labReportInterpretation: {
+    type: "ValueX",
+    path: "Observation.where(code.coding.exists(system = 'http://loinc.org' and code = '56850-1')).value",
+  },
+  observationInterpretation: {
+    type: "Coding",
+    path: "Observation.interpretation.coding.where(system = 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation')",
   },
 
   // Organization

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -62,6 +62,46 @@ export interface LabReportElementData {
   diagnosticReportDataItems: AccordionItem[];
   organizationDisplayDataProps: DisplayDataProps[];
 }
+export interface AbnormalObservationInterpretation {
+  code: 'AA' | 'HH' | 'LL' | 'HU' | 'LU';
+  display: string;
+  color: string;
+  backgroundColor: string;
+}
+
+const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
+  'AA': { 
+    display: 'Critical Abnormal', 
+    color: '#FFFFFF',
+    backgroundColor: '#B50909'
+  },
+  'HH': { 
+    display: 'Critical High', 
+    color: '#FFFFFF',
+    backgroundColor: '#B50909'
+  },
+  'LL': { 
+    display: 'Critical Low', 
+    color: '#FFFFFF',
+    backgroundColor: '#B50909'
+  },
+  'HU': { 
+    display: 'Significantly High', 
+    color: '#000000',
+    backgroundColor: '#FFA500'
+  },
+  'LU': { 
+    display: 'Significantly Low', 
+    color: '#000000',
+    backgroundColor: '#FFA500'
+  }
+} as const;
+
+type AbnormalObservationInterpretationCode = keyof typeof ABNORMAL_OBSERVATION_INTERPRETATIONS;
+
+const isAbnormalObservationInterpretation = (code: string): code is AbnormalObservationInterpretationCode => {
+  return code in ABNORMAL_OBSERVATION_INTERPRETATIONS;
+};
 
 /**
  * Evaluates lab information and RR data from the provided FHIR bundle and mappings.
@@ -95,11 +135,7 @@ export const evaluateLabInfoData = (
         <div className="display-flex flex-row flex-justify flex-align-center gap-05">
           <span>
             {title}
-            {checkAbnormalTag(labReportJson) && (
-              <Tag background="#B50909" className="margin-left-105">
-                Abnormal
-              </Tag>
-            )}
+            {renderLabAbnormalityTag(obs, labReportJson)}
           </span>
 
           {/** inline style due to existing css rules on this button text */}
@@ -239,6 +275,91 @@ export const checkAbnormalTag = (labReportJson?: HtmlTableJson): boolean => {
   const labResultName = labReportJson.resultName;
 
   return labResultName?.toLowerCase().includes("abnormal") ?? false;
+};
+
+/**
+ * Evaluates FHIR observations for abnormal HL7 interpretation codes
+ * @param observations Array of FHIR observations
+ * @returns Abnormal observation interpretation or null if none found
+ */
+export const evaluateAbnormalObservationInterpretation = (
+  observations: Observation[]
+): AbnormalObservationInterpretation | null => {
+  if (!observations || observations.length === 0) {
+    return null;
+  }
+
+  for (const observation of observations) {
+    if (!observation.interpretation || observation.interpretation.length === 0) {
+      continue;
+    }
+
+    for (const interpretation of observation.interpretation) {
+      if (!interpretation.coding || interpretation.coding.length === 0) {
+        continue;
+      }
+
+      for (const coding of interpretation.coding) {
+        // Verify this is an HL7 observation interpretation code
+        if (coding.system !== 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation') {
+          continue;
+        }
+
+        const code = coding.code;
+        if (!code || !isAbnormalObservationInterpretation(code)) {
+          continue;
+        }
+
+        const interpretationConfig = ABNORMAL_OBSERVATION_INTERPRETATIONS[code];
+        return {
+          code: code,
+          display: coding.display || interpretationConfig.display,
+          color: interpretationConfig.color,
+          backgroundColor: interpretationConfig.backgroundColor
+        };
+      }
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Renders a lab tag for abnormal observation interpretations
+ * @param observations Array of FHIR observation resources
+ * @param labReportJson Fallback HTML-based lab report data for backwards compatibility
+ * @returns React element for the lab tag, or null if no abnormality
+ */
+const renderLabAbnormalityTag = (
+  observations: Observation[],
+  labReportJson?: HtmlTableJson
+): React.ReactNode => {
+  const abnormalInterpretation = evaluateAbnormalObservationInterpretation(observations);
+  if (abnormalInterpretation) {
+    return (
+      <Tag 
+        style={{
+          backgroundColor: abnormalInterpretation.backgroundColor,
+          color: abnormalInterpretation.color,
+          fontWeight: 'bold'
+        }}
+        className="margin-left-105"
+      >
+        {abnormalInterpretation.display}
+      </Tag>
+    );
+  }
+
+  // Fall back to existing abnormal detection for backwards compatibility
+  if (checkAbnormalTag(labReportJson)) {
+    return (
+      <Tag background="#B50909" className="margin-left-105">
+        Abnormal
+      </Tag>
+    );
+  }
+
+  return null;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -64,11 +64,11 @@ export interface LabReportElementData {
 }
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
-  "AA": "Critical Abnormal",
-  "HH": "Critical High", 
-  "LL": "Critical Low",
-  "HU": "Significantly High",
-  "LU": "Significantly Low",
+  AA: "Critical Abnormal",
+  HH: "Critical High",
+  LL: "Critical Low",
+  HU: "Significantly High",
+  LU: "Significantly Low",
 } as const;
 
 type AbnormalObservationInterpretationCode =

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -62,27 +62,13 @@ export interface LabReportElementData {
   diagnosticReportDataItems: AccordionItem[];
   organizationDisplayDataProps: DisplayDataProps[];
 }
-export interface AbnormalObservationInterpretation {
-  code: "AA" | "HH" | "LL" | "HU" | "LU";
-  display: string;
-}
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
-  AA: {
-    display: "Critical Abnormal",
-  },
-  HH: {
-    display: "Critical High",
-  },
-  LL: {
-    display: "Critical Low",
-  },
-  HU: {
-    display: "Significantly High",
-  },
-  LU: {
-    display: "Significantly Low",
-  },
+  "AA": "Critical Abnormal",
+  "HH": "Critical High", 
+  "LL": "Critical Low",
+  "HU": "Significantly High",
+  "LU": "Significantly Low",
 } as const;
 
 type AbnormalObservationInterpretationCode =
@@ -280,7 +266,7 @@ export const checkAbnormalTag = (labReportJson?: HtmlTableJson): boolean => {
  */
 export const evaluateAbnormalObservationInterpretation = (
   observations: Observation[],
-): AbnormalObservationInterpretation | null => {
+): { code: string; display: string } | null => {
   if (!observations || observations.length === 0) {
     return null;
   }
@@ -312,12 +298,10 @@ export const evaluateAbnormalObservationInterpretation = (
           continue;
         }
 
-        const interpretationConfig = ABNORMAL_OBSERVATION_INTERPRETATIONS[code];
+        const display = ABNORMAL_OBSERVATION_INTERPRETATIONS[code];
         return {
           code,
-          display: coding.display || interpretationConfig.display,
-          color: interpretationConfig.color,
-          backgroundColor: interpretationConfig.backgroundColor,
+          display,
         };
       }
     }

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -100,7 +100,12 @@ const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
 type AbnormalObservationInterpretationCode =
   keyof typeof ABNORMAL_OBSERVATION_INTERPRETATIONS;
 
-const isAbnormalObservationInterpretation = (
+/**
+ *
+ * @param code HL7 observation interptetation code
+ * @returns true if code is in list of abnormal observation interpretation codes
+ */
+export const isAbnormalObservationInterpretation = (
   code: string,
 ): code is AbnormalObservationInterpretationCode => {
   return code in ABNORMAL_OBSERVATION_INTERPRETATIONS;
@@ -321,7 +326,7 @@ export const evaluateAbnormalObservationInterpretation = (
 
         const interpretationConfig = ABNORMAL_OBSERVATION_INTERPRETATIONS[code];
         return {
-          code: code,
+          code,
           display: coding.display || interpretationConfig.display,
           color: interpretationConfig.color,
           backgroundColor: interpretationConfig.backgroundColor,

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -330,7 +330,7 @@ export const evaluateAbnormalObservationInterpretation = (
  * @param labReportJson Fallback HTML-based lab report data for backwards compatibility
  * @returns React element for the lab tag, or null if no abnormality
  */
-const renderLabAbnormalityTag = (
+export const renderLabAbnormalityTag = (
   observations: Observation[],
   labReportJson?: HtmlTableJson
 ): React.ReactNode => {

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -336,8 +336,6 @@ export const renderLabAbnormalityTag = (
   observations: Observation[],
   labReportJson?: HtmlTableJson,
 ): React.ReactNode => {
-  
-
   const abnormalInterpretation =
     evaluateAbnormalObservationInterpretation(observations);
   if (abnormalInterpretation) {

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -65,35 +65,23 @@ export interface LabReportElementData {
 export interface AbnormalObservationInterpretation {
   code: "AA" | "HH" | "LL" | "HU" | "LU";
   display: string;
-  color: string;
-  backgroundColor: string;
 }
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
   AA: {
     display: "Critical Abnormal",
-    color: "#FFFFFF",
-    backgroundColor: "#B50909",
   },
   HH: {
     display: "Critical High",
-    color: "#FFFFFF",
-    backgroundColor: "#B50909",
   },
   LL: {
     display: "Critical Low",
-    color: "#FFFFFF",
-    backgroundColor: "#B50909",
   },
   HU: {
     display: "Significantly High",
-    color: "#000000",
-    backgroundColor: "#FFA500",
   },
   LU: {
     display: "Significantly Low",
-    color: "#000000",
-    backgroundColor: "#FFA500",
   },
 } as const;
 
@@ -348,18 +336,13 @@ export const renderLabAbnormalityTag = (
   observations: Observation[],
   labReportJson?: HtmlTableJson,
 ): React.ReactNode => {
+  
+
   const abnormalInterpretation =
     evaluateAbnormalObservationInterpretation(observations);
   if (abnormalInterpretation) {
     return (
-      <Tag
-        style={{
-          backgroundColor: abnormalInterpretation.backgroundColor,
-          color: abnormalInterpretation.color,
-          fontWeight: "bold",
-        }}
-        className="margin-left-105"
-      >
+      <Tag background="#B50909" className="margin-left-105">
         {abnormalInterpretation.display}
       </Tag>
     );

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -1,5 +1,5 @@
 import "server-only";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { HeadingLevel, Tag } from "@trussworks/react-uswds";
 import {
@@ -41,6 +41,7 @@ import {
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import {
   extractNumbersAndPeriods,
+  stringSort,
   toKebabCase,
 } from "@/app/utils/format-utils";
 import {
@@ -63,26 +64,13 @@ export interface LabReportElementData {
   organizationDisplayDataProps: DisplayDataProps[];
 }
 
-const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
+const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
+  A: "Abnormal",
   AA: "Critical Abnormal",
   HH: "Critical High",
   LL: "Critical Low",
   HU: "Significantly High",
   LU: "Significantly Low",
-} as const;
-
-type AbnormalObservationInterpretationCode =
-  keyof typeof ABNORMAL_OBSERVATION_INTERPRETATIONS;
-
-/**
- *
- * @param code HL7 observation interptetation code
- * @returns true if code is in list of abnormal observation interpretation codes
- */
-export const isAbnormalObservationInterpretation = (
-  code: string,
-): code is AbnormalObservationInterpretationCode => {
-  return code in ABNORMAL_OBSERVATION_INTERPRETATIONS;
 };
 
 /**
@@ -117,11 +105,17 @@ export const evaluateLabInfoData = (
         <div className="display-flex flex-row flex-justify flex-align-center gap-05">
           <span>
             {title}
-            {renderLabAbnormalityTag(obs, labReportJson)}
+            <LabInterpretationTag
+              observations={obs}
+              labReportJson={labReportJson}
+            />
           </span>
 
           {/** inline style due to existing css rules on this button text */}
-          <span className="text-base" style={{ fontSize: "1rem" }}>
+          <span
+            className="text-base flex-shrink-0"
+            style={{ fontSize: "1rem" }}
+          >
             {evaluateValue(report, fhirPathMappings.effectiveX)}
           </span>
         </div>
@@ -245,6 +239,12 @@ export const getAllLabJsonObjects = (fhirBundle: Bundle): HtmlTableJson[] => {
   return formatTablesToJSON(labsString);
 };
 
+const isAbnormal = (interpretation: string) => {
+  return Object.values(ABNORMAL_OBSERVATION_INTERPRETATIONS).some((v) =>
+    interpretation.toLowerCase().includes(v.toLowerCase()),
+  );
+};
+
 /**
  * Checks whether the result name of a lab report includes the term "abnormal"
  * @param labReportJson - A JSON object representing the lab report HTML string
@@ -256,7 +256,7 @@ export const checkAbnormalTag = (labReportJson?: HtmlTableJson): boolean => {
   }
   const labResultName = labReportJson.resultName;
 
-  return labResultName?.toLowerCase().includes("abnormal") ?? false;
+  return !!labResultName && isAbnormal(labResultName);
 };
 
 /**
@@ -264,79 +264,76 @@ export const checkAbnormalTag = (labReportJson?: HtmlTableJson): boolean => {
  * @param observations Array of FHIR observations
  * @returns Abnormal observation interpretation or null if none found
  */
-export const evaluateAbnormalObservationInterpretation = (
+const evaluateAbnormalInterpretation = (
   observations: Observation[],
-): { code: string; display: string } | null => {
-  if (!observations || observations.length === 0) {
-    return null;
-  }
+): string[] => {
+  const abnormalInterpretations = evaluateAll(
+    observations,
+    fhirPathMappings.observationInterpretation,
+  )
+    .filter(
+      ({ code }) =>
+        !!code && ABNORMAL_OBSERVATION_INTERPRETATIONS.hasOwnProperty(code),
+    )
+    .map(({ code }) => ABNORMAL_OBSERVATION_INTERPRETATIONS[code!]);
 
-  for (const observation of observations) {
-    if (
-      !observation.interpretation ||
-      observation.interpretation.length === 0
-    ) {
-      continue;
-    }
-
-    for (const interpretation of observation.interpretation) {
-      if (!interpretation.coding || interpretation.coding.length === 0) {
-        continue;
-      }
-
-      for (const coding of interpretation.coding) {
-        // Verify this is an HL7 observation interpretation code
-        if (
-          coding.system !==
-          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
-        ) {
-          continue;
-        }
-
-        const code = coding.code;
-        if (!code || !isAbnormalObservationInterpretation(code)) {
-          continue;
-        }
-
-        const display = ABNORMAL_OBSERVATION_INTERPRETATIONS[code];
-        return {
-          code,
-          display,
-        };
-      }
-    }
-  }
-
-  return null;
+  // unique-ify and sort
+  return [...new Set(abnormalInterpretations)].sort(stringSort);
 };
+
+const InterpretationTag = ({
+  isAbnormal,
+  children,
+}: {
+  isAbnormal: boolean;
+  children: ReactNode;
+}) => (
+  <Tag
+    background={isAbnormal ? "#B50909" : "#adadad"}
+    className="margin-left-105"
+  >
+    {children}
+  </Tag>
+);
 
 /**
  * Renders a lab tag for abnormal observation interpretations
- * @param observations Array of FHIR observation resources
- * @param labReportJson Fallback HTML-based lab report data for backwards compatibility
+ * @param props react props
+ * @param props.observations Array of FHIR observation resources
+ * @param props.labReportJson Fallback HTML-based lab report data for backwards compatibility
  * @returns React element for the lab tag, or null if no abnormality
  */
-export const renderLabAbnormalityTag = (
-  observations: Observation[],
-  labReportJson?: HtmlTableJson,
-): React.ReactNode => {
-  const abnormalInterpretation =
-    evaluateAbnormalObservationInterpretation(observations);
-  if (abnormalInterpretation) {
+export const LabInterpretationTag = ({
+  observations,
+  labReportJson,
+}: {
+  observations: Observation[];
+  labReportJson?: HtmlTableJson;
+}): React.ReactNode => {
+  const reportInterpretation = evaluateValue(
+    observations,
+    fhirPathMappings.labReportInterpretation,
+  );
+  if (reportInterpretation) {
     return (
-      <Tag background="#B50909" className="margin-left-105">
-        {abnormalInterpretation.display}
-      </Tag>
+      <InterpretationTag isAbnormal={isAbnormal(reportInterpretation)}>
+        {reportInterpretation}
+      </InterpretationTag>
     );
+  }
+
+  const abnormalInterpretations = evaluateAbnormalInterpretation(observations);
+  if (abnormalInterpretations.length > 0) {
+    return abnormalInterpretations.map((interpretation) => (
+      <InterpretationTag key={interpretation} isAbnormal={true}>
+        {interpretation}
+      </InterpretationTag>
+    ));
   }
 
   // Fall back to existing abnormal detection for backwards compatibility
   if (checkAbnormalTag(labReportJson)) {
-    return (
-      <Tag background="#B50909" className="margin-left-105">
-        Abnormal
-      </Tag>
-    );
+    return <InterpretationTag isAbnormal={true}>Abnormal</InterpretationTag>;
   }
 
   return null;

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -63,43 +63,46 @@ export interface LabReportElementData {
   organizationDisplayDataProps: DisplayDataProps[];
 }
 export interface AbnormalObservationInterpretation {
-  code: 'AA' | 'HH' | 'LL' | 'HU' | 'LU';
+  code: "AA" | "HH" | "LL" | "HU" | "LU";
   display: string;
   color: string;
   backgroundColor: string;
 }
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS = {
-  'AA': { 
-    display: 'Critical Abnormal', 
-    color: '#FFFFFF',
-    backgroundColor: '#B50909'
+  AA: {
+    display: "Critical Abnormal",
+    color: "#FFFFFF",
+    backgroundColor: "#B50909",
   },
-  'HH': { 
-    display: 'Critical High', 
-    color: '#FFFFFF',
-    backgroundColor: '#B50909'
+  HH: {
+    display: "Critical High",
+    color: "#FFFFFF",
+    backgroundColor: "#B50909",
   },
-  'LL': { 
-    display: 'Critical Low', 
-    color: '#FFFFFF',
-    backgroundColor: '#B50909'
+  LL: {
+    display: "Critical Low",
+    color: "#FFFFFF",
+    backgroundColor: "#B50909",
   },
-  'HU': { 
-    display: 'Significantly High', 
-    color: '#000000',
-    backgroundColor: '#FFA500'
+  HU: {
+    display: "Significantly High",
+    color: "#000000",
+    backgroundColor: "#FFA500",
   },
-  'LU': { 
-    display: 'Significantly Low', 
-    color: '#000000',
-    backgroundColor: '#FFA500'
-  }
+  LU: {
+    display: "Significantly Low",
+    color: "#000000",
+    backgroundColor: "#FFA500",
+  },
 } as const;
 
-type AbnormalObservationInterpretationCode = keyof typeof ABNORMAL_OBSERVATION_INTERPRETATIONS;
+type AbnormalObservationInterpretationCode =
+  keyof typeof ABNORMAL_OBSERVATION_INTERPRETATIONS;
 
-const isAbnormalObservationInterpretation = (code: string): code is AbnormalObservationInterpretationCode => {
+const isAbnormalObservationInterpretation = (
+  code: string,
+): code is AbnormalObservationInterpretationCode => {
   return code in ABNORMAL_OBSERVATION_INTERPRETATIONS;
 };
 
@@ -283,14 +286,17 @@ export const checkAbnormalTag = (labReportJson?: HtmlTableJson): boolean => {
  * @returns Abnormal observation interpretation or null if none found
  */
 export const evaluateAbnormalObservationInterpretation = (
-  observations: Observation[]
+  observations: Observation[],
 ): AbnormalObservationInterpretation | null => {
   if (!observations || observations.length === 0) {
     return null;
   }
 
   for (const observation of observations) {
-    if (!observation.interpretation || observation.interpretation.length === 0) {
+    if (
+      !observation.interpretation ||
+      observation.interpretation.length === 0
+    ) {
       continue;
     }
 
@@ -301,7 +307,10 @@ export const evaluateAbnormalObservationInterpretation = (
 
       for (const coding of interpretation.coding) {
         // Verify this is an HL7 observation interpretation code
-        if (coding.system !== 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation') {
+        if (
+          coding.system !==
+          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+        ) {
           continue;
         }
 
@@ -315,7 +324,7 @@ export const evaluateAbnormalObservationInterpretation = (
           code: code,
           display: coding.display || interpretationConfig.display,
           color: interpretationConfig.color,
-          backgroundColor: interpretationConfig.backgroundColor
+          backgroundColor: interpretationConfig.backgroundColor,
         };
       }
     }
@@ -332,16 +341,17 @@ export const evaluateAbnormalObservationInterpretation = (
  */
 export const renderLabAbnormalityTag = (
   observations: Observation[],
-  labReportJson?: HtmlTableJson
+  labReportJson?: HtmlTableJson,
 ): React.ReactNode => {
-  const abnormalInterpretation = evaluateAbnormalObservationInterpretation(observations);
+  const abnormalInterpretation =
+    evaluateAbnormalObservationInterpretation(observations);
   if (abnormalInterpretation) {
     return (
-      <Tag 
+      <Tag
         style={{
           backgroundColor: abnormalInterpretation.backgroundColor,
           color: abnormalInterpretation.color,
-          fontWeight: 'bold'
+          fontWeight: "bold",
         }}
         className="margin-left-105"
       >

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/LabInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/LabInfo.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`LabInfo when labResults is DisplayDataProps[] should match snapshot tes
                       SARS-CoV-2 (COVID-19) RNA [Presence] in Respiratory system specimen by NAA with probe detection
                     </span>
                     <span
-                      class="text-base"
+                      class="text-base flex-shrink-0"
                       style="font-size: 1rem;"
                     />
                   </div>
@@ -507,7 +507,7 @@ Mos Eisley, CO 00055
                       </span>
                     </span>
                     <span
-                      class="text-base"
+                      class="text-base flex-shrink-0"
                       style="font-size: 1rem;"
                     >
                       02/04/2000 3:51 PM EST
@@ -902,7 +902,7 @@ Mos Eisley, CO 00055
                       Stool Pathogens 12 To 25 Targets
                     </span>
                     <span
-                      class="text-base"
+                      class="text-base flex-shrink-0"
                       style="font-size: 1rem;"
                     >
                       02/04/2000 3:51 PM EST
@@ -1405,7 +1405,7 @@ County: Empire
                       Cytogenomic SNP microarray
                     </span>
                     <span
-                      class="text-base"
+                      class="text-base flex-shrink-0"
                       style="font-size: 1rem;"
                     >
                       05/05/1824 11:58 AM GMT-4:56:02

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/labsService.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/labsService.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`LabsService tests Labs Utils returnFieldValueFromLabHtmlString extracts correct field value from within a lab report 1`] = `
+exports[`LabsService tests returnFieldValueFromLabHtmlString extracts correct field value from within a lab report 1`] = `
 <React.Fragment>
   <p>
     <span>

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -20,7 +20,6 @@ import {
   evaluateOrganismsReportData,
   evaluateDiagnosticReportData,
   evaluateLabOrganizationData,
-  evaluateAbnormalObservationInterpretation,
   ResultObject,
   combineOrgAndReportData,
   evaluateLabInfoData,
@@ -30,8 +29,7 @@ import {
   getJsonLab,
   getAllLabJsonObjects,
   getObservations,
-  isAbnormalObservationInterpretation,
-  renderLabAbnormalityTag,
+  LabInterpretationTag,
 } from "@/app/view-data/services/labsService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
@@ -292,391 +290,392 @@ describe("LabsService tests", () => {
       });
     });
 
-    describe("isAbnormalObservationInterpretation", () => {
-      it("sohuld return true if code is in list of abnormal observation interpretations", () => {
-        const codes = ["AA", "HH", "LL", "HU", "LU"].forEach((code) => {
-          const result = isAbnormalObservationInterpretation(code);
-          expect(result).toBeTrue();
-        });
-      });
-
-      it("sohuld return false if code is not in list of abnormal observation interpretations", () => {
-        const result = isAbnormalObservationInterpretation("ZZ");
-        expect(result).toBeFalse();
-      });
-    });
-
-    describe("evaluateAbnormalObservationInterpretation", () => {
-      it("should return null if observations is empty", () => {
-        const result = evaluateAbnormalObservationInterpretation([]);
-        expect(result).toBeNull();
+    describe("LabInterpretationTag", () => {
+      it("should return null if no observations", () => {
+        const { container } = render(
+          <LabInterpretationTag observations={[]} />,
+        );
+        expect(container).toBeEmptyDOMElement();
       });
 
       it("should return null if observation interpretation is undefined", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: undefined,
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
+        const { container } = render(
+          <LabInterpretationTag
+            observations={[
+              {
+                interpretation: undefined,
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
+              },
+            ]}
+          />,
+        );
+        expect(container).toBeEmptyDOMElement();
       });
 
       it("should return null if observation interpretation is empty", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
-      });
-
-      it("should return null if observation interpretation coding is undefined", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [{ coding: undefined }],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
-      });
-
-      it("should return null if observation interpretation coding is empty", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [{ coding: [] }],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
+        const { container } = render(
+          <LabInterpretationTag
+            observations={[
+              {
+                interpretation: [],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
+              },
+            ]}
+          />,
+        );
+        expect(container).toBeEmptyDOMElement();
       });
 
       it("should return null if observation interpretation coding is not HL7 observation interpretation code", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [{ coding: [{ system: "http://test.com" }] }],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
-      });
-
-      it("should return null if observation interpretation coding code is undefined", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [
+        const { container } = render(
+          <LabInterpretationTag
+            observations={[
               {
-                coding: [
-                  {
-                    system:
-                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                    code: undefined,
-                  },
-                ],
+                interpretation: [{ coding: [{ system: "http://test.com" }] }],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
               },
-            ],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
+            ]}
+          />,
+        );
+        expect(container).toBeEmptyDOMElement();
       });
 
       it("should return null if observation interpretation coding code is not abnormal", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [
+        const { container } = render(
+          <LabInterpretationTag
+            observations={[
               {
-                coding: [
+                interpretation: [
                   {
-                    system:
-                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                    code: "ZZ",
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "ZZ",
+                      },
+                    ],
                   },
                 ],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
               },
-            ],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-        expect(result).toBeNull();
+            ]}
+          />,
+        );
+        expect(container).toBeEmptyDOMElement();
       });
 
       it("should return AbnormalObservationInterpretation if code is abnormal", () => {
-        const result = evaluateAbnormalObservationInterpretation([
-          {
-            interpretation: [
+        render(
+          <LabInterpretationTag
+            observations={[
               {
-                coding: [
+                interpretation: [
                   {
-                    system:
-                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                    code: "AA",
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "AA",
+                      },
+                    ],
                   },
                 ],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
               },
-            ],
-            resourceType: "Observation",
-            code: { coding: undefined },
-            status: "unknown",
-          },
-        ]);
-
-        expect(result?.code).toBe("AA");
-        expect(result?.display).toBe("Critical Abnormal");
-      });
-    });
-
-    describe("renderLabAbnormalityTag", () => {
-      it("should return null if lab report is not abnormal", () => {
-        const result = renderLabAbnormalityTag(
-          getObservations(labReportNormal!, BundleLab),
-          labReportNormalJsonObject,
+            ]}
+          />,
         );
-        expect(result).toBeNull();
+        expect(screen.getByText("Critical Abnormal")).toBeVisible();
+      });
+
+      it("should return all AbnormalObservationInterpretation if code is abnormal", () => {
+        render(
+          <LabInterpretationTag
+            observations={[
+              {
+                interpretation: [
+                  {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "AA",
+                      },
+                    ],
+                  },
+                  {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "LL",
+                      },
+                    ],
+                  },
+                ],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
+              },
+            ]}
+          />,
+        );
+        expect(screen.getByText("Critical Abnormal")).toBeVisible();
+        expect(screen.getByText("Critical Low")).toBeVisible();
+      });
+
+      it("should favor diagnostic report interpretation if available", () => {
+        render(
+          <LabInterpretationTag
+            observations={[
+              {
+                interpretation: [
+                  {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "AA",
+                      },
+                    ],
+                  },
+                  {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        code: "LL",
+                      },
+                    ],
+                  },
+                ],
+                resourceType: "Observation",
+                code: { coding: undefined },
+                status: "unknown",
+              },
+              {
+                interpretation: [],
+                resourceType: "Observation",
+                code: {
+                  coding: [{ code: "56850-1", system: "http://loinc.org" }],
+                },
+                valueString: "Super weird",
+                status: "unknown",
+              },
+            ]}
+          />,
+        );
+        expect(screen.getByText("Super weird")).toBeVisible();
+        expect(screen.queryByText("Critical Abnormal")).toBeNull();
+        expect(screen.queryByText("Critical Low")).toBeNull();
       });
 
       it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations", () => {
-        const result = renderLabAbnormalityTag(
-          getObservations(labReportAbnormal!, BundleLab),
-          labReportAbnormalJsonObject,
+        render(
+          <LabInterpretationTag
+            observations={getObservations(labReportAbnormal!, BundleLab)}
+            labReportJson={labReportAbnormalJsonObject}
+          />,
         );
-        render(<>{result}</>);
         const tagElement = screen.getByText("Abnormal");
         expect(tagElement).toBeInTheDocument();
         expect(tagElement).toHaveStyle({ backgroundColor: "#B50909" });
         expect(tagElement).toHaveClass("margin-left-105");
-        expect(tagElement).not.toHaveStyle({ fontWeight: "bold" });
       });
+    });
+  });
 
-      it("should render abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
-        const mockObservations: Observation[] = [
-          {
-            resourceType: "Observation",
-            status: "final",
-            code: { coding: [] },
-            interpretation: [
+  describe("searchResultRecord", () => {
+    const labHTMLJson = labReportNormalJsonObject.tables;
+
+    it("extracts string of all results of a search for specified lab report", () => {
+      const searchKey = "Collection Time";
+      const expectedResult = "09/28/2000 4:51\u00A0PM\u00A0EDT";
+
+      const result = searchResultRecord(labHTMLJson, searchKey);
+
+      expect(result).toStrictEqual(expectedResult);
+    });
+
+    it("returns an empty string of results if none are found for search key", () => {
+      const invalidSearchKey = "foobar";
+      const expectedResult = "";
+
+      const result = searchResultRecord(labHTMLJson, invalidSearchKey);
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe("returnAnalysisTime", () => {
+    it("extracts and formats correct field value from within a lab report", () => {
+      const fieldName = "Analysis Time";
+
+      const result = returnAnalysisTime(labReportNormalJsonObject, fieldName);
+
+      expect(result).toEqual("09/28/2000 4:59\u00A0PM\u00A0EDT");
+    });
+
+    it("extracts returns noData if unavailable", () => {
+      const fieldName = "Analysis Time";
+
+      const result = returnAnalysisTime({}, fieldName);
+
+      expect(result).toEqual(noData);
+    });
+
+    it("Concats date times if multiple passed", () => {
+      const fieldName = "Analysis Time";
+
+      const result = returnAnalysisTime(
+        {
+          resultId: "Result.1.2.3.4.5",
+          resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
+          tables: [
+            [
               {
-                coding: [
-                  {
-                    system:
-                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                    code: "HH",
-                    display: "Critical High",
-                  },
-                ],
+                "Analysis Time": {
+                  value: (
+                    <p>
+                      <span>
+                        <i>09/28/2000 1:59:00 PM PDT</i>
+                      </span>
+                      <span>
+                        <i>09/28/2000 2:59:00 PM PDT</i>
+                      </span>
+                    </p>
+                  ),
+                  metadata: {},
+                },
               },
             ],
-          },
-        ];
+          ],
+        },
+        fieldName,
+      );
 
-        const result = renderLabAbnormalityTag(mockObservations);
-        render(<>{result}</>);
-
-        const tagElement = screen.getByText("Critical High");
-        expect(tagElement).toBeInTheDocument();
-        expect(tagElement).toHaveStyle({ backgroundColor: "#B50909" });
-        expect(tagElement).toHaveClass("margin-left-105");
-        expect(tagElement).not.toHaveStyle({ fontWeight: "bold" });
-      });
+      expect(result).toEqual(
+        "09/28/2000 4:59\u00A0PM\u00A0EDT, 09/28/2000 5:59\u00A0PM\u00A0EDT",
+      );
     });
 
-    describe("searchResultRecord", () => {
-      const labHTMLJson = labReportNormalJsonObject.tables;
+    it("Returns concated date times if deeply nested", () => {
+      const fieldName = "Analysis Time";
 
-      it("extracts string of all results of a search for specified lab report", () => {
-        const searchKey = "Collection Time";
-        const expectedResult = "09/28/2000 4:51\u00A0PM\u00A0EDT";
-
-        const result = searchResultRecord(labHTMLJson, searchKey);
-
-        expect(result).toStrictEqual(expectedResult);
-      });
-
-      it("returns an empty string of results if none are found for search key", () => {
-        const invalidSearchKey = "foobar";
-        const expectedResult = "";
-
-        const result = searchResultRecord(labHTMLJson, invalidSearchKey);
-
-        expect(result).toEqual(expectedResult);
-      });
-    });
-
-    describe("returnAnalysisTime", () => {
-      it("extracts and formats correct field value from within a lab report", () => {
-        const fieldName = "Analysis Time";
-
-        const result = returnAnalysisTime(labReportNormalJsonObject, fieldName);
-
-        expect(result).toEqual("09/28/2000 4:59\u00A0PM\u00A0EDT");
-      });
-
-      it("extracts returns noData if unavailable", () => {
-        const fieldName = "Analysis Time";
-
-        const result = returnAnalysisTime({}, fieldName);
-
-        expect(result).toEqual(noData);
-      });
-
-      it("Concats date times if multiple passed", () => {
-        const fieldName = "Analysis Time";
-
-        const result = returnAnalysisTime(
-          {
-            resultId: "Result.1.2.3.4.5",
-            resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
-            tables: [
-              [
-                {
-                  "Analysis Time": {
-                    value: (
-                      <p>
-                        <span>
-                          <i>09/28/2000 1:59:00 PM PDT</i>
-                        </span>
-                        <span>
-                          <i>09/28/2000 2:59:00 PM PDT</i>
-                        </span>
-                      </p>
-                    ),
-                    metadata: {},
-                  },
+      const result = returnAnalysisTime(
+        {
+          resultId: "Result.1.2.3.4.5",
+          resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
+          tables: [
+            [
+              {
+                "Analysis Time": {
+                  value: (
+                    <p>
+                      <span>
+                        <i>09/28/2000 1:59:00 PM PDT</i>
+                        <i>09/28/2000 2:59:00 PM PDT</i>
+                      </span>
+                    </p>
+                  ),
+                  metadata: {},
                 },
-              ],
+              },
             ],
-          },
-          fieldName,
-        );
+          ],
+        },
+        fieldName,
+      );
 
-        expect(result).toEqual(
-          "09/28/2000 4:59\u00A0PM\u00A0EDT, 09/28/2000 5:59\u00A0PM\u00A0EDT",
-        );
-      });
-
-      it("Returns concated date times if deeply nested", () => {
-        const fieldName = "Analysis Time";
-
-        const result = returnAnalysisTime(
-          {
-            resultId: "Result.1.2.3.4.5",
-            resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
-            tables: [
-              [
-                {
-                  "Analysis Time": {
-                    value: (
-                      <p>
-                        <span>
-                          <i>09/28/2000 1:59:00 PM PDT</i>
-                          <i>09/28/2000 2:59:00 PM PDT</i>
-                        </span>
-                      </p>
-                    ),
-                    metadata: {},
-                  },
-                },
-              ],
-            ],
-          },
-          fieldName,
-        );
-
-        expect(result).toEqual(
-          "09/28/2000 4:59\u00A0PM\u00A0EDT, 09/28/2000 5:59\u00A0PM\u00A0EDT",
-        );
-      });
-
-      it("Returns noData if emptiness is nested", () => {
-        const fieldName = "Analysis Time";
-
-        const result = returnAnalysisTime(
-          {
-            resultId: "Result.1.2.3.4.5",
-            resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
-            tables: [
-              [
-                {
-                  "Analysis Time": {
-                    value: (
-                      <p>
-                        <span>
-                          <i></i>
-                        </span>
-                      </p>
-                    ),
-                    metadata: {},
-                  },
-                },
-              ],
-            ],
-          },
-          fieldName,
-        );
-
-        expect(result).toEqual(noData);
-      });
+      expect(result).toEqual(
+        "09/28/2000 4:59\u00A0PM\u00A0EDT, 09/28/2000 5:59\u00A0PM\u00A0EDT",
+      );
     });
 
-    describe("returnFieldValueFromLabHtmlString", () => {
-      it("extracts correct field value from within a lab report", () => {
-        const fieldName = "Analysis Time";
+    it("Returns noData if emptiness is nested", () => {
+      const fieldName = "Analysis Time";
 
-        const result = returnFieldValueFromLabHtmlString(
-          labReportNormalJsonObject,
-          fieldName,
-        );
+      const result = returnAnalysisTime(
+        {
+          resultId: "Result.1.2.3.4.5",
+          resultName: "Stool Pathogens, NAAT, 12 to 25 Targets",
+          tables: [
+            [
+              {
+                "Analysis Time": {
+                  value: (
+                    <p>
+                      <span>
+                        <i></i>
+                      </span>
+                    </p>
+                  ),
+                  metadata: {},
+                },
+              },
+            ],
+          ],
+        },
+        fieldName,
+      );
 
-        expect(result).toMatchSnapshot();
-      });
+      expect(result).toEqual(noData);
+    });
+  });
 
-      it("returns NoData if none are found for field name", () => {
-        const invalidFieldName = "foobar";
+  describe("returnFieldValueFromLabHtmlString", () => {
+    it("extracts correct field value from within a lab report", () => {
+      const fieldName = "Analysis Time";
 
-        const result = returnFieldValueFromLabHtmlString(
-          labReportNormalJsonObject,
-          invalidFieldName,
-        );
+      const result = returnFieldValueFromLabHtmlString(
+        labReportNormalJsonObject,
+        fieldName,
+      );
 
-        expect(result).toStrictEqual(noData);
-      });
+      expect(result).toMatchSnapshot();
     });
 
-    describe("evaluateOrganismsReportData", () => {
-      it("should return the correct organisms table when the data exists for a lab report", () => {
-        const result = evaluateOrganismsReportData(
-          getObservations(labOrganismsTableAndNarr!, BundleLab),
-        )!;
-        render(result);
+    it("returns NoData if none are found for field name", () => {
+      const invalidFieldName = "foobar";
 
-        expect(
-          screen.getByText("Avycaz (Ceftazidime/Avibactam)"),
-        ).toBeInTheDocument();
-        expect(screen.getByText("0.25: Susceptible")).toBeInTheDocument();
-        expect(screen.getAllByText("MIC")).toHaveLength(3);
-      });
-      it("should return undefined if lab organisms data does not exist for a lab report", () => {
-        const result = evaluateOrganismsReportData(
-          getObservations(labReportNormal!, BundleLab),
-        );
+      const result = returnFieldValueFromLabHtmlString(
+        labReportNormalJsonObject,
+        invalidFieldName,
+      );
 
-        expect(result).toBeUndefined();
-      });
+      expect(result).toStrictEqual(noData);
+    });
+  });
+
+  describe("evaluateOrganismsReportData", () => {
+    it("should return the correct organisms table when the data exists for a lab report", () => {
+      const result = evaluateOrganismsReportData(
+        getObservations(labOrganismsTableAndNarr!, BundleLab),
+      )!;
+      render(result);
+
+      expect(
+        screen.getByText("Avycaz (Ceftazidime/Avibactam)"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("0.25: Susceptible")).toBeInTheDocument();
+      expect(screen.getAllByText("MIC")).toHaveLength(3);
+    });
+    it("should return undefined if lab organisms data does not exist for a lab report", () => {
+      const result = evaluateOrganismsReportData(
+        getObservations(labReportNormal!, BundleLab),
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -29,6 +29,8 @@ import {
   getJsonLab,
   getAllLabJsonObjects,
   getObservations,
+  evaluateAbnormalObservationInterpretation,
+  renderLabAbnormalityTag,
 } from "@/app/view-data/services/labsService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
@@ -173,6 +175,15 @@ const labReportAbnormal = evaluateOneAndCheck<DiagnosticReport>(
   pathLabReportAbnormal,
   "DiagnosticReport",
 );
+
+const pathLabReportAbnormalInterpretation = 
+      "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(id = '68477c03-5689-f9e5-c267-a3c7bdff6fe0')";
+const labReportAbnormalInterpretation = evaluateOneAndCheck<DiagnosticReport>(
+  BundleLab,
+  pathLabReportAbnormalInterpretation,
+  "DiagnosticReport",
+);
+
 const jsonLabs = getAllLabJsonObjects(BundleLab);
 const labReportAbnormalJsonObject = getJsonLab(
   jsonLabs,
@@ -758,6 +769,25 @@ describe("LabsService tests", () => {
       expect(
         findIdenticalOrg(orgMappings, matchedOrg2)?.telecom?.[0].value,
       ).not.toBeDefined();
+    });
+  });
+
+  describe('Abnormal HL7 Observation Interpretations', () => {
+   
+    const observationsAbnormalInterpretation = getObservations(labReportAbnormalInterpretation!, BundleLab);
+
+    describe('evaluateAbnormalObservationInterpretation', () => {
+      it('should return null for observations without abnormal interpretations', () => {
+        const normalObservations = getObservations(labReportNormal!, BundleLab);
+
+        const result = evaluateAbnormalObservationInterpretation(normalObservations);
+        expect(result).toBeNull();
+      });
+
+      it('should detect abnormal interpretation from real FHIR data', () => {
+        const result = evaluateAbnormalObservationInterpretation(observationsAbnormalInterpretation);
+        expect(result).toBeNull();
+      });
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -176,8 +176,8 @@ const labReportAbnormal = evaluateOneAndCheck<DiagnosticReport>(
   "DiagnosticReport",
 );
 
-const pathLabReportAbnormalInterpretation = 
-      "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(id = '68477c03-5689-f9e5-c267-a3c7bdff6fe0')";
+const pathLabReportAbnormalInterpretation =
+  "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(id = '68477c03-5689-f9e5-c267-a3c7bdff6fe0')";
 const labReportAbnormalInterpretation = evaluateOneAndCheck<DiagnosticReport>(
   BundleLab,
   pathLabReportAbnormalInterpretation,
@@ -772,20 +772,25 @@ describe("LabsService tests", () => {
     });
   });
 
-  describe('Abnormal HL7 Observation Interpretations', () => {
-   
-    const observationsAbnormalInterpretation = getObservations(labReportAbnormalInterpretation!, BundleLab);
+  describe("Abnormal HL7 Observation Interpretations", () => {
+    const observationsAbnormalInterpretation = getObservations(
+      labReportAbnormalInterpretation!,
+      BundleLab,
+    );
 
-    describe('evaluateAbnormalObservationInterpretation', () => {
-      it('should return null for observations without abnormal interpretations', () => {
+    describe("evaluateAbnormalObservationInterpretation", () => {
+      it("should return null for observations without abnormal interpretations", () => {
         const normalObservations = getObservations(labReportNormal!, BundleLab);
 
-        const result = evaluateAbnormalObservationInterpretation(normalObservations);
+        const result =
+          evaluateAbnormalObservationInterpretation(normalObservations);
         expect(result).toBeNull();
       });
 
-      it('should detect abnormal interpretation from real FHIR data', () => {
-        const result = evaluateAbnormalObservationInterpretation(observationsAbnormalInterpretation);
+      it("should detect abnormal interpretation from real FHIR data", () => {
+        const result = evaluateAbnormalObservationInterpretation(
+          observationsAbnormalInterpretation,
+        );
         expect(result).toBeNull();
       });
     });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -443,33 +443,48 @@ describe("LabsService tests", () => {
 
     describe("renderLabAbnormalityTag", () => {
       it("should return null if lab report is not abnormal", () => {
-        /*
-        // TODO
         const result = renderLabAbnormalityTag(getObservations(labReportNormal!, BundleLab), labReportNormalJsonObject);
         expect(result).toBeNull();
-        */
       });
 
-      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations", () => {
-        /*
-        // TODO
+      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations",  () => {
         const result = renderLabAbnormalityTag(getObservations(labReportAbnormal!, BundleLab), labReportAbnormalJsonObject);
         render(<>{result}</>); 
-
         const tagElement = screen.getByText('Abnormal');
         expect(tagElement).toBeInTheDocument();
         expect(tagElement).toHaveStyle({ backgroundColor: '#B50909' });
         expect(tagElement).toHaveClass('margin-left-105');
         expect(tagElement).not.toHaveStyle({ fontWeight: 'bold' });
-        */
       });
 
       it("should render abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
-        // TODO
-      });
+        const mockObservations: Observation[] = [
+          {
+            resourceType: "Observation",
+            status: "final",
+            code: { coding: [] },
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: "HH",
+                    display: "Critical High",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
 
-      it("should render highest priority abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
-        // TODO
+        const result = renderLabAbnormalityTag(mockObservations);
+        render(<>{result}</>);
+
+        const tagElement = screen.getByText("Critical High");
+        expect(tagElement).toBeInTheDocument();
+        expect(tagElement).toHaveStyle({ backgroundColor: '#B50909' });
+        expect(tagElement).toHaveClass('margin-left-105');
+        expect(tagElement).not.toHaveStyle({ fontWeight: 'bold' });
       });
     });
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -294,116 +294,147 @@ describe("LabsService tests", () => {
 
     describe("isAbnormalObservationInterpretation", () => {
       it("sohuld return true if code is in list of abnormal observation interpretations", () => {
-        const codes = [ "AA", "HH", "LL", "HU", "LU"].forEach(code => {
+        const codes = ["AA", "HH", "LL", "HU", "LU"].forEach((code) => {
           const result = isAbnormalObservationInterpretation(code);
-          expect(result).toBeTrue()
-        })
+          expect(result).toBeTrue();
+        });
       });
-    
+
       it("sohuld return false if code is not in list of abnormal observation interpretations", () => {
         const result = isAbnormalObservationInterpretation("ZZ");
-        expect(result).toBeFalse()
+        expect(result).toBeFalse();
       });
     });
 
     describe("evaluateAbnormalObservationInterpretation", () => {
-      it("should return null if observations is empty",  () => {
+      it("should return null if observations is empty", () => {
         const result = evaluateAbnormalObservationInterpretation([]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation is undefined", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: undefined,
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: undefined,
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
-      }); 
+      });
 
       it("should return null if observation interpretation is empty", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation coding is undefined", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: undefined}],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [{ coding: undefined }],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation coding is empty", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: []}],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [{ coding: [] }],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation coding is not HL7 observation interpretation code", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: [{system: "http://test.com"}]}],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [{ coding: [{ system: "http://test.com" }] }],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation coding code is undefined", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: [
-            {
-              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-              code: undefined
-            }]
-          }],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: undefined,
+                  },
+                ],
+              },
+            ],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
 
       it("should return null if observation interpretation coding code is not abnormal", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: [
-            {
-              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-              code: "ZZ"
-            }]
-          }],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: "ZZ",
+                  },
+                ],
+              },
+            ],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
         expect(result).toBeNull();
       });
-      
+
       it("should return AbnormalObservationInterpretation if code is abnormal", () => {
-        const result  = evaluateAbnormalObservationInterpretation([{
-          interpretation: [{coding: [
-            {
-              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-              code: "AA"
-            }]
-          }],
-          resourceType: "Observation", 
-          code: {coding: undefined}, 
-          status: "unknown"
-        }]);
+        const result = evaluateAbnormalObservationInterpretation([
+          {
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: "AA",
+                  },
+                ],
+              },
+            ],
+            resourceType: "Observation",
+            code: { coding: undefined },
+            status: "unknown",
+          },
+        ]);
 
         expect(result?.code).toBe("AA");
         expect(result?.display).toBe("Critical Abnormal");
@@ -419,7 +450,7 @@ describe("LabsService tests", () => {
         */
       });
 
-      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations",  () => {
+      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations", () => {
         /*
         // TODO
         const result = renderLabAbnormalityTag(getObservations(labReportAbnormal!, BundleLab), labReportAbnormalJsonObject);

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -20,6 +20,7 @@ import {
   evaluateOrganismsReportData,
   evaluateDiagnosticReportData,
   evaluateLabOrganizationData,
+  evaluateAbnormalObservationInterpretation,
   ResultObject,
   combineOrgAndReportData,
   evaluateLabInfoData,
@@ -29,7 +30,7 @@ import {
   getJsonLab,
   getAllLabJsonObjects,
   getObservations,
-  evaluateAbnormalObservationInterpretation,
+  isAbnormalObservationInterpretation,
   renderLabAbnormalityTag,
 } from "@/app/view-data/services/labsService";
 
@@ -175,15 +176,6 @@ const labReportAbnormal = evaluateOneAndCheck<DiagnosticReport>(
   pathLabReportAbnormal,
   "DiagnosticReport",
 );
-
-const pathLabReportAbnormalInterpretation =
-  "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(id = '68477c03-5689-f9e5-c267-a3c7bdff6fe0')";
-const labReportAbnormalInterpretation = evaluateOneAndCheck<DiagnosticReport>(
-  BundleLab,
-  pathLabReportAbnormalInterpretation,
-  "DiagnosticReport",
-);
-
 const jsonLabs = getAllLabJsonObjects(BundleLab);
 const labReportAbnormalJsonObject = getJsonLab(
   jsonLabs,
@@ -297,6 +289,156 @@ describe("LabsService tests", () => {
         const result = checkAbnormalTag(labReportNormalJsonObject);
 
         expect(result).toStrictEqual(expectedResult);
+      });
+    });
+
+    describe("isAbnormalObservationInterpretation", () => {
+      it("sohuld return true if code is in list of abnormal observation interpretations", () => {
+        const codes = [ "AA", "HH", "LL", "HU", "LU"].forEach(code => {
+          const result = isAbnormalObservationInterpretation(code);
+          expect(result).toBeTrue()
+        })
+      });
+    
+      it("sohuld return false if code is not in list of abnormal observation interpretations", () => {
+        const result = isAbnormalObservationInterpretation("ZZ");
+        expect(result).toBeFalse()
+      });
+    });
+
+    describe("evaluateAbnormalObservationInterpretation", () => {
+      it("should return null if observations is empty",  () => {
+        const result = evaluateAbnormalObservationInterpretation([]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation is undefined", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: undefined,
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      }); 
+
+      it("should return null if observation interpretation is empty", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation coding is undefined", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: undefined}],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation coding is empty", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: []}],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation coding is not HL7 observation interpretation code", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: [{system: "http://test.com"}]}],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation coding code is undefined", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: undefined
+            }]
+          }],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+
+      it("should return null if observation interpretation coding code is not abnormal", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: "ZZ"
+            }]
+          }],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+        expect(result).toBeNull();
+      });
+      
+      it("should return AbnormalObservationInterpretation if code is abnormal", () => {
+        const result  = evaluateAbnormalObservationInterpretation([{
+          interpretation: [{coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: "AA"
+            }]
+          }],
+          resourceType: "Observation", 
+          code: {coding: undefined}, 
+          status: "unknown"
+        }]);
+
+        expect(result?.code).toBe("AA");
+        expect(result?.display).toBe("Critical Abnormal");
+      });
+    });
+
+    describe("renderLabAbnormalityTag", () => {
+      it("should return null if lab report is not abnormal", () => {
+        /*
+        // TODO
+        const result = renderLabAbnormalityTag(getObservations(labReportNormal!, BundleLab), labReportNormalJsonObject);
+        expect(result).toBeNull();
+        */
+      });
+
+      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations",  () => {
+        /*
+        // TODO
+        const result = renderLabAbnormalityTag(getObservations(labReportAbnormal!, BundleLab), labReportAbnormalJsonObject);
+        render(<>{result}</>); 
+
+        const tagElement = screen.getByText('Abnormal');
+        expect(tagElement).toBeInTheDocument();
+        expect(tagElement).toHaveStyle({ backgroundColor: '#B50909' });
+        expect(tagElement).toHaveClass('margin-left-105');
+        expect(tagElement).not.toHaveStyle({ fontWeight: 'bold' });
+        */
+      });
+
+      it("should render abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
+        // TODO
+      });
+
+      it("should render highest priority abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
+        // TODO
       });
     });
 
@@ -769,30 +911,6 @@ describe("LabsService tests", () => {
       expect(
         findIdenticalOrg(orgMappings, matchedOrg2)?.telecom?.[0].value,
       ).not.toBeDefined();
-    });
-  });
-
-  describe("Abnormal HL7 Observation Interpretations", () => {
-    const observationsAbnormalInterpretation = getObservations(
-      labReportAbnormalInterpretation!,
-      BundleLab,
-    );
-
-    describe("evaluateAbnormalObservationInterpretation", () => {
-      it("should return null for observations without abnormal interpretations", () => {
-        const normalObservations = getObservations(labReportNormal!, BundleLab);
-
-        const result =
-          evaluateAbnormalObservationInterpretation(normalObservations);
-        expect(result).toBeNull();
-      });
-
-      it("should detect abnormal interpretation from real FHIR data", () => {
-        const result = evaluateAbnormalObservationInterpretation(
-          observationsAbnormalInterpretation,
-        );
-        expect(result).toBeNull();
-      });
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -443,18 +443,24 @@ describe("LabsService tests", () => {
 
     describe("renderLabAbnormalityTag", () => {
       it("should return null if lab report is not abnormal", () => {
-        const result = renderLabAbnormalityTag(getObservations(labReportNormal!, BundleLab), labReportNormalJsonObject);
+        const result = renderLabAbnormalityTag(
+          getObservations(labReportNormal!, BundleLab),
+          labReportNormalJsonObject,
+        );
         expect(result).toBeNull();
       });
 
-      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations",  () => {
-        const result = renderLabAbnormalityTag(getObservations(labReportAbnormal!, BundleLab), labReportAbnormalJsonObject);
-        render(<>{result}</>); 
-        const tagElement = screen.getByText('Abnormal');
+      it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations", () => {
+        const result = renderLabAbnormalityTag(
+          getObservations(labReportAbnormal!, BundleLab),
+          labReportAbnormalJsonObject,
+        );
+        render(<>{result}</>);
+        const tagElement = screen.getByText("Abnormal");
         expect(tagElement).toBeInTheDocument();
-        expect(tagElement).toHaveStyle({ backgroundColor: '#B50909' });
-        expect(tagElement).toHaveClass('margin-left-105');
-        expect(tagElement).not.toHaveStyle({ fontWeight: 'bold' });
+        expect(tagElement).toHaveStyle({ backgroundColor: "#B50909" });
+        expect(tagElement).toHaveClass("margin-left-105");
+        expect(tagElement).not.toHaveStyle({ fontWeight: "bold" });
       });
 
       it("should render abnormal tag when lab report abnormal observation interpretations has abnormal observation interpretations", () => {
@@ -467,7 +473,8 @@ describe("LabsService tests", () => {
               {
                 coding: [
                   {
-                    system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
                     code: "HH",
                     display: "Critical High",
                   },
@@ -482,9 +489,9 @@ describe("LabsService tests", () => {
 
         const tagElement = screen.getByText("Critical High");
         expect(tagElement).toBeInTheDocument();
-        expect(tagElement).toHaveStyle({ backgroundColor: '#B50909' });
-        expect(tagElement).toHaveClass('margin-left-105');
-        expect(tagElement).not.toHaveStyle({ fontWeight: 'bold' });
+        expect(tagElement).toHaveStyle({ backgroundColor: "#B50909" });
+        expect(tagElement).toHaveClass("margin-left-105");
+        expect(tagElement).not.toHaveStyle({ fontWeight: "bold" });
       });
     });
 

--- a/test-data/fhir/BundleLab.json
+++ b/test-data/fhir/BundleLab.json
@@ -64,7 +64,6 @@
       }
     },
     {
-
       "fullUrl": "urn:uuid:68477c03-5689-f9e5-c267-a3c7bdff6fe0",
       "resource": {
         "resourceType": "DiagnosticReport",
@@ -121,7 +120,6 @@
         "method": "PUT",
         "url": "DiagnosticReport/68477c03-5689-f9e5-c267-a3c7bdff6fe0"
       }
-    
     },
     {
       "fullUrl": "urn:uuid:ab1ecbe4-6de0-4f78-cea6-a880a15e88bc",
@@ -458,11 +456,9 @@
           {
             "coding": [
               {
-
                 "code": "A",
                 "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
                 "display": "Abnormal"
-                
               }
             ]
           }

--- a/test-data/fhir/BundleLab.json
+++ b/test-data/fhir/BundleLab.json
@@ -64,6 +64,7 @@
       }
     },
     {
+
       "fullUrl": "urn:uuid:68477c03-5689-f9e5-c267-a3c7bdff6fe0",
       "resource": {
         "resourceType": "DiagnosticReport",
@@ -120,6 +121,7 @@
         "method": "PUT",
         "url": "DiagnosticReport/68477c03-5689-f9e5-c267-a3c7bdff6fe0"
       }
+    
     },
     {
       "fullUrl": "urn:uuid:ab1ecbe4-6de0-4f78-cea6-a880a15e88bc",
@@ -456,9 +458,11 @@
           {
             "coding": [
               {
+
                 "code": "A",
                 "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
                 "display": "Abnormal"
+                
               }
             ]
           }


### PR DESCRIPTION
## Summary

Add more ways to tag the interpretation on the lab report:
1. If there's an overall report interpretation, always tag the report in the header (and make it red if we recognize it as an abnormal interpretation)
2. If not, if there are interpretations on observations within the report that are abnormal, display tags for each type of abnormality encountered (all red)
3. If not, if there is an html lab report and the name includes the text "abnormal", tag the header
4. If not, no header for you

What needs to be done
Labs outside of the general reference range are currently tagged as 'abnormal'. With the expanded HL7 spec, labs can be tagged with a range of abnormalities. For now, we'll stick to the significant and critical abnormalities in the lab tags.

If a lab comes in with an abnormal range, the tag will display in the lab header like so:
<img width="622" height="231" alt="Frame 686" src="https://github.com/user-attachments/assets/60b3cf13-a160-491f-b93a-423b8a8a834d" />

There is an outstanding question about whether labs come in with reference ranges... if they don't, they may not be tagged with a tag.

## Why it needs to be done
There seems to be different terminology and different grades to describe the deviation from normalcy in labs. Ideally, the Viewer would display any form of abnormality in the lab header.

This comes from the [HL7 observation interpretation](https://terminology.hl7.org/3.1.0/ValueSet-v3-ObservationInterpretation.html).

## Related Issue

Fixes #1036

## Acceptance Criteria

Add additional abnormalities to lab tags:

- [ ] Critical abnormal
- [ ] Critical high
- [ ] Critical low
- [ ] Significantly high
- [ ] Significantly low
