### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Data Ingestion Building Blocks (DIBBs) eCR Viewer
+
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CDCgov/dibbs-ecr-viewer)
 
 **General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm). GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/CDCgov/dibbs-ecr-viewer) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.