### PR TITLE
chore: add `--skipApiVersionCheck` to avoid Azurite/azure-storage API drift

### DIFF
--- a/containers/ecr-viewer/docker-compose.yaml
+++ b/containers/ecr-viewer/docker-compose.yaml
@@ -148,11 +148,13 @@ services:
       dockerfile: azurite.Dockerfile
     hostname: azurite
     restart: always
+    # Temporary: --skipApiVersionCheck is needed until Azurite supports the latest Azure Storage API version.
+    # See: https://github.com/Azure/Azurite/issues/2623
     command:
       - /bin/sh
       - -c
       - |
-        azurite --blobHost 0.0.0.0 --blobPort 10000 -l data --debug /data/debug.log &
+        azurite --skipApiVersionCheck --blobHost 0.0.0.0 --blobPort 10000 -l data --debug /data/debug.log &
         sleep 5
         az storage container create --name ecr-viewer-files
         tail -f /dev/null


### PR DESCRIPTION
# PULL REQUEST

## Summary

Known issue -- The new `azure-storage` API version is still unsupported by Azurite. The open issue below recommends temporarily adding --skipApiVersionCheck until Azurite supports the latest API version.

Github issue: https://github.com/Azure/Azurite/issues/2623

## Related Issue

N/A - CI tests were breaking

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
