### PR TITLE
fix: Version number bug pt.3

### DIFF
--- a/containers/ecr-viewer/Dockerfile
+++ b/containers/ecr-viewer/Dockerfile
@@ -14,8 +14,6 @@ RUN npm ci
 
 # Rebuild the source code only when needed
 FROM base AS builder
-ARG APP_VERSION
-ENV APP_VERSION=$APP_VERSION
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --exclude=./seed-scripts . .
@@ -28,6 +26,8 @@ RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 WORKDIR /app
 
 # Uncomment the following line in case you want to disable telemetry during runtime.


### PR DESCRIPTION
# PULL REQUEST

## Summary

I think this should be the last fix for version number showing up in prod. Re-reading the docs below, I think `APP_VERSION=$APP_VERSION` and `ENV APP_VERSION=$APP_VERSION` need to be in the runner stage, not the build stage. Previously, the env var wasn't getting propagated to runtime because the runner stage wasn't actually a child stage of the build stage.

[Docker Documentation: Variables](https://docs.docker.com/build/building/variables/)
[Next.js: Variables](https://nextjs.org/docs/pages/guides/environment-variables)

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
