### PR TITLE
Add 'Connection: close' header to orchestration POST request

### DIFF
--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -82,7 +82,9 @@ async def post_request(client: httpx.AsyncClient, url: str, payload: dict) -> Re
     :param payload: The body of the Request object, as a dictionary.
     :return: A Response object from the posted endpoint.
     """
-    return await client.post(url, json=payload, headers={"x-orchestration": "true", "Connection": "close"})
+    return await client.post(
+        url, json=payload, headers={"x-orchestration": "true", "Connection": "close"}
+    )
 
 
 async def _send_websocket_dump(


### PR DESCRIPTION
# PULL REQUEST

Adds a 'Connection: close' header to the POST request service in the orchestration container. This should theoretically prevent any connections between the services from being kept alive, preventing the `Server disconnected without sending a response` errors.

## Related Issue

Fixes #1291
