### PR TITLE
fix: update fast-xml-parser to fixed version for another cve

### DIFF
--- a/containers/ecr-viewer/package-lock.json
+++ b/containers/ecr-viewer/package-lock.json
@@ -10935,9 +10935,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -10946,7 +10946,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -132,6 +132,6 @@
     "pretty-format": {
       "react-is": "$react-is"
     },
-    "fast-xml-parser": "5.3.4"
+    "fast-xml-parser": "5.3.6"
   }
 }


### PR DESCRIPTION
# PULL REQUEST
## Summary

Update fast-xml-parser version to close CVE

## Related Issue

Fixes https://github.com/CDCgov/dibbs-ecr-viewer/security/dependabot/57

## Acceptance Criteria

App still works
