### PR TITLE
build: only specify python image versions to the minor

### DIFF
--- a/containers/ecr-viewer/seed-scripts/Dockerfile
+++ b/containers/ecr-viewer/seed-scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.6-alpine
+FROM python:3.13-alpine
 
 # Set the working directory in the container
 WORKDIR /code

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.6-alpine
+FROM python:3.13-alpine
 
 RUN apk update && \
     apk upgrade --no-cache

--- a/containers/message-parser/Dockerfile
+++ b/containers/message-parser/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.6-alpine
+FROM python:3.13-alpine
 
 RUN apk update && \
     apk upgrade --no-cache

--- a/containers/orchestration/Dockerfile
+++ b/containers/orchestration/Dockerfile
@@ -4,7 +4,7 @@ ARG TRIGGER_CODE_REFERENCE_URL
 ARG SMARTY_AUTH_ID
 ARG SMARTY_AUTH_TOKEN
 
-FROM python:3.13.6-alpine
+FROM python:3.13-alpine
 
 RUN apk update && \
     apk upgrade --no-cache

--- a/containers/trigger-code-reference/Dockerfile
+++ b/containers/trigger-code-reference/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.6-alpine
+FROM python:3.13-alpine
 
 RUN apk update && \
     apk upgrade --no-cache


### PR DESCRIPTION
# PULL REQUEST

## Summary

Remove patch specifiers on python images

(https://skylight-hq.slack.com/archives/C05B5R8K0TF/p1755521933757759)
