### PR TITLE
fix: name normalization handling

### DIFF
--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/CDA_eICR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/CDA_eICR.xml
@@ -36,7 +36,8 @@
       <patient>
         <name use="L">
           <given>Dash</given>
-          <family>Rendar</family>
+          <!-- Mc and emoji to ensure in e2e testing that names pass through correctly -->
+          <family>McRendar🐨</family>
         </name>
         <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"
           displayName="Female" />

--- a/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/CDA_eICR.xml
+++ b/containers/ecr-viewer/seed-scripts/baseECR/star-wars/dash-rendar/CDA_eICR.xml
@@ -36,8 +36,8 @@
       <patient>
         <name use="L">
           <given>Dash</given>
-          <!-- Mc and emoji to ensure in e2e testing that names pass through correctly -->
-          <family>McRendar🐨</family>
+          <!-- O' and 木 to ensure in e2e testing that names pass through correctly -->
+          <family>O'Rendar木</family>
         </name>
         <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"
           displayName="Female" />

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
@@ -4,7 +4,7 @@ import { AnyDb } from "@/app/data/metadataDb/database";
 import { dbDialect, dbNamespace } from "@/app/data/metadataDb/utils/db-config";
 
 /**
- * Add condition_code column and foreign key constraint to ecr_rr_conditions, backfill condition codes.
+ * Alter sql server name columns to support unicode (no matter the collation).
  * @param db - the database connection
  */
 export async function up(db: Kysely<AnyDb>): Promise<void> {
@@ -14,15 +14,20 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
   const schema = dbNamespace();
   const _db = db.withSchema(schema);
 
+  // sql server only allows you to alter one column at a time
   await _db.schema
     .alterTable("ecr_data")
     .alterColumn("first_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
+    .execute();
+
+  await _db.schema
+    .alterTable("ecr_data")
     .alterColumn("last_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
     .execute();
 }
 
 /**
- * Roll back condition_code addition to ecr_rr_conditions.
+ * Roll back sql server name column unicode support (no matter the collation).
  * @param db - the database connection
  */
 export async function down(db: Kysely<AnyDb>): Promise<void> {
@@ -32,7 +37,10 @@ export async function down(db: Kysely<AnyDb>): Promise<void> {
   const _db = db.withSchema(dbNamespace());
   await _db.schema
     .alterTable("ecr_data")
-    .alterColumn("first_name", (cb) => cb.setDataType("varchar(255)"))
     .alterColumn("last_name", (cb) => cb.setDataType("varchar(255)"))
+    .execute();
+  await _db.schema
+    .alterTable("ecr_data")
+    .alterColumn("first_name", (cb) => cb.setDataType("varchar(255)"))
     .execute();
 }

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
@@ -1,0 +1,38 @@
+import { Kysely, sql } from "kysely";
+
+import { AnyDb } from "@/app/data/metadataDb/database";
+import { dbDialect, dbNamespace } from "@/app/data/metadataDb/utils/db-config";
+
+/**
+ * Add condition_code column and foreign key constraint to ecr_rr_conditions, backfill condition codes.
+ * @param db - the database connection
+ */
+export async function up(db: Kysely<AnyDb>): Promise<void> {
+  // This migration only applies to sql server
+  if (dbDialect() !== "sqlserver") return;
+
+  const schema = dbNamespace();
+  const _db = db.withSchema(schema);
+
+  await _db.schema
+    .alterTable("ecr_data")
+    .alterColumn("first_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
+    .alterColumn("last_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
+    .execute();
+}
+
+/**
+ * Roll back condition_code addition to ecr_rr_conditions.
+ * @param db - the database connection
+ */
+export async function down(db: Kysely<AnyDb>): Promise<void> {
+  // This migration only applies to sql server
+  if (dbDialect() !== "sqlserver") return;
+
+  const _db = db.withSchema(dbNamespace());
+  await _db.schema
+    .alterTable("ecr_data")
+    .alterColumn("first_name", (cb) => cb.setDataType("varchar(255)"))
+    .alterColumn("last_name", (cb) => cb.setDataType("varchar(255)"))
+    .execute();
+}

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20250818153300_name_unicode.ts
@@ -1,4 +1,4 @@
-import { Kysely, sql } from "kysely";
+import { CompiledQuery, Kysely } from "kysely";
 
 import { AnyDb } from "@/app/data/metadataDb/database";
 import { dbDialect, dbNamespace } from "@/app/data/metadataDb/utils/db-config";
@@ -12,18 +12,20 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
   if (dbDialect() !== "sqlserver") return;
 
   const schema = dbNamespace();
-  const _db = db.withSchema(schema);
 
-  // sql server only allows you to alter one column at a time
-  await _db.schema
-    .alterTable("ecr_data")
-    .alterColumn("first_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
-    .execute();
-
-  await _db.schema
-    .alterTable("ecr_data")
-    .alterColumn("last_name", (cb) => cb.setDataType(sql`nvarchar(255)`))
-    .execute();
+  // sql server only allows you to alter one column at a time and requires the full definition
+  // kysely only allows you to alter one thing about a column at a time
+  // these do not play well together...
+  await db.executeQuery(
+    CompiledQuery.raw(
+      `ALTER TABLE [${schema}].[ecr_data] ALTER COLUMN first_name nvarchar(255) NOT NULL`,
+    ),
+  );
+  await db.executeQuery(
+    CompiledQuery.raw(
+      `ALTER TABLE [${schema}].[ecr_data] ALTER COLUMN last_name nvarchar(255) NOT NULL`,
+    ),
+  );
 }
 
 /**
@@ -34,13 +36,15 @@ export async function down(db: Kysely<AnyDb>): Promise<void> {
   // This migration only applies to sql server
   if (dbDialect() !== "sqlserver") return;
 
-  const _db = db.withSchema(dbNamespace());
-  await _db.schema
-    .alterTable("ecr_data")
-    .alterColumn("last_name", (cb) => cb.setDataType("varchar(255)"))
-    .execute();
-  await _db.schema
-    .alterTable("ecr_data")
-    .alterColumn("first_name", (cb) => cb.setDataType("varchar(255)"))
-    .execute();
+  const schema = dbNamespace();
+  await db.executeQuery(
+    CompiledQuery.raw(
+      `ALTER TABLE [${schema}].[ecr_data] ALTER COLUMN first_name varchar(255) NOT NULL`,
+    ),
+  );
+  await db.executeQuery(
+    CompiledQuery.raw(
+      `ALTER TABLE [${schema}].[ecr_data] ALTER COLUMN last_name varchar(255) NOT NULL`,
+    ),
+  );
 }

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/index.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/index.ts
@@ -5,4 +5,5 @@ export default {
   "20250505100700_ecr_fks.ts": require("./20250505100700_ecr_fks"),
   "20250522120000_condition_fk.ts": require("./20250522120000_condition_fk"),
   "20250708095700_audit_log.ts": require("./20250708095700_audit_log"),
+  "20250818153300_name_unicode.ts": require("./20250818153300_name_unicode"),
 };

--- a/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
+++ b/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
@@ -10,7 +10,11 @@ import { useLibraryQueryParam } from "@/app/hooks/useQueryParam";
 import { formatDate, formatDateTime } from "@/app/services/formatDateService";
 import { EcrDisplay, RelatedEcr } from "@/app/types";
 import { noData } from "@/app/utils/data-utils";
-import { makePlural, toSentenceCase } from "@/app/utils/format-utils";
+import {
+  ifUnformatted,
+  makePlural,
+  toSentenceCase,
+} from "@/app/utils/format-utils";
 import { saveToSessionStorage } from "@/app/utils/storage-utils";
 
 const transition: Transition = {
@@ -38,9 +42,9 @@ export const EcrTableDataRow = ({
 }) => {
   const [isExpanded, setExpanded] = useState(false);
   const patientName =
-    toSentenceCase(item.patient_first_name) +
+    ifUnformatted(item.patient_first_name, toSentenceCase) +
     " " +
-    toSentenceCase(item.patient_last_name);
+    ifUnformatted(item.patient_last_name, toSentenceCase);
 
   const conditionsList = (
     <ul className="ecr-table-list">

--- a/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
+++ b/containers/ecr-viewer/src/app/components/table/ecr/EcrTableDataRow.tsx
@@ -10,11 +10,7 @@ import { useLibraryQueryParam } from "@/app/hooks/useQueryParam";
 import { formatDate, formatDateTime } from "@/app/services/formatDateService";
 import { EcrDisplay, RelatedEcr } from "@/app/types";
 import { noData } from "@/app/utils/data-utils";
-import {
-  ifUnformatted,
-  makePlural,
-  toSentenceCase,
-} from "@/app/utils/format-utils";
+import { makePlural } from "@/app/utils/format-utils";
 import { saveToSessionStorage } from "@/app/utils/storage-utils";
 
 const transition: Transition = {
@@ -41,10 +37,7 @@ export const EcrTableDataRow = ({
   index: number;
 }) => {
   const [isExpanded, setExpanded] = useState(false);
-  const patientName =
-    ifUnformatted(item.patient_first_name, toSentenceCase) +
-    " " +
-    ifUnformatted(item.patient_last_name, toSentenceCase);
+  const patientName = item.patient_first_name + " " + item.patient_last_name;
 
   const conditionsList = (
     <ul className="ecr-table-list">

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -13,7 +13,6 @@ import {
 } from "fhir/r4";
 
 import {
-  ifUnformatted,
   makePlural,
   toSentenceCase,
   toTitleCase,
@@ -38,10 +37,10 @@ export const formatName = (
   const { use, prefix, given, family, suffix } = humanName;
 
   const segments = [
-    ...(withUse && use ? [`${ifUnformatted(use, toSentenceCase)}:`] : []),
-    ...(prefix?.map((p) => ifUnformatted(p, toTitleCase)) ?? []),
-    ...(given?.map((g) => ifUnformatted(g, toTitleCase)) ?? []),
-    ifUnformatted(family, toTitleCase),
+    ...(withUse && use ? [`${toSentenceCase(use)}:`] : []),
+    ...(prefix ?? []),
+    ...(given ?? []),
+    family,
     ...(suffix ?? []),
   ];
 

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -13,6 +13,7 @@ import {
 } from "fhir/r4";
 
 import {
+  ifUnformatted,
   makePlural,
   toSentenceCase,
   toTitleCase,
@@ -45,31 +46,6 @@ export const formatName = (
   ];
 
   return segments.filter(Boolean).join(" ");
-};
-
-// if a string is unformatted, format it, otherwise return it
-const ifUnformatted = (
-  str: string | undefined,
-  formatter: (val: string | undefined) => string | undefined,
-) => {
-  if (!str) return str;
-  return isFormatted(str) ? str : formatter(str);
-};
-
-// strings are considered unformatted if they are all caps or all lowercase
-const isFormatted = (str: string) => {
-  let hasLower = false;
-  let hasUpper = false;
-  for (const c of str) {
-    if (c.match(/[A-Z]/)) {
-      hasUpper = true;
-    }
-    if (c.match(/[a-z]/)) {
-      hasLower = true;
-    }
-  }
-
-  return hasUpper && hasLower;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -37,14 +37,39 @@ export const formatName = (
   const { use, prefix, given, family, suffix } = humanName;
 
   const segments = [
-    ...(withUse && use ? [`${toSentenceCase(use)}:`] : []),
-    ...(prefix?.map(toTitleCase) ?? []),
-    ...(given?.map(toTitleCase) ?? []),
-    toTitleCase(family ?? ""),
+    ...(withUse && use ? [`${ifUnformatted(use, toSentenceCase)}:`] : []),
+    ...(prefix?.map((p) => ifUnformatted(p, toTitleCase)) ?? []),
+    ...(given?.map((g) => ifUnformatted(g, toTitleCase)) ?? []),
+    ifUnformatted(family, toTitleCase),
     ...(suffix ?? []),
   ];
 
   return segments.filter(Boolean).join(" ");
+};
+
+// if a string is unformatted, format it, otherwise return it
+const ifUnformatted = (
+  str: string | undefined,
+  formatter: (val: string | undefined) => string | undefined,
+) => {
+  if (!str) return str;
+  return isFormatted(str) ? str : formatter(str);
+};
+
+// strings are considered unformatted if they are all caps or all lowercase
+const isFormatted = (str: string) => {
+  let hasLower = false;
+  let hasUpper = false;
+  for (const c of str) {
+    if (c.match(/[A-Z]/)) {
+      hasUpper = true;
+    }
+    if (c.match(/[a-z]/)) {
+      hasLower = true;
+    }
+  }
+
+  return hasUpper && hasLower;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -50,36 +50,6 @@ export const toTitleCase = (str: string | undefined) => {
 };
 
 /**
- * If a string is unformatted, format it, otherwise return it as is.
- * @param str The string to format
- * @param formatter The formatting function
- * @returns formatted string
- */
-export const ifUnformatted = (
-  str: string | undefined,
-  formatter: (val: string | undefined) => string | undefined,
-) => {
-  if (!str) return str;
-  return isFormatted(str) ? str : formatter(str);
-};
-
-// strings are considered unformatted if they are all caps or all lowercase
-const isFormatted = (str: string) => {
-  let hasLower = false;
-  let hasUpper = false;
-  for (const c of str) {
-    if (c.match(/[A-Z]/)) {
-      hasUpper = true;
-    }
-    if (c.match(/[a-z]/)) {
-      hasLower = true;
-    }
-  }
-
-  return hasUpper && hasLower;
-};
-
-/**
  * Extracts and concatenates all sequences of numbers and periods from each string in the input array,
  * excluding any leading and trailing periods in the first matched sequence of each string.
  * @param inputValues - An array of strings from which numbers and periods will be extracted.

--- a/containers/ecr-viewer/src/app/utils/format-utils.ts
+++ b/containers/ecr-viewer/src/app/utils/format-utils.ts
@@ -50,6 +50,36 @@ export const toTitleCase = (str: string | undefined) => {
 };
 
 /**
+ * If a string is unformatted, format it, otherwise return it as is.
+ * @param str The string to format
+ * @param formatter The formatting function
+ * @returns formatted string
+ */
+export const ifUnformatted = (
+  str: string | undefined,
+  formatter: (val: string | undefined) => string | undefined,
+) => {
+  if (!str) return str;
+  return isFormatted(str) ? str : formatter(str);
+};
+
+// strings are considered unformatted if they are all caps or all lowercase
+const isFormatted = (str: string) => {
+  let hasLower = false;
+  let hasUpper = false;
+  for (const c of str) {
+    if (c.match(/[A-Z]/)) {
+      hasUpper = true;
+    }
+    if (c.match(/[a-z]/)) {
+      hasLower = true;
+    }
+  }
+
+  return hasUpper && hasLower;
+};
+
+/**
  * Extracts and concatenates all sequences of numbers and periods from each string in the input array,
  * excluding any leading and trailing periods in the first matched sequence of each string.
  * @param inputValues - An array of strings from which numbers and periods will be extracted.

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
@@ -124,7 +124,7 @@ test.describe("ecr library page", () => {
 
       await expect(page.getByLabel("Page 2")).not.toBeVisible();
       await expect(page.getByText("Showing 1-3")).toBeVisible();
-      await expect(page.getByText("Yoda")).toBeVisible();
+      await expect(page.getByText("McRendar🐨")).toBeVisible();
       await expect(page.locator("tbody > tr")).toHaveCount(3);
     });
 

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
@@ -125,7 +125,7 @@ test.describe("ecr library page", () => {
       await expect(page.getByLabel("Page 2")).not.toBeVisible();
       await expect(page.getByText("Showing 1-3")).toBeVisible();
       // Regex to make sure name is formatted correctly
-      await expect(page.getByText(/McRendar🐨/)).toBeVisible();
+      await expect(page.getByText(/O'Rendar木/)).toBeVisible();
       await expect(page.locator("tbody > tr")).toHaveCount(3);
     });
 

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
@@ -110,7 +110,7 @@ test.describe("ecr library page", () => {
       await expect(page.getByText("No eCRs found.")).toBeVisible();
     });
 
-    test.only("Set results per page", async ({ page }) => {
+    test("Set results per page", async ({ page }) => {
       await page.goto("/ecr-viewer?itemsPerPage=1");
       await expect(
         page.getByLabel("Filter by reportable condition"),

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-library.spec.ts
@@ -110,7 +110,7 @@ test.describe("ecr library page", () => {
       await expect(page.getByText("No eCRs found.")).toBeVisible();
     });
 
-    test("Set results per page", async ({ page }) => {
+    test.only("Set results per page", async ({ page }) => {
       await page.goto("/ecr-viewer?itemsPerPage=1");
       await expect(
         page.getByLabel("Filter by reportable condition"),
@@ -124,7 +124,8 @@ test.describe("ecr library page", () => {
 
       await expect(page.getByLabel("Page 2")).not.toBeVisible();
       await expect(page.getByText("Showing 1-3")).toBeVisible();
-      await expect(page.getByText("McRendar🐨")).toBeVisible();
+      // Regex to make sure name is formatted correctly
+      await expect(page.getByText(/McRendar🐨/)).toBeVisible();
       await expect(page.locator("tbody > tr")).toHaveCount(3);
     });
 

--- a/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/table/EcrTableContent.test.tsx
@@ -26,8 +26,8 @@ describe("EcrTableContent", () => {
   const mockedListEcrData = jest.mocked(listEcrData);
   const mockData: EcrDisplay[] = Array.from({ length: 25 }, (_, i) => ({
     ecrId: `id-${i + 1}`,
-    patient_first_name: `first-${i + 1}`,
-    patient_last_name: `last-${i + 1}`,
+    patient_first_name: `FirsT-${i + 1}`,
+    patient_last_name: `McLast-${i + 1}`,
     dateModified: `2021-01-0${(i % 9) + 1}`,
     patient_date_of_birth: `2000-01-0${(i % 9) + 1}`,
     reportable_conditions: [

--- a/containers/ecr-viewer/tests/unit/app/components/table/__snapshots__/EcrTableContent.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/components/table/__snapshots__/EcrTableContent.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
 <table
@@ -48,7 +48,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-1"
             >
-              First-1 Last-1
+              FirsT-1 McLast-1
             </a>
             <br />
             DOB: 
@@ -142,7 +142,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-2"
             >
-              First-2 Last-2
+              FirsT-2 McLast-2
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -238,7 +238,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-3"
             >
-              First-3 Last-3
+              FirsT-3 McLast-3
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -334,7 +334,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-4"
             >
-              First-4 Last-4
+              FirsT-4 McLast-4
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -430,7 +430,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-5"
             >
-              First-5 Last-5
+              FirsT-5 McLast-5
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -526,7 +526,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-6"
             >
-              First-6 Last-6
+              FirsT-6 McLast-6
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -622,7 +622,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-7"
             >
-              First-7 Last-7
+              FirsT-7 McLast-7
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -718,7 +718,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-8"
             >
-              First-8 Last-8
+              FirsT-8 McLast-8
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -814,7 +814,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-9"
             >
-              First-9 Last-9
+              FirsT-9 McLast-9
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -910,7 +910,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-10"
             >
-              First-10 Last-10
+              FirsT-10 McLast-10
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1006,7 +1006,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-11"
             >
-              First-11 Last-11
+              FirsT-11 McLast-11
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1102,7 +1102,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-12"
             >
-              First-12 Last-12
+              FirsT-12 McLast-12
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1198,7 +1198,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-13"
             >
-              First-13 Last-13
+              FirsT-13 McLast-13
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1294,7 +1294,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-14"
             >
-              First-14 Last-14
+              FirsT-14 McLast-14
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1390,7 +1390,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-15"
             >
-              First-15 Last-15
+              FirsT-15 McLast-15
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1486,7 +1486,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-16"
             >
-              First-16 Last-16
+              FirsT-16 McLast-16
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1582,7 +1582,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-17"
             >
-              First-17 Last-17
+              FirsT-17 McLast-17
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1678,7 +1678,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-18"
             >
-              First-18 Last-18
+              FirsT-18 McLast-18
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1774,7 +1774,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-19"
             >
-              First-19 Last-19
+              FirsT-19 McLast-19
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1870,7 +1870,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-20"
             >
-              First-20 Last-20
+              FirsT-20 McLast-20
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -1966,7 +1966,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-21"
             >
-              First-21 Last-21
+              FirsT-21 McLast-21
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2062,7 +2062,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-22"
             >
-              First-22 Last-22
+              FirsT-22 McLast-22
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2158,7 +2158,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-23"
             >
-              First-23 Last-23
+              FirsT-23 McLast-23
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2254,7 +2254,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-24"
             >
-              First-24 Last-24
+              FirsT-24 McLast-24
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2350,7 +2350,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 1`] = `
               class="action-text"
               href="/view-data?id=id-25"
             >
-              First-25 Last-25
+              FirsT-25 McLast-25
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2455,7 +2455,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-1"
             >
-              First-1 Last-1
+              FirsT-1 McLast-1
             </a>
             <br />
             DOB: 
@@ -2522,7 +2522,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-0"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2556,7 +2556,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-1"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2592,7 +2592,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-2"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2626,7 +2626,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-3"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2660,7 +2660,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-4"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2744,7 +2744,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-2"
             >
-              First-2 Last-2
+              FirsT-2 McLast-2
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2840,7 +2840,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-3"
             >
-              First-3 Last-3
+              FirsT-3 McLast-3
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -2936,7 +2936,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-4"
             >
-              First-4 Last-4
+              FirsT-4 McLast-4
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3032,7 +3032,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-5"
             >
-              First-5 Last-5
+              FirsT-5 McLast-5
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3128,7 +3128,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-6"
             >
-              First-6 Last-6
+              FirsT-6 McLast-6
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3224,7 +3224,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-7"
             >
-              First-7 Last-7
+              FirsT-7 McLast-7
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3320,7 +3320,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-8"
             >
-              First-8 Last-8
+              FirsT-8 McLast-8
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3416,7 +3416,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-9"
             >
-              First-9 Last-9
+              FirsT-9 McLast-9
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3512,7 +3512,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-10"
             >
-              First-10 Last-10
+              FirsT-10 McLast-10
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3608,7 +3608,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-11"
             >
-              First-11 Last-11
+              FirsT-11 McLast-11
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3704,7 +3704,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-12"
             >
-              First-12 Last-12
+              FirsT-12 McLast-12
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3800,7 +3800,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-13"
             >
-              First-13 Last-13
+              FirsT-13 McLast-13
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3896,7 +3896,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-14"
             >
-              First-14 Last-14
+              FirsT-14 McLast-14
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -3992,7 +3992,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-15"
             >
-              First-15 Last-15
+              FirsT-15 McLast-15
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4088,7 +4088,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-16"
             >
-              First-16 Last-16
+              FirsT-16 McLast-16
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4184,7 +4184,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-17"
             >
-              First-17 Last-17
+              FirsT-17 McLast-17
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4280,7 +4280,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-18"
             >
-              First-18 Last-18
+              FirsT-18 McLast-18
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4376,7 +4376,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-19"
             >
-              First-19 Last-19
+              FirsT-19 McLast-19
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4472,7 +4472,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-20"
             >
-              First-20 Last-20
+              FirsT-20 McLast-20
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4568,7 +4568,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-21"
             >
-              First-21 Last-21
+              FirsT-21 McLast-21
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4664,7 +4664,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-22"
             >
-              First-22 Last-22
+              FirsT-22 McLast-22
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4760,7 +4760,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-23"
             >
-              First-23 Last-23
+              FirsT-23 McLast-23
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4856,7 +4856,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-24"
             >
-              First-24 Last-24
+              FirsT-24 McLast-24
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -4952,7 +4952,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 2`] = `
               class="action-text"
               href="/view-data?id=id-25"
             >
-              First-25 Last-25
+              FirsT-25 McLast-25
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5057,7 +5057,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-1"
             >
-              First-1 Last-1
+              FirsT-1 McLast-1
             </a>
             <br />
             DOB: 
@@ -5124,7 +5124,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-0"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5158,7 +5158,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-1"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5194,7 +5194,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-2"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5228,7 +5228,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-3"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5262,7 +5262,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-4"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5296,7 +5296,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-5"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5330,7 +5330,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
           class="action-text"
           href="/view-data?id=id-rel-1-6"
         >
-          First-1 Last-1
+          FirsT-1 McLast-1
         </a>
         <span
           class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5391,7 +5391,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-2"
             >
-              First-2 Last-2
+              FirsT-2 McLast-2
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5487,7 +5487,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-3"
             >
-              First-3 Last-3
+              FirsT-3 McLast-3
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5583,7 +5583,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-4"
             >
-              First-4 Last-4
+              FirsT-4 McLast-4
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5679,7 +5679,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-5"
             >
-              First-5 Last-5
+              FirsT-5 McLast-5
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5775,7 +5775,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-6"
             >
-              First-6 Last-6
+              FirsT-6 McLast-6
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5871,7 +5871,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-7"
             >
-              First-7 Last-7
+              FirsT-7 McLast-7
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -5967,7 +5967,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-8"
             >
-              First-8 Last-8
+              FirsT-8 McLast-8
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6063,7 +6063,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-9"
             >
-              First-9 Last-9
+              FirsT-9 McLast-9
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6159,7 +6159,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-10"
             >
-              First-10 Last-10
+              FirsT-10 McLast-10
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6255,7 +6255,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-11"
             >
-              First-11 Last-11
+              FirsT-11 McLast-11
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6351,7 +6351,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-12"
             >
-              First-12 Last-12
+              FirsT-12 McLast-12
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6447,7 +6447,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-13"
             >
-              First-13 Last-13
+              FirsT-13 McLast-13
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6543,7 +6543,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-14"
             >
-              First-14 Last-14
+              FirsT-14 McLast-14
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6639,7 +6639,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-15"
             >
-              First-15 Last-15
+              FirsT-15 McLast-15
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6735,7 +6735,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-16"
             >
-              First-16 Last-16
+              FirsT-16 McLast-16
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6831,7 +6831,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-17"
             >
-              First-17 Last-17
+              FirsT-17 McLast-17
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -6927,7 +6927,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-18"
             >
-              First-18 Last-18
+              FirsT-18 McLast-18
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7023,7 +7023,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-19"
             >
-              First-19 Last-19
+              FirsT-19 McLast-19
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7119,7 +7119,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-20"
             >
-              First-20 Last-20
+              FirsT-20 McLast-20
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7215,7 +7215,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-21"
             >
-              First-21 Last-21
+              FirsT-21 McLast-21
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7311,7 +7311,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-22"
             >
-              First-22 Last-22
+              FirsT-22 McLast-22
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7407,7 +7407,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-23"
             >
-              First-23 Last-23
+              FirsT-23 McLast-23
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7503,7 +7503,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-24"
             >
-              First-24 Last-24
+              FirsT-24 McLast-24
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"
@@ -7599,7 +7599,7 @@ exports[`EcrTableContent load with an eCR should match snapshot 3`] = `
               class="action-text"
               href="/view-data?id=id-25"
             >
-              First-25 Last-25
+              FirsT-25 McLast-25
             </a>
             <span
               class="usa-tag margin-x-1 padding-x-05 padding-y-2px bg-primary-lighter radius-md text-thin text-base-dark"

--- a/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
@@ -54,6 +54,45 @@ describe("FormatService tests", () => {
       const result = formatName(emptyHumanName);
       expect(result).toEqual(expectedName);
     });
+
+    it("should not format if mixed case", () => {
+      const mixedHumanName = {
+        given: ["I aM", "A Name"],
+        family: "McName😈",
+        prefix: ["Master"],
+        suffix: ["Jr"],
+      } as HumanName;
+      const expectedName = "Master I aM A Name McName😈 Jr";
+
+      const result = formatName(mixedHumanName);
+      expect(result).toEqual(expectedName);
+    });
+
+    it("should format if all lower case", () => {
+      const lowerHumanName = {
+        given: ["i am", "a name"],
+        family: "mcname😈",
+        prefix: ["master"],
+        suffix: ["jr"],
+      } as HumanName;
+      const expectedName = "Master I Am A Name Mcname😈 jr";
+
+      const result = formatName(lowerHumanName);
+      expect(result).toEqual(expectedName);
+    });
+
+    it("should format if all upper case", () => {
+      const lowerHumanName = {
+        given: ["I AM", "A NAME"],
+        family: "MCNAME😈",
+        prefix: ["MASTER"],
+        suffix: ["JR"],
+      } as HumanName;
+      const expectedName = "Master I Am A Name Mcname😈 JR";
+
+      const result = formatName(lowerHumanName);
+      expect(result).toEqual(expectedName);
+    });
   });
 
   describe("Format age", () => {

--- a/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
@@ -55,42 +55,16 @@ describe("FormatService tests", () => {
       expect(result).toEqual(expectedName);
     });
 
-    it("should not format if mixed case", () => {
+    it("should not format", () => {
       const mixedHumanName = {
         given: ["I aM", "A Name"],
         family: "McName😈",
-        prefix: ["Master"],
-        suffix: ["Jr"],
-      } as HumanName;
-      const expectedName = "Master I aM A Name McName😈 Jr";
-
-      const result = formatName(mixedHumanName);
-      expect(result).toEqual(expectedName);
-    });
-
-    it("should format if all lower case", () => {
-      const lowerHumanName = {
-        given: ["i am", "a name"],
-        family: "mcname😈",
         prefix: ["master"],
-        suffix: ["jr"],
-      } as HumanName;
-      const expectedName = "Master I Am A Name Mcname😈 jr";
-
-      const result = formatName(lowerHumanName);
-      expect(result).toEqual(expectedName);
-    });
-
-    it("should format if all upper case", () => {
-      const lowerHumanName = {
-        given: ["I AM", "A NAME"],
-        family: "MCNAME😈",
-        prefix: ["MASTER"],
         suffix: ["JR"],
       } as HumanName;
-      const expectedName = "Master I Am A Name Mcname😈 JR";
+      const expectedName = "master I aM A Name McName😈 JR";
 
-      const result = formatName(lowerHumanName);
+      const result = formatName(mixedHumanName);
       expect(result).toEqual(expectedName);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -131,7 +131,7 @@ describe("Snapshot test for eCR Document", () => {
 
       render(actual);
 
-      expect(screen.getByText("Dr Toob Nix SR")).toBeInTheDocument();
+      expect(screen.getByText("DR Toob Nix SR")).toBeInTheDocument();
       expect(screen.getByText("family")).toBeInTheDocument();
       expect(
         screen.getByText("Start: 11/16/1884 End: 05/21/1896"),

--- a/containers/orchestration/app/default_configs/bundle-metadata-core.json
+++ b/containers/orchestration/app/default_configs/bundle-metadata-core.json
@@ -6,10 +6,6 @@
     },
     {
       "service": "ingestion",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names"
-    },
-    {
-      "service": "ingestion",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
         "dob_format": ""

--- a/containers/orchestration/app/default_configs/bundle-metadata-extended.json
+++ b/containers/orchestration/app/default_configs/bundle-metadata-extended.json
@@ -6,10 +6,6 @@
     },
     {
       "service": "ingestion",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names"
-    },
-    {
-      "service": "ingestion",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
         "dob_format": ""

--- a/containers/orchestration/app/default_configs/bundle-only.json
+++ b/containers/orchestration/app/default_configs/bundle-only.json
@@ -6,10 +6,6 @@
     },
     {
       "service": "ingestion",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names"
-    },
-    {
-      "service": "ingestion",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
         "dob_format": ""


### PR DESCRIPTION
# PULL REQUEST

## Summary

Generally allow names through as is
* Do not standardize names as part of the eCR processing anymore
* Change the column type of `first_name` and `last_name` to `nvarchar` on sql server
* Only format the name in the front end if it looks un-formmated (all caps or lower)

context: https://skylight-hq.slack.com/archives/C05B5R8K0TF/p1755542099777099

## Related Issue

Fixes #691
