### PR TITLE
fix: FHIR converter escapes special characters in code display text

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-36 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch v7.0-37 --depth 1 /App
 WORKDIR /App
 
 RUN dotnet restore


### PR DESCRIPTION
# PULL REQUEST

## Summary

Updates FHIR converter to latest version. Escapes special characters in places that they are appearing, which is causing eCR. ingestion to fail.

## Related Issue

Fixes #1227 

## Acceptance Criteria

- [ ] FHIR conversion is successful for eCRs with special characters in code original text
- [ ] FHIR conversion is successful for eCRs with special characters in coding displayName
- [ ] FHIR conversion is successful for eCRs with special characters in observation value displayName
- [ ] FHIR conversion is successful for eCRs with special characters in observation value translation displayName
- [ ] FHIR conversion is successful for eCRs with special characters in observation value translation displayName
- [ ] FHIR conversion is successful for eCRs with special characters in observation code translation displayName

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
