### PR TITLE
chore: update converter with XHTML fix

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-27 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch josh/xhtml --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch josh/xhtml --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-28 --depth 1 /App
 
 WORKDIR /App
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Updating the FHIR converter to include the XHTML fixes [here](https://github.com/CDCgov/dibbs-FHIR-Converter/pull/83).

