### PR TITLE
fix: update tf_branch and add event_type inputs to trigger-dev-workfl…

### DIFF
--- a/.github/workflows/trigger-demo-workflow.yaml
+++ b/.github/workflows/trigger-demo-workflow.yaml
@@ -8,7 +8,6 @@ on:
         type: string
         description: "The container tag to deploy. Example: `8.4.0`"
         required: true
-        default: main
       event_type:
         type: choice
         options:

--- a/.github/workflows/trigger-dev-workflow.yaml
+++ b/.github/workflows/trigger-dev-workflow.yaml
@@ -31,7 +31,7 @@ on:
     inputs:
       container_tag:
         type: string
-        description: "The container tag to deploy. Example: `5.0.0`"
+        description: "The container tag to deploy. Example: `8.4.0`"
         required: true
       tf_branch:
         type: string


### PR DESCRIPTION
## Changes Proposed

### Dev file
- Added a new required input `event_type` on dev deployments with two options: "plans" and "deploys".
- Modified the `EVENT_TYPE` environment variable in the job to use the provided `event_type` input value.
- Set the `event_type` default in the workflow_call to `deploys` to prevent behavior changes in current workflows.

### Demo file
- Bring demo deployment workflow file more in line with dev file structure and arguments

## Testing

- Can test the AWS/Azure dev plans/deploys with [this workflow](https://github.com/CDCgov/dibbs-ecr-viewer/actions/workflows/trigger-dev-workflow.yaml), and by setting the branch to `alis/wf_trigger_mod1`
- Can test the Azure demo plan/deploy with [this workflow](https://github.com/CDCgov/dibbs-ecr-viewer/actions/workflows/trigger-demo-workflow.yaml), and by setting the branch to `alis/wf_trigger_mod1`
- Reviewers should verify that the workflow correctly sets plan(s) and deploy(s) as inputs.
- Check that the `EVENT_TYPE` environment variable is set correctly based on the provided input value.