### PR TITLE
ci: update node version on tests

### DIFF
--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   CONTAINER: ecr-viewer
-  NODE_VERSION: 22 # Adjust the Node.js version as needed
+  NODE_VERSION: 24 # Adjust the Node.js version as needed
 
 jobs:
   javascript-linting:


### PR DESCRIPTION
# PULL REQUEST


## Summary

We're on node 24 now, use it in testing