### PR TITLE
fix: revert FHIR converter to 7.0-19

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-20 --depth 1 /build/FHIR-Converter
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-19 --depth 1 /build/FHIR-Converter
 
 WORKDIR /build/FHIR-Converter
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Reverts FHIR Converter version due to a bug present in eCRs with multiple encounters.

## Related Issue

Fixes #1119 

## Acceptance Criteria

- The viewer uses FHIR Converter version 7.0-19
- The following eCR can be ingested using a config with a metadata db:
[CDA_eICR.xml](https://github.com/user-attachments/files/22139909/CDA_eICR.xml)
[CDA_RR.xml](https://github.com/user-attachments/files/22139910/CDA_RR.xml)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
