### PR TITLE
fix: Version number pt.3

### DIFF
--- a/containers/ecr-viewer/Dockerfile
+++ b/containers/ecr-viewer/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 FROM node:24-alpine AS base
+ARG APP_VERSION
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -26,8 +27,11 @@ RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner
+
+# Inherits APP_VERSION from base
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
+
 WORKDIR /app
 
 # Uncomment the following line in case you want to disable telemetry during runtime.

--- a/containers/ecr-viewer/docker-compose.yaml
+++ b/containers/ecr-viewer/docker-compose.yaml
@@ -8,14 +8,13 @@ services:
       context: ./
       dockerfile: Dockerfile
       args:
-        - APP_VERSION=1.0
+        - APP_VERSION=vTest
     network_mode: host
     environment:
       - CONFIG_NAME=${CONFIG_NAME:-AWS_SQLSERVER_NON_INTEGRATED}
       - NBS_PUB_KEY
       - NBS_API_PUB_KEY
       - SAVE_XML=false
-      - APP_VERSION=vTest
       # METADATA DATABASE
       - DATABASE_URL=${DATABASE_URL:-postgres://postgres:pw@localhost:5432/ecr_viewer_db}
       - METADATA_DATABASE_SCHEMA


### PR DESCRIPTION
# PULL REQUEST
## Summary

Setting `APP_VERSION` at `base`, and then `runner` will inherit `APP_VERSION` from base

From the Dockerfile [docs](https://docs.docker.com/reference/dockerfile/):
```
An ARG variable declared within a build stage is automatically inherited by other stages based on that stage. 
Unrelated build stages do not have access to the variable. To use an argument in multiple distinct stages, 
each stage must include the ARG instruction, or they must both be based on a shared base stage in the 
same Dockerfile where the variable is declared.
```

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
