### PR TITLE
perf: Reduce lag on Viewer - Pt. 1 Labs

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -148,9 +148,7 @@ export type PathTypes = {
   procedureSpecimen: CodeableConcept;
   procedureMethod: CodeableConcept;
   procedurePriority: CodeableConcept;
-  diagnosticReports: DiagnosticReport;
   diagnosticReportStatus: string;
-  observations: Observation;
   labResultDiv: string;
   specimenCollectionTime: TimeX;
   specimenReceivedTime: TimeX;
@@ -164,7 +162,6 @@ export type PathTypes = {
   observationResultStatus: string;
   labReportInterpretation: ValueX;
   observationInterpretation: Coding;
-  organizations: Organization;
   organizationType: ValueX;
   patientTravelHistory: Observation;
   travelHistoryLocation: string;
@@ -628,21 +625,13 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
 
   // === Lab Info ===
-  diagnosticReports: {
-    type: "DiagnosticReport",
-    path: "entry.resource.DiagnosticReport",
-  },
   diagnosticReportStatus: {
     type: "string",
     path: "iif(extension('http://terminology.hl7.org/CodeSystem/v2-0123').valueCodeableConcept.coding.display.exists(), extension('http://terminology.hl7.org/CodeSystem/v2-0123').valueCodeableConcept.coding.display, status)",
   },
-  observations: {
-    type: "Observation",
-    path: "entry.resource.Observation",
-  },
   labResultDiv: {
     type: "string",
-    path: "entry.resource.section.where(code.coding.exists(system = 'http://loinc.org' and code = '30954-2')).text.`div`",
+    path: "section.where(code.coding.exists(system = 'http://loinc.org' and code = '30954-2')).text.`div`",
   },
   specimenCollectionTime: {
     type: "TimeX",
@@ -668,6 +657,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "string",
     path: "(valueQuantity.value.toString() | valueString | valueCodeableConcept.coding.display | iif(valueQuantity.unit.exists(), iif(valueQuantity.unit = '%', valueQuantity.unit, ' ' + valueQuantity.unit), '') | iif(interpretation.coding.display.exists(), ' (' + interpretation.coding.display + ')', '')).join('')",
   },
+  // TODO: Generalize
   observationReferenceRange: {
     type: "ObservationReferenceRange",
     path: "referenceRange",
@@ -695,10 +685,6 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
 
   // Organization
-  organizations: {
-    type: "Organization",
-    path: "entry.resource.Organization",
-  },
   organizationType: {
     type: "ValueX",
     path: "type.coding.display",
@@ -743,7 +729,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   // Stamped
   stampedImmunizations: {
     type: "Immunization",
-    path: "entry.resource.where(extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').valueCoding.code = %snomedCode and resourceType = 'Immunization')",
+    path: "Immunization.where(extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').valueCoding.code = %snomedCode)",
   },
 
   // Generic

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -657,7 +657,6 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "string",
     path: "(valueQuantity.value.toString() | valueString | valueCodeableConcept.coding.display | iif(valueQuantity.unit.exists(), iif(valueQuantity.unit = '%', valueQuantity.unit, ' ' + valueQuantity.unit), '') | iif(interpretation.coding.display.exists(), ' (' + interpretation.coding.display + ')', '')).join('')",
   },
-  // TODO: Generalize
   observationReferenceRange: {
     type: "ObservationReferenceRange",
     path: "referenceRange",
@@ -729,7 +728,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   // Stamped
   stampedImmunizations: {
     type: "Immunization",
-    path: "Immunization.where(extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').valueCoding.code = %snomedCode)",
+    path: "entry.resource.where(extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').valueCoding.code = %snomedCode and resourceType = 'Immunization')",
   },
 
   // Generic

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -30,7 +30,7 @@ import {
 import { notEmpty } from "@/app/utils/data-utils";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
-import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+import { FhirIndex, getResourceById } from "@/app/view-data/services/fhirResourcesIndexService";
 
 // TODO: Follow up on FHIR/fhirpath typing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,9 +353,8 @@ export const evaluateReference2 = <T extends Resource>(
   if (!ref) return undefined;
 
   const [resourceType, id] = ref.split("/");
-  const result = fhirIndex.fhirResourcesById[id];
-  // TODO ANGELA: Add type checking
-
+  const result = getResourceById<T>(fhirIndex, resourceType as T["resourceType"], id);
+  
   if (result && result?.resourceType !== resourceType) {
     console.error(
       `Resource type mismatch: Expected ${resourceType}, but got ${result?.resourceType}`

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -351,7 +351,7 @@ export const evaluateReference = <T extends Resource>(
  * error logged if it does not match.
  *
  * Expects a single element to be returned from the reference.
- * 
+ *
  * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param ref - The reference string (e.g., "Patient/123").
  * @returns The FHIR Resource or undefined if not found.

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -342,8 +342,8 @@ export const evaluateReference = <T extends Resource>(
   return result;
 };
 
+// TODO ANGELA: Add JSdoc
 export const evaluateReference2 = <T extends Resource>(
-  // fhirData: FhirData,
   fhirIndex: FhirIndex,
   ref?: string | Reference
 ): T | undefined => {
@@ -354,7 +354,7 @@ export const evaluateReference2 = <T extends Resource>(
 
   const [resourceType, id] = ref.split("/");
   const result = fhirIndex.fhirResourcesById[id];
-  // TODO: Add type checking
+  // TODO ANGELA: Add type checking
 
   if (result && result?.resourceType !== resourceType) {
     console.error(

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -356,7 +356,7 @@ export const evaluateReference = <T extends Resource>(
  * @param ref - The reference string (e.g., "Patient/123").
  * @returns The FHIR Resource or undefined if not found.
  */
-// TODO ANGELA: Eventually want this to replace evaluateReference completely
+// TODO: Eventually want this to replace evaluateReference completely
 export const evaluateReference2 = <T extends Resource>(
   fhirIndex: FhirIndex,
   ref?: string | Reference,

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -30,7 +30,10 @@ import {
 import { notEmpty } from "@/app/utils/data-utils";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
-import { FhirIndex, getResourceById } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getResourceById,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 // TODO: Follow up on FHIR/fhirpath typing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -345,7 +348,7 @@ export const evaluateReference = <T extends Resource>(
 // TODO ANGELA: Add JSdoc
 export const evaluateReference2 = <T extends Resource>(
   fhirIndex: FhirIndex,
-  ref?: string | Reference
+  ref?: string | Reference,
 ): T | undefined => {
   if (typeof ref !== "string") {
     ref = formatReference(ref);
@@ -353,11 +356,15 @@ export const evaluateReference2 = <T extends Resource>(
   if (!ref) return undefined;
 
   const [resourceType, id] = ref.split("/");
-  const result = getResourceById<T>(fhirIndex, resourceType as T["resourceType"], id);
-  
+  const result = getResourceById<T>(
+    fhirIndex,
+    resourceType as T["resourceType"],
+    id,
+  );
+
   if (result && result?.resourceType !== resourceType) {
     console.error(
-      `Resource type mismatch: Expected ${resourceType}, but got ${result?.resourceType}`
+      `Resource type mismatch: Expected ${resourceType}, but got ${result?.resourceType}`,
     );
   }
 

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -30,6 +30,7 @@ import {
 import { notEmpty } from "@/app/utils/data-utils";
 
 import fhirPathMappings, { PathTypes, ValueX, FhirPath } from "./fhir-paths";
+import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 // TODO: Follow up on FHIR/fhirpath typing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -339,6 +340,29 @@ export const evaluateReference = <T extends Resource>(
   }
 
   return result;
+};
+
+export const evaluateReference2 = <T extends Resource>(
+  // fhirData: FhirData,
+  fhirIndex: FhirIndex,
+  ref?: string | Reference
+): T | undefined => {
+  if (typeof ref !== "string") {
+    ref = formatReference(ref);
+  }
+  if (!ref) return undefined;
+
+  const [resourceType, id] = ref.split("/");
+  const result = fhirIndex.fhirResourcesById[id];
+  // TODO: Add type checking
+
+  if (result && result?.resourceType !== resourceType) {
+    console.error(
+      `Resource type mismatch: Expected ${resourceType}, but got ${result?.resourceType}`
+    );
+  }
+
+  return result as T;
 };
 
 type RefPathTypes = {

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -342,7 +342,18 @@ export const evaluateReference = <T extends Resource>(
   return result;
 };
 
-// TODO ANGELA: Add JSdoc
+/**
+ * Evaluates a reference to return a resource. The resulting type of the expected resource
+ * must be provided as a type parameter. This will also be checked at runtime and an
+ * error logged if it does not match.
+ *
+ * Expects a single element to be returned from the reference.
+ * 
+ * @param fhirIndex - FHIR resources indexed by type & by ID
+ * @param ref - The reference string (e.g., "Patient/123").
+ * @returns The FHIR Resource or undefined if not found.
+ */
+// TODO ANGELA: Eventually want this to replace evaluateReference completely
 export const evaluateReference2 = <T extends Resource>(
   fhirIndex: FhirIndex,
   ref?: string | Reference

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -53,10 +53,7 @@ export const getEcrDocumentAccordionItems = (
     fhirIndex,
     "DiagnosticReport",
   );
-  const labInfoData = evaluateLabInfoData(
-    fhirIndex,
-    diagnosticReports,
-  );
+  const labInfoData = evaluateLabInfoData(fhirIndex, diagnosticReports);
 
   const hasUnavailableData = () => {
     const unavailableDataArrays = [

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -54,7 +54,6 @@ export const getEcrDocumentAccordionItems = (
     "DiagnosticReport",
   );
   const labInfoData = evaluateLabInfoData(
-    fhirBundle,
     fhirIndex,
     diagnosticReports,
   );

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Bundle } from "fhir/r4";
+import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import { AccordionItem } from "@/app/types";
 import { evaluateAll } from "@/app/utils/evaluate";
@@ -25,6 +25,7 @@ import {
   evaluatePregnancyData,
 } from "@/app/view-data/services/evaluateFhirDataService";
 import { evaluateLabInfoData } from "@/app/view-data/services/labsService";
+import { FhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
 
 import { evaluateClinicalData } from "./clinical-data";
 
@@ -35,20 +36,51 @@ import { evaluateClinicalData } from "./clinical-data";
  */
 export const getEcrDocumentAccordionItems = (
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex
 ): AccordionItem[] => {
+  const t0 = performance.now();
   const demographicsData = evaluateDemographicsData(fhirBundle);
+  const t11 = performance.now();
+  console.log("Time to run evaluateDemographics", t11 - t0);
   const socialData = evaluateSocialData(fhirBundle);
+  const t12 = performance.now();
+  console.log("Time to run evaluateSocialData", t12 - t0);
   const pregnancyData = evaluatePregnancyData(fhirBundle);
+  const t13 = performance.now();
+  console.log("Time to run evaluatePregnancyData", t13 - t0);
   const hospitalEncounterData = evaluateHospitalEncounterData(fhirBundle);
+  const t14 = performance.now();
+  console.log("Time to run evaluateHospitalEncounterData", t14 - t0);
   const encounterData = evaluateEncounterData(fhirBundle);
+  const t15 = performance.now();
+  console.log("Time to run evaluateEncounterData", t15 - t0);
   const providerData = evaluateProviderData(fhirBundle);
+  const t16 = performance.now();
+  console.log("Time to run evaluateProviderData", t16 - t0);
   const clinicalData = evaluateClinicalData(fhirBundle);
+  const t17 = performance.now();
+  console.log("Time to run evaluateClinicalData", t17 - t0);
   const ecrMetadata = evaluateEcrMetadata(fhirBundle);
+  const t18 = performance.now();
+  console.log("Time to run evaluateEcrMetadata", t18 - t0);
   const facilityData = evaluateFacilityData(fhirBundle);
+  const t19 = performance.now();
+  console.log("Time to run evaluateFacilityData", t19 - t0);
+  const lab0 = performance.now();
+
+  const diagnosticReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport')
+  const lab1 = performance.now();
+  console.log("Time to evaluate diagnosticReports", lab1 - lab0);
   const labInfoData = evaluateLabInfoData(
     fhirBundle,
-    evaluateAll(fhirBundle, fhirPathMappings.diagnosticReports),
+    diagnosticReports,
+    fhirIndex
   );
+  const t20 = performance.now();
+  console.log("Time to run evaluateLabInfoData", t20 - t0);
+
+  const t1 = performance.now();
+  console.log("Time to evaluate all : ", t1 - t0);
 
   const hasUnavailableData = () => {
     const unavailableDataArrays = [
@@ -70,9 +102,11 @@ export const getEcrDocumentAccordionItems = (
       ecrMetadata.eicrAuthorDetails.map((details) => details.unavailableData),
     ];
     return unavailableDataArrays.some(
-      (array) => Array.isArray(array) && array.length > 0,
+      (array) => Array.isArray(array) && array.length > 0
     );
   };
+
+  const t2 = performance.now();
   const accordionItems: AccordionItem[] = [
     {
       title: "Patient Info",
@@ -123,7 +157,7 @@ export const getEcrDocumentAccordionItems = (
     {
       title: "Clinical Info",
       content: Object.values(clinicalData).some(
-        (section) => section.availableData.length > 0,
+        (section) => section.availableData.length > 0
       ) ? (
         <ClinicalInfo
           clinicalNotes={clinicalData.clinicalNotes.availableData}
@@ -165,7 +199,7 @@ export const getEcrDocumentAccordionItems = (
           ecrMetadata.eRSDProcessingInfo ||
           ecrMetadata.eicrDetails.availableData.length > 0 ||
           ecrMetadata.eicrAuthorDetails.find(
-            (authorDetails) => authorDetails.availableData.length > 0,
+            (authorDetails) => authorDetails.availableData.length > 0
           ) ||
           ecrMetadata.ecrCustodianDetails.availableData.length > 0 ? (
             <EcrMetadata
@@ -225,7 +259,7 @@ export const getEcrDocumentAccordionItems = (
                 ...ecrMetadata.ecrCustodianDetails.unavailableData,
               ]}
               eicrAuthorUnavailableData={ecrMetadata.eicrAuthorDetails.map(
-                (authorDetails) => authorDetails.unavailableData,
+                (authorDetails) => authorDetails.unavailableData
               )}
             />
           ) : (
@@ -246,6 +280,8 @@ export const getEcrDocumentAccordionItems = (
       headingLevel: "h3",
     };
   });
+  const t3 = performance.now();
+  console.log("Time to build accordion components", t3 - t2);
 
   return accordionItems;
 };

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -23,7 +23,10 @@ import {
   evaluatePregnancyData,
 } from "@/app/view-data/services/evaluateFhirDataService";
 import { evaluateLabInfoData } from "@/app/view-data/services/labsService";
-import { FhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getResourcesByType,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 import { evaluateClinicalData } from "./clinical-data";
 
@@ -35,7 +38,7 @@ import { evaluateClinicalData } from "./clinical-data";
  */
 export const getEcrDocumentAccordionItems = (
   fhirBundle: Bundle,
-  fhirIndex: FhirIndex
+  fhirIndex: FhirIndex,
 ): AccordionItem[] => {
   const demographicsData = evaluateDemographicsData(fhirBundle);
   const socialData = evaluateSocialData(fhirBundle);
@@ -46,13 +49,16 @@ export const getEcrDocumentAccordionItems = (
   const clinicalData = evaluateClinicalData(fhirBundle);
   const ecrMetadata = evaluateEcrMetadata(fhirBundle);
   const facilityData = evaluateFacilityData(fhirBundle);
-  const diagnosticReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport')
+  const diagnosticReports = getResourcesByType<DiagnosticReport>(
+    fhirIndex,
+    "DiagnosticReport",
+  );
   const labInfoData = evaluateLabInfoData(
     fhirBundle,
     fhirIndex,
-    diagnosticReports
+    diagnosticReports,
   );
-  
+
   const hasUnavailableData = () => {
     const unavailableDataArrays = [
       demographicsData.unavailableData,
@@ -73,7 +79,7 @@ export const getEcrDocumentAccordionItems = (
       ecrMetadata.eicrAuthorDetails.map((details) => details.unavailableData),
     ];
     return unavailableDataArrays.some(
-      (array) => Array.isArray(array) && array.length > 0
+      (array) => Array.isArray(array) && array.length > 0,
     );
   };
 
@@ -127,7 +133,7 @@ export const getEcrDocumentAccordionItems = (
     {
       title: "Clinical Info",
       content: Object.values(clinicalData).some(
-        (section) => section.availableData.length > 0
+        (section) => section.availableData.length > 0,
       ) ? (
         <ClinicalInfo
           clinicalNotes={clinicalData.clinicalNotes.availableData}
@@ -169,7 +175,7 @@ export const getEcrDocumentAccordionItems = (
           ecrMetadata.eRSDProcessingInfo ||
           ecrMetadata.eicrDetails.availableData.length > 0 ||
           ecrMetadata.eicrAuthorDetails.find(
-            (authorDetails) => authorDetails.availableData.length > 0
+            (authorDetails) => authorDetails.availableData.length > 0,
           ) ||
           ecrMetadata.ecrCustodianDetails.availableData.length > 0 ? (
             <EcrMetadata
@@ -229,7 +235,7 @@ export const getEcrDocumentAccordionItems = (
                 ...ecrMetadata.ecrCustodianDetails.unavailableData,
               ]}
               eicrAuthorUnavailableData={ecrMetadata.eicrAuthorDetails.map(
-                (authorDetails) => authorDetails.unavailableData
+                (authorDetails) => authorDetails.unavailableData,
               )}
             />
           ) : (
@@ -250,6 +256,6 @@ export const getEcrDocumentAccordionItems = (
       headingLevel: "h3",
     };
   });
-  
+
   return accordionItems;
 };

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import { AccordionItem } from "@/app/types";
-import { evaluateAll } from "@/app/utils/evaluate";
-import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { toKebabCase } from "@/app/utils/format-utils";
 import ClinicalInfo from "@/app/view-data/components/ClinicalInfo";
 import Demographics from "@/app/view-data/components/Demographics";
@@ -32,56 +30,29 @@ import { evaluateClinicalData } from "./clinical-data";
 /**
  * Functional component for an accordion container displaying various sections of eCR information.
  * @param fhirBundle - The FHIR bundle containing patient information.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns The JSX element representing the accordion container.
  */
 export const getEcrDocumentAccordionItems = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex
 ): AccordionItem[] => {
-  const t0 = performance.now();
   const demographicsData = evaluateDemographicsData(fhirBundle);
-  const t11 = performance.now();
-  console.log("Time to run evaluateDemographics", t11 - t0);
   const socialData = evaluateSocialData(fhirBundle);
-  const t12 = performance.now();
-  console.log("Time to run evaluateSocialData", t12 - t0);
   const pregnancyData = evaluatePregnancyData(fhirBundle);
-  const t13 = performance.now();
-  console.log("Time to run evaluatePregnancyData", t13 - t0);
   const hospitalEncounterData = evaluateHospitalEncounterData(fhirBundle);
-  const t14 = performance.now();
-  console.log("Time to run evaluateHospitalEncounterData", t14 - t0);
   const encounterData = evaluateEncounterData(fhirBundle);
-  const t15 = performance.now();
-  console.log("Time to run evaluateEncounterData", t15 - t0);
   const providerData = evaluateProviderData(fhirBundle);
-  const t16 = performance.now();
-  console.log("Time to run evaluateProviderData", t16 - t0);
   const clinicalData = evaluateClinicalData(fhirBundle);
-  const t17 = performance.now();
-  console.log("Time to run evaluateClinicalData", t17 - t0);
   const ecrMetadata = evaluateEcrMetadata(fhirBundle);
-  const t18 = performance.now();
-  console.log("Time to run evaluateEcrMetadata", t18 - t0);
   const facilityData = evaluateFacilityData(fhirBundle);
-  const t19 = performance.now();
-  console.log("Time to run evaluateFacilityData", t19 - t0);
-  const lab0 = performance.now();
-
   const diagnosticReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport')
-  const lab1 = performance.now();
-  console.log("Time to evaluate diagnosticReports", lab1 - lab0);
   const labInfoData = evaluateLabInfoData(
     fhirBundle,
-    diagnosticReports,
-    fhirIndex
+    fhirIndex,
+    diagnosticReports
   );
-  const t20 = performance.now();
-  console.log("Time to run evaluateLabInfoData", t20 - t0);
-
-  const t1 = performance.now();
-  console.log("Time to evaluate all : ", t1 - t0);
-
+  
   const hasUnavailableData = () => {
     const unavailableDataArrays = [
       demographicsData.unavailableData,
@@ -106,7 +77,6 @@ export const getEcrDocumentAccordionItems = (
     );
   };
 
-  const t2 = performance.now();
   const accordionItems: AccordionItem[] = [
     {
       title: "Patient Info",
@@ -280,8 +250,6 @@ export const getEcrDocumentAccordionItems = (
       headingLevel: "h3",
     };
   });
-  const t3 = performance.now();
-  console.log("Time to build accordion components", t3 - t2);
-
+  
   return accordionItems;
 };

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -6,13 +6,6 @@ import { AccordionItem } from "@/app/types";
 import { toKebabCase } from "@/app/utils/format-utils";
 
 import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
-import {
-  evaluateEcrSummaryConditionSummary,
-  evaluateEcrSummaryEncounterDetails,
-  evaluateEcrSummaryPatientDetails,
-} from "@/app/view-data/services/ecrSummaryService";
-import { Bundle } from "fhir/r4";
-import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 interface EcrSummaryProps {
   patientDetails: DisplayDataProps[];
@@ -107,7 +100,6 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
       };
     },
   );
-
   return (
     <div
       className="usa-summary-box padding-3"

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -6,11 +6,13 @@ import { AccordionItem } from "@/app/types";
 import { toKebabCase } from "@/app/utils/format-utils";
 
 import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
+import { evaluateEcrSummaryConditionSummary, evaluateEcrSummaryEncounterDetails, evaluateEcrSummaryPatientDetails } from "@/app/view-data/services/ecrSummaryService";
+import { Bundle } from "fhir/r4";
+import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 interface EcrSummaryProps {
-  patientDetails: DisplayDataProps[];
-  encounterDetails: DisplayDataProps[];
-  conditionSummary: ConditionSummary[];
+  fhirBundle: Bundle;
+  fhirIndex: FhirIndex;
   snomed?: string;
 }
 
@@ -33,125 +35,135 @@ export interface ConditionSummary {
  * @returns a react element for eCR Summary
  */
 const EcrSummary: React.FC<EcrSummaryProps> = ({
-  patientDetails,
-  encounterDetails,
-  conditionSummary,
-  snomed,
+  fhirBundle,
+  fhirIndex,
+  snomed
 }) => {
-  const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
-    (condition) => {
-      const hasImmunizationDetails = condition.immunizationDetails.length > 0;
-      const hasClinicalDetails = condition.clinicalDetails.length > 0;
-      return {
-        title: condition.title,
-        id: toKebabCase(condition.title),
-        headingLevel: "h4",
-        className: "side-nav-ignore border-1px border-accent-cool-darker",
-        expanded: snomed === condition.snomed || conditionSummary.length === 1,
-        content: (
-          <>
-            {condition.conditionDetails.map((item, i) => (
-              <DataDisplay item={item} key={`condition-${i}`} />
+  const t0 = performance.now();
+  const patientDetails = evaluateEcrSummaryPatientDetails(fhirBundle).availableData;
+  const encounterDetails = evaluateEcrSummaryEncounterDetails(fhirBundle).availableData;
+  const conditionSummary = evaluateEcrSummaryConditionSummary(fhirBundle, fhirIndex, snomed);
+  const t1 = performance.now();
+  console.log("Evaluate eCR summary: ", t1 - t0);
+  try {
+    const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
+      (condition) => {
+        const hasImmunizationDetails = condition.immunizationDetails.length > 0;
+        const hasClinicalDetails = condition.clinicalDetails.length > 0;
+        return {
+          title: condition.title,
+          id: toKebabCase(condition.title),
+          headingLevel: "h4",
+          className: "side-nav-ignore border-1px border-accent-cool-darker",
+          expanded: snomed === condition.snomed || conditionSummary.length === 1,
+          content: (
+            <>
+              {condition.conditionDetails.map((item, i) => (
+                <DataDisplay item={item} key={`condition-${i}`} />
+              ))}
+              {(hasImmunizationDetails || hasClinicalDetails) && (
+                <>
+                  <h5
+                    className="text-bold margin-top-0 margin-bottom-1"
+                    id="relevant-clinical"
+                  >
+                    Clinical Sections Relevant to Reportable Condition
+                  </h5>
+                  {hasImmunizationDetails && (
+                    <div className="margin-top-0">
+                      {condition.immunizationDetails.map((item, i) => (
+                        <DataTableDisplay item={item} key={`imx-${i}`} />
+                      ))}
+                    </div>
+                  )}
+                  {hasClinicalDetails && (
+                    <div className="margin-top-0">
+                      {condition.clinicalDetails.map((item, i) => (
+                        <DataTableDisplay item={item} key={`detail-${i}`} />
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+              {condition.labDetails.length > 0 && (
+                <>
+                  <h5
+                    className="text-bold margin-0 margin-bottom-1"
+                    id="relevant-labs"
+                  >
+                    Lab Results Relevant to Reportable Condition
+                  </h5>
+                  <div className="margin-top-0">
+                    {condition.labDetails.map((item, index) => (
+                      <DataTableDisplay
+                        item={item}
+                        key={`${item.title}-${index}`}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          ),
+        };
+      },
+    );
+    return (
+      <div
+        className="usa-summary-box padding-3"
+        aria-labelledby="summary-box-key-information"
+      >
+        <div className="usa-summary-box__body margin-bottom-05">
+          <h3
+            className="summary-box-key-information side-nav-ignore"
+            id="patient-summary"
+          >
+            Patient Summary
+          </h3>
+          <div className="usa-summary-box__text">
+            {patientDetails.map((item, i) => (
+              <DataDisplay item={item} key={`pat-${i}`} themeColor="blue" />
             ))}
-            {(hasImmunizationDetails || hasClinicalDetails) && (
-              <>
-                <h5
-                  className="text-bold margin-top-0 margin-bottom-1"
-                  id="relevant-clinical"
-                >
-                  Clinical Sections Relevant to Reportable Condition
-                </h5>
-                {hasImmunizationDetails && (
-                  <div className="margin-top-0">
-                    {condition.immunizationDetails.map((item, i) => (
-                      <DataTableDisplay item={item} key={`imx-${i}`} />
-                    ))}
-                  </div>
-                )}
-                {hasClinicalDetails && (
-                  <div className="margin-top-0">
-                    {condition.clinicalDetails.map((item, i) => (
-                      <DataTableDisplay item={item} key={`detail-${i}`} />
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-            {condition.labDetails.length > 0 && (
-              <>
-                <h5
-                  className="text-bold margin-0 margin-bottom-1"
-                  id="relevant-labs"
-                >
-                  Lab Results Relevant to Reportable Condition
-                </h5>
-                <div className="margin-top-0">
-                  {condition.labDetails.map((item, index) => (
-                    <DataTableDisplay
-                      item={item}
-                      key={`${item.title}-${index}`}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-          </>
-        ),
-      };
-    },
-  );
-  return (
-    <div
-      className="usa-summary-box padding-3"
-      aria-labelledby="summary-box-key-information"
-    >
-      <div className="usa-summary-box__body margin-bottom-05">
-        <h3
-          className="summary-box-key-information side-nav-ignore"
-          id="patient-summary"
-        >
-          Patient Summary
-        </h3>
-        <div className="usa-summary-box__text">
-          {patientDetails.map((item, i) => (
-            <DataDisplay item={item} key={`pat-${i}`} themeColor="blue" />
-          ))}
-        </div>
-      </div>
-      <div className="usa-summary-box__body">
-        <h3
-          className="summary-box-key-information side-nav-ignore"
-          id="encounter-summary"
-        >
-          Encounter Summary
-        </h3>
-        <div className="usa-summary-box__text">
-          {encounterDetails.map((item, i) => (
-            <DataDisplay item={item} key={`enc-${i}`} themeColor="blue" />
-          ))}
-        </div>
-      </div>
-      <div className="usa-summary-box__body">
-        <h3
-          className="summary-box-key-information side-nav-ignore header-with-tag"
-          id="condition-summary"
-        >
-          <div>Condition Summary</div>
-          <div>
-            <Tag className="tag-info">
-              {numConditionsText(conditionSummaryAccordionItems.length)}
-            </Tag>
           </div>
-        </h3>
-        <div className="usa-summary-box__text condition-details-accordion">
-          <Accordion
-            items={conditionSummaryAccordionItems}
-            className="accordion-primary"
-          />
+        </div>
+        <div className="usa-summary-box__body">
+          <h3
+            className="summary-box-key-information side-nav-ignore"
+            id="encounter-summary"
+          >
+            Encounter Summary
+          </h3>
+          <div className="usa-summary-box__text">
+            {encounterDetails.map((item, i) => (
+              <DataDisplay item={item} key={`enc-${i}`} themeColor="blue" />
+            ))}
+          </div>
+        </div>
+        <div className="usa-summary-box__body">
+          <h3
+            className="summary-box-key-information side-nav-ignore header-with-tag"
+            id="condition-summary"
+          >
+            <div>Condition Summary</div>
+            <div>
+              <Tag className="tag-info">
+                {numConditionsText(conditionSummaryAccordionItems.length)}
+              </Tag>
+            </div>
+          </h3>
+          <div className="usa-summary-box__text condition-details-accordion">
+            <Accordion
+              items={conditionSummaryAccordionItems}
+              className="accordion-primary"
+            />
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  } finally {
+    const t2 = performance.now()
+    console.log("EcrSummary: ", t2 - t0);
+  }
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -11,8 +11,9 @@ import { Bundle } from "fhir/r4";
 import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 interface EcrSummaryProps {
-  fhirBundle: Bundle;
-  fhirIndex: FhirIndex;
+  patientDetails: DisplayDataProps[];
+  encounterDetails: DisplayDataProps[];
+  conditionSummary: ConditionSummary[];
   snomed?: string;
 }
 
@@ -35,135 +36,127 @@ export interface ConditionSummary {
  * @returns a react element for eCR Summary
  */
 const EcrSummary: React.FC<EcrSummaryProps> = ({
-  fhirBundle,
-  fhirIndex,
+  patientDetails,
+  encounterDetails,
+  conditionSummary,
   snomed
 }) => {
-  const t0 = performance.now();
-  const patientDetails = evaluateEcrSummaryPatientDetails(fhirBundle).availableData;
-  const encounterDetails = evaluateEcrSummaryEncounterDetails(fhirBundle).availableData;
-  const conditionSummary = evaluateEcrSummaryConditionSummary(fhirBundle, fhirIndex, snomed);
-  const t1 = performance.now();
-  console.log("Evaluate eCR summary: ", t1 - t0);
-  try {
-    const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
-      (condition) => {
-        const hasImmunizationDetails = condition.immunizationDetails.length > 0;
-        const hasClinicalDetails = condition.clinicalDetails.length > 0;
-        return {
-          title: condition.title,
-          id: toKebabCase(condition.title),
-          headingLevel: "h4",
-          className: "side-nav-ignore border-1px border-accent-cool-darker",
-          expanded: snomed === condition.snomed || conditionSummary.length === 1,
-          content: (
-            <>
-              {condition.conditionDetails.map((item, i) => (
-                <DataDisplay item={item} key={`condition-${i}`} />
-              ))}
-              {(hasImmunizationDetails || hasClinicalDetails) && (
-                <>
-                  <h5
-                    className="text-bold margin-top-0 margin-bottom-1"
-                    id="relevant-clinical"
-                  >
-                    Clinical Sections Relevant to Reportable Condition
-                  </h5>
-                  {hasImmunizationDetails && (
-                    <div className="margin-top-0">
-                      {condition.immunizationDetails.map((item, i) => (
-                        <DataTableDisplay item={item} key={`imx-${i}`} />
-                      ))}
-                    </div>
-                  )}
-                  {hasClinicalDetails && (
-                    <div className="margin-top-0">
-                      {condition.clinicalDetails.map((item, i) => (
-                        <DataTableDisplay item={item} key={`detail-${i}`} />
-                      ))}
-                    </div>
-                  )}
-                </>
-              )}
-              {condition.labDetails.length > 0 && (
-                <>
-                  <h5
-                    className="text-bold margin-0 margin-bottom-1"
-                    id="relevant-labs"
-                  >
-                    Lab Results Relevant to Reportable Condition
-                  </h5>
+  
+  const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
+    (condition) => {
+      const hasImmunizationDetails = condition.immunizationDetails.length > 0;
+      const hasClinicalDetails = condition.clinicalDetails.length > 0;
+      return {
+        title: condition.title,
+        id: toKebabCase(condition.title),
+        headingLevel: "h4",
+        className: "side-nav-ignore border-1px border-accent-cool-darker",
+        expanded: snomed === condition.snomed || conditionSummary.length === 1,
+        content: (
+          <>
+            {condition.conditionDetails.map((item, i) => (
+              <DataDisplay item={item} key={`condition-${i}`} />
+            ))}
+            {(hasImmunizationDetails || hasClinicalDetails) && (
+              <>
+                <h5
+                  className="text-bold margin-top-0 margin-bottom-1"
+                  id="relevant-clinical"
+                >
+                  Clinical Sections Relevant to Reportable Condition
+                </h5>
+                {hasImmunizationDetails && (
                   <div className="margin-top-0">
-                    {condition.labDetails.map((item, index) => (
-                      <DataTableDisplay
-                        item={item}
-                        key={`${item.title}-${index}`}
-                      />
+                    {condition.immunizationDetails.map((item, i) => (
+                      <DataTableDisplay item={item} key={`imx-${i}`} />
                     ))}
                   </div>
-                </>
-              )}
-            </>
-          ),
-        };
-      },
-    );
-    return (
-      <div
-        className="usa-summary-box padding-3"
-        aria-labelledby="summary-box-key-information"
-      >
-        <div className="usa-summary-box__body margin-bottom-05">
-          <h3
-            className="summary-box-key-information side-nav-ignore"
-            id="patient-summary"
-          >
-            Patient Summary
-          </h3>
-          <div className="usa-summary-box__text">
-            {patientDetails.map((item, i) => (
-              <DataDisplay item={item} key={`pat-${i}`} themeColor="blue" />
-            ))}
-          </div>
-        </div>
-        <div className="usa-summary-box__body">
-          <h3
-            className="summary-box-key-information side-nav-ignore"
-            id="encounter-summary"
-          >
-            Encounter Summary
-          </h3>
-          <div className="usa-summary-box__text">
-            {encounterDetails.map((item, i) => (
-              <DataDisplay item={item} key={`enc-${i}`} themeColor="blue" />
-            ))}
-          </div>
-        </div>
-        <div className="usa-summary-box__body">
-          <h3
-            className="summary-box-key-information side-nav-ignore header-with-tag"
-            id="condition-summary"
-          >
-            <div>Condition Summary</div>
-            <div>
-              <Tag className="tag-info">
-                {numConditionsText(conditionSummaryAccordionItems.length)}
-              </Tag>
-            </div>
-          </h3>
-          <div className="usa-summary-box__text condition-details-accordion">
-            <Accordion
-              items={conditionSummaryAccordionItems}
-              className="accordion-primary"
-            />
-          </div>
+                )}
+                {hasClinicalDetails && (
+                  <div className="margin-top-0">
+                    {condition.clinicalDetails.map((item, i) => (
+                      <DataTableDisplay item={item} key={`detail-${i}`} />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+            {condition.labDetails.length > 0 && (
+              <>
+                <h5
+                  className="text-bold margin-0 margin-bottom-1"
+                  id="relevant-labs"
+                >
+                  Lab Results Relevant to Reportable Condition
+                </h5>
+                <div className="margin-top-0">
+                  {condition.labDetails.map((item, index) => (
+                    <DataTableDisplay
+                      item={item}
+                      key={`${item.title}-${index}`}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </>
+        ),
+      };
+    },
+  );
+  
+  return (
+    <div
+      className="usa-summary-box padding-3"
+      aria-labelledby="summary-box-key-information"
+    >
+      <div className="usa-summary-box__body margin-bottom-05">
+        <h3
+          className="summary-box-key-information side-nav-ignore"
+          id="patient-summary"
+        >
+          Patient Summary
+        </h3>
+        <div className="usa-summary-box__text">
+          {patientDetails.map((item, i) => (
+            <DataDisplay item={item} key={`pat-${i}`} themeColor="blue" />
+          ))}
         </div>
       </div>
-    );
-  } finally {
-    const t2 = performance.now()
-    console.log("EcrSummary: ", t2 - t0);
-  }
+      <div className="usa-summary-box__body">
+        <h3
+          className="summary-box-key-information side-nav-ignore"
+          id="encounter-summary"
+        >
+          Encounter Summary
+        </h3>
+        <div className="usa-summary-box__text">
+          {encounterDetails.map((item, i) => (
+            <DataDisplay item={item} key={`enc-${i}`} themeColor="blue" />
+          ))}
+        </div>
+      </div>
+      <div className="usa-summary-box__body">
+        <h3
+          className="summary-box-key-information side-nav-ignore header-with-tag"
+          id="condition-summary"
+        >
+          <div>Condition Summary</div>
+          <div>
+            <Tag className="tag-info">
+              {numConditionsText(conditionSummaryAccordionItems.length)}
+            </Tag>
+          </div>
+        </h3>
+        <div className="usa-summary-box__text condition-details-accordion">
+          <Accordion
+            items={conditionSummaryAccordionItems}
+            className="accordion-primary"
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -6,7 +6,11 @@ import { AccordionItem } from "@/app/types";
 import { toKebabCase } from "@/app/utils/format-utils";
 
 import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
-import { evaluateEcrSummaryConditionSummary, evaluateEcrSummaryEncounterDetails, evaluateEcrSummaryPatientDetails } from "@/app/view-data/services/ecrSummaryService";
+import {
+  evaluateEcrSummaryConditionSummary,
+  evaluateEcrSummaryEncounterDetails,
+  evaluateEcrSummaryPatientDetails,
+} from "@/app/view-data/services/ecrSummaryService";
 import { Bundle } from "fhir/r4";
 import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
@@ -39,9 +43,8 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
   patientDetails,
   encounterDetails,
   conditionSummary,
-  snomed
+  snomed,
 }) => {
-  
   const conditionSummaryAccordionItems: AccordionItem[] = conditionSummary.map(
     (condition) => {
       const hasImmunizationDetails = condition.immunizationDetails.length > 0;
@@ -104,7 +107,7 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
       };
     },
   );
-  
+
   return (
     <div
       className="usa-summary-box padding-3"

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -12,15 +12,11 @@ import { getEcrDocumentAccordionItems } from "./components/EcrDocument/accordion
 import EcrSummary from "./components/EcrSummary";
 import SideNav from "./components/SideNav";
 import {
-  evaluateEcrSummaryConditionSummary,
-  evaluateEcrSummaryEncounterDetails,
-  evaluateEcrSummaryPatientDetails,
-} from "./services/ecrSummaryService";
-import {
   evaluatePatientDOB,
   evaluatePatientName,
 } from "./services/evaluateFhirDataService";
 import { getFhirData, isSuccessResponse } from "./services/fhirDataService";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 /**
  * Functional component for rendering the eCR Viewer page.
@@ -33,67 +29,70 @@ const ECRViewerPage = async ({
 }: {
   searchParams: Promise<{ id?: string; "snomed-code"?: string }>;
 }) => {
-  const _searchParams = await searchParams;
-  const fhirId = _searchParams.id ?? "";
-  const snomedCode = _searchParams["snomed-code"] ?? "";
-
-  const user = await getLoggedInUserSession();
-  // If we have a user that means we're using IDP auth and not NBS Auth, so we
-  // need to check if they're authorized to view this eCR
-  if (user) {
-    const authed = await isLoggedInUserEcrAuthed(fhirId);
-    if (!authed) notFound();
-  }
-
-  const resp = await getFhirData({ eicr_id: fhirId });
-  if (!isSuccessResponse(resp)) {
-    if (resp.status === 404) {
-      return <RetrievalFailed />;
-    } else {
-      return (
-        <GenericError>
-          <pre>
-            <code>{`${resp.status}: ${resp.payload.message}`}</code>
-          </pre>
-        </GenericError>
-      );
+  const t0 = performance.now()
+  try {
+    const _searchParams = await searchParams;
+    const fhirId = _searchParams.id ?? "";
+    const snomedCode = _searchParams["snomed-code"] ?? "";
+  
+    const user = await getLoggedInUserSession();
+    // If we have a user that means we're using IDP auth and not NBS Auth, so we
+    // need to check if they're authorized to view this eCR
+    if (user) {
+      const authed = await isLoggedInUserEcrAuthed(fhirId);
+      if (!authed) notFound();
     }
-  }
-
-  const fhirBundle = resp.payload.fhirBundle;
-  const patientName = evaluatePatientName(fhirBundle, true);
-  const patientDOB = evaluatePatientDOB(fhirBundle);
-
-  const accordionItems = getEcrDocumentAccordionItems(fhirBundle);
-  return (
-    <ECRViewerLayout patientName={patientName} patientDOB={patientDOB}>
-      <SideNav />
-      <div className="ecr-viewer-container">
-        <div className="margin-bottom-3">
-          <h2 className="margin-bottom-05 margin-top-3" id="ecr-summary">
-            eCR Summary
-          </h2>
-          <div className="text-base-darker line-height-sans-5">
-            Provides key info upfront to help you understand the eCR at a glance
+  
+    const resp = await getFhirData({ eicr_id: fhirId });
+    if (!isSuccessResponse(resp)) {
+      if (resp.status === 404) {
+        return <RetrievalFailed />;
+      } else {
+        return (
+          <GenericError>
+            <pre>
+              <code>{`${resp.status}: ${resp.payload.message}`}</code>
+            </pre>
+          </GenericError>
+        );
+      }
+    }
+  
+    const fhirBundle = resp.payload.fhirBundle;
+    const fhirIndex = getFhirIndex(fhirBundle);
+    const patientName = evaluatePatientName(fhirBundle, true);
+    const patientDOB = evaluatePatientDOB(fhirBundle);
+    
+    const t2 = performance.now()
+    const accordionItems = getEcrDocumentAccordionItems(fhirBundle, fhirIndex);
+    const t3 = performance.now()
+    console.log("Time to run getEcrDocumentAccordionItems: ", t3 - t2 );
+    return (
+      <ECRViewerLayout patientName={patientName} patientDOB={patientDOB}>
+        <SideNav />
+        <div className="ecr-viewer-container">
+          <div className="margin-bottom-3">
+            <h2 className="margin-bottom-05 margin-top-3" id="ecr-summary">
+              eCR Summary
+            </h2>
+            <div className="text-base-darker line-height-sans-5">
+              Provides key info upfront to help you understand the eCR at a
+              glance
+            </div>
           </div>
+          <EcrSummary
+            fhirBundle={fhirBundle}
+            fhirIndex={fhirIndex}
+            snomed={snomedCode}
+          />
+          <EcrDocument initialAccordionItems={accordionItems} />
         </div>
-        <EcrSummary
-          patientDetails={
-            evaluateEcrSummaryPatientDetails(fhirBundle).availableData
-          }
-          encounterDetails={
-            evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
-          }
-          conditionSummary={evaluateEcrSummaryConditionSummary(
-            fhirBundle,
-            snomedCode,
-          )}
-          snomed={snomedCode}
-        />
-        <EcrDocument initialAccordionItems={accordionItems} />
-      </div>
-    </ECRViewerLayout>
-  );
+      </ECRViewerLayout>
+    );
+  } finally {
+    const t1 = performance.now()
+    console.log("Time to run EcrViewerPage: ", t1 - t0 );
+  }
 };
 
 export default ECRViewerPage;

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "./services/evaluateFhirDataService";
 import { getFhirData, isSuccessResponse } from "./services/fhirDataService";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+import { evaluateEcrSummaryConditionSummary, evaluateEcrSummaryEncounterDetails, evaluateEcrSummaryPatientDetails } from "./services/ecrSummaryService";
 
 /**
  * Functional component for rendering the eCR Viewer page.
@@ -81,8 +82,17 @@ const ECRViewerPage = async ({
             </div>
           </div>
           <EcrSummary
-            fhirBundle={fhirBundle}
-            fhirIndex={fhirIndex}
+            patientDetails={
+              evaluateEcrSummaryPatientDetails(fhirBundle).availableData
+            }
+            encounterDetails={
+              evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
+            }
+            conditionSummary={evaluateEcrSummaryConditionSummary(
+              fhirBundle,
+              fhirIndex,
+              snomedCode
+            )}
             snomed={snomedCode}
           />
           <EcrDocument initialAccordionItems={accordionItems} />

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -17,7 +17,11 @@ import {
 } from "./services/evaluateFhirDataService";
 import { getFhirData, isSuccessResponse } from "./services/fhirDataService";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
-import { evaluateEcrSummaryConditionSummary, evaluateEcrSummaryEncounterDetails, evaluateEcrSummaryPatientDetails } from "./services/ecrSummaryService";
+import {
+  evaluateEcrSummaryConditionSummary,
+  evaluateEcrSummaryEncounterDetails,
+  evaluateEcrSummaryPatientDetails,
+} from "./services/ecrSummaryService";
 
 /**
  * Functional component for rendering the eCR Viewer page.
@@ -31,12 +35,12 @@ const ECRViewerPage = async ({
 }: {
   searchParams: Promise<{ id?: string; "snomed-code"?: string }>;
 }) => {
-  const t0 = performance.now()
+  const t0 = performance.now();
   try {
     const _searchParams = await searchParams;
     const fhirId = _searchParams.id ?? "";
     const snomedCode = _searchParams["snomed-code"] ?? "";
-  
+
     const user = await getLoggedInUserSession();
     // If we have a user that means we're using IDP auth and not NBS Auth, so we
     // need to check if they're authorized to view this eCR
@@ -44,7 +48,7 @@ const ECRViewerPage = async ({
       const authed = await isLoggedInUserEcrAuthed(fhirId);
       if (!authed) notFound();
     }
-  
+
     const resp = await getFhirData({ eicr_id: fhirId });
     if (!isSuccessResponse(resp)) {
       if (resp.status === 404) {
@@ -59,16 +63,16 @@ const ECRViewerPage = async ({
         );
       }
     }
-  
+
     const fhirBundle = resp.payload.fhirBundle;
     const fhirIndex = getFhirIndex(fhirBundle);
     const patientName = evaluatePatientName(fhirBundle, true);
     const patientDOB = evaluatePatientDOB(fhirBundle);
-    
-    const t2 = performance.now()
+
+    const t2 = performance.now();
     const accordionItems = getEcrDocumentAccordionItems(fhirBundle, fhirIndex);
-    const t3 = performance.now()
-    console.log("Time to run getEcrDocumentAccordionItems: ", t3 - t2 );
+    const t3 = performance.now();
+    console.log("Time to run getEcrDocumentAccordionItems: ", t3 - t2);
     return (
       <ECRViewerLayout patientName={patientName} patientDOB={patientDOB}>
         <SideNav />
@@ -92,7 +96,7 @@ const ECRViewerPage = async ({
             conditionSummary={evaluateEcrSummaryConditionSummary(
               fhirBundle,
               fhirIndex,
-              snomedCode
+              snomedCode,
             )}
             snomed={snomedCode}
           />
@@ -101,8 +105,8 @@ const ECRViewerPage = async ({
       </ECRViewerLayout>
     );
   } finally {
-    const t1 = performance.now()
-    console.log("Time to run EcrViewerPage: ", t1 - t0 );
+    const t1 = performance.now();
+    console.log("Time to run EcrViewerPage: ", t1 - t0);
   }
 };
 

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -29,85 +29,75 @@ import {
  * @param params.searchParams searchParams for page
  * @returns The main eCR Viewer JSX component.
  */
-// TODO ANGELA: Remove performance.now() calls
 const ECRViewerPage = async ({
   searchParams,
 }: {
   searchParams: Promise<{ id?: string; "snomed-code"?: string }>;
 }) => {
-  const t0 = performance.now();
-  try {
-    const _searchParams = await searchParams;
-    const fhirId = _searchParams.id ?? "";
-    const snomedCode = _searchParams["snomed-code"] ?? "";
+  const _searchParams = await searchParams;
+  const fhirId = _searchParams.id ?? "";
+  const snomedCode = _searchParams["snomed-code"] ?? "";
 
-    const user = await getLoggedInUserSession();
-    // If we have a user that means we're using IDP auth and not NBS Auth, so we
-    // need to check if they're authorized to view this eCR
-    if (user) {
-      const authed = await isLoggedInUserEcrAuthed(fhirId);
-      if (!authed) notFound();
-    }
-
-    const resp = await getFhirData({ eicr_id: fhirId });
-    if (!isSuccessResponse(resp)) {
-      if (resp.status === 404) {
-        return <RetrievalFailed />;
-      } else {
-        return (
-          <GenericError>
-            <pre>
-              <code>{`${resp.status}: ${resp.payload.message}`}</code>
-            </pre>
-          </GenericError>
-        );
-      }
-    }
-
-    const fhirBundle = resp.payload.fhirBundle;
-    const fhirIndex = getFhirIndex(fhirBundle);
-    const patientName = evaluatePatientName(fhirBundle, true);
-    const patientDOB = evaluatePatientDOB(fhirBundle);
-
-    const t2 = performance.now();
-    const accordionItems = getEcrDocumentAccordionItems(fhirBundle, fhirIndex);
-    const t3 = performance.now();
-    console.log("Time to run getEcrDocumentAccordionItems: ", t3 - t2);
-    return (
-      <ECRViewerLayout patientName={patientName} patientDOB={patientDOB}>
-        <SideNav />
-        <div className="ecr-viewer-container">
-          <div className="margin-bottom-3">
-            <h2 className="margin-bottom-05 margin-top-3" id="ecr-summary">
-              eCR Summary
-            </h2>
-            <div className="text-base-darker line-height-sans-5">
-              Provides key info upfront to help you understand the eCR at a
-              glance
-            </div>
-          </div>
-          <EcrSummary
-            patientDetails={
-              evaluateEcrSummaryPatientDetails(fhirBundle).availableData
-            }
-            encounterDetails={
-              evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
-            }
-            conditionSummary={evaluateEcrSummaryConditionSummary(
-              fhirBundle,
-              fhirIndex,
-              snomedCode,
-            )}
-            snomed={snomedCode}
-          />
-          <EcrDocument initialAccordionItems={accordionItems} />
-        </div>
-      </ECRViewerLayout>
-    );
-  } finally {
-    const t1 = performance.now();
-    console.log("Time to run EcrViewerPage: ", t1 - t0);
+  const user = await getLoggedInUserSession();
+  // If we have a user that means we're using IDP auth and not NBS Auth, so we
+  // need to check if they're authorized to view this eCR
+  if (user) {
+    const authed = await isLoggedInUserEcrAuthed(fhirId);
+    if (!authed) notFound();
   }
+
+  const resp = await getFhirData({ eicr_id: fhirId });
+  if (!isSuccessResponse(resp)) {
+    if (resp.status === 404) {
+      return <RetrievalFailed />;
+    } else {
+      return (
+        <GenericError>
+          <pre>
+            <code>{`${resp.status}: ${resp.payload.message}`}</code>
+          </pre>
+        </GenericError>
+      );
+    }
+  }
+
+  const fhirBundle = resp.payload.fhirBundle;
+  const fhirIndex = getFhirIndex(fhirBundle);
+  const patientName = evaluatePatientName(fhirBundle, true);
+  const patientDOB = evaluatePatientDOB(fhirBundle);
+
+  const accordionItems = getEcrDocumentAccordionItems(fhirBundle, fhirIndex);
+  return (
+    <ECRViewerLayout patientName={patientName} patientDOB={patientDOB}>
+      <SideNav />
+      <div className="ecr-viewer-container">
+        <div className="margin-bottom-3">
+          <h2 className="margin-bottom-05 margin-top-3" id="ecr-summary">
+            eCR Summary
+          </h2>
+          <div className="text-base-darker line-height-sans-5">
+            Provides key info upfront to help you understand the eCR at a
+            glance
+          </div>
+        </div>
+        <EcrSummary
+          patientDetails={
+            evaluateEcrSummaryPatientDetails(fhirBundle).availableData
+          }
+          encounterDetails={
+            evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
+          }
+          conditionSummary={evaluateEcrSummaryConditionSummary(
+            fhirBundle,
+            fhirIndex,
+            snomedCode,
+          )}
+          snomed={snomedCode}
+        />
+        <EcrDocument initialAccordionItems={accordionItems} />
+      </div>
+    </ECRViewerLayout>
+  );
 };
 
 export default ECRViewerPage;

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -76,8 +76,7 @@ const ECRViewerPage = async ({
             eCR Summary
           </h2>
           <div className="text-base-darker line-height-sans-5">
-            Provides key info upfront to help you understand the eCR at a
-            glance
+            Provides key info upfront to help you understand the eCR at a glance
           </div>
         </div>
         <EcrSummary

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -25,6 +25,7 @@ import { evaluateEcrSummaryConditionSummary, evaluateEcrSummaryEncounterDetails,
  * @param params.searchParams searchParams for page
  * @returns The main eCR Viewer JSX component.
  */
+// TODO ANGELA: Remove performance.now() calls
 const ECRViewerPage = async ({
   searchParams,
 }: {

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -156,7 +156,8 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
 /**
  * Evaluates and retrieves all condition details in a bundle.
  * @param fhirBundle - The FHIR bundle containing patient data.
- * @param snomedCode - The SNOMED code identifying the main snomed code.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
+ * @param snomedCode - (Optional) The SNOMED code identifying the main snomed code.
  * @returns An array of condition summary objects.
  */
 export const evaluateEcrSummaryConditionSummary = (
@@ -292,6 +293,7 @@ export const evaluateEcrSummaryRelevantClinicalDetails = (
 /**
  * Evaluates and retrieves relevant lab results from the FHIR bundle using the provided SNOMED code and path mappings.
  * @param fhirBundle - The FHIR bundle containing patient data.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param snomedCode - String containing the SNOMED code search parameter.
  * @param lastDividerLine - Boolean to determine if a divider line should be added to the end of the lab results. Default to true
  * @returns An array of lab result details objects containing title and value pairs.
@@ -308,24 +310,14 @@ export const evaluateEcrSummaryRelevantLabResults = (
     return [];
   }
 
-  // const labReports = evaluateAll(
-  //   fhirBundle,
-  //   fhirPathMappings.diagnosticReports,
-  // );
-
   const labReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport');
   const labsWithCode = getRelevantResources(labReports, snomedCode);
   const labsWithCodeIds = new Set(labsWithCode.map((lab) => lab.id));
 
-  // const observationsList = evaluateAll(
-  //   fhirBundle,
-  //   fhirPathMappings.observations,
-  // );
   const observationsList = getResourcesByType<Observation>(
     fhirIndex,
     "Observation"
   );
-  // console.log(observationsList);
   const relevantObsIds = new Set(
     getRelevantResources(observationsList, snomedCode).map((entry) => entry.id)
   );
@@ -351,8 +343,8 @@ export const evaluateEcrSummaryRelevantLabResults = (
   }
   const relevantLabElements = evaluateLabInfoData(
     fhirBundle,
-    relevantLabs,
     fhirIndex,
+    relevantLabs,
     "h4"
   );
 

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -163,7 +163,7 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
 export const evaluateEcrSummaryConditionSummary = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
-  snomedCode?: string
+  snomedCode?: string,
 ): ConditionSummary[] => {
   const rrConditions = evaluateAll(fhirBundle, fhirPathMappings.rrConditions);
   const conditionsList: {
@@ -171,7 +171,7 @@ export const evaluateEcrSummaryConditionSummary = (
   } = {};
   for (const observation of rrConditions) {
     const coding = observation?.valueCodeableConcept?.coding?.find(
-      (coding) => coding.system === "http://snomed.info/sct"
+      (coding) => coding.system === "http://snomed.info/sct",
     );
 
     const displayText =
@@ -190,12 +190,12 @@ export const evaluateEcrSummaryConditionSummary = (
     observation?.hasMember?.forEach((ref) => {
       const rrInfoObs: Observation | undefined = evaluateReference(
         fhirBundle,
-        ref.reference
+        ref.reference,
       );
       const { rules } = getReportabilityRulesReasons(rrInfoObs);
 
       rules.forEach((rule: string) =>
-        conditionsList[conditionListKey].ruleSummaries.add(rule)
+        conditionsList[conditionListKey].ruleSummaries.add(rule),
       );
     });
   }
@@ -215,7 +215,7 @@ export const evaluateEcrSummaryConditionSummary = (
               {[...conditionsList[conditionsListKey].ruleSummaries].map(
                 (summary) => (
                   <p key={summary}>{summary}</p>
-                )
+                ),
               )}
             </div>
           ),
@@ -227,13 +227,13 @@ export const evaluateEcrSummaryConditionSummary = (
       ),
       clinicalDetails: evaluateEcrSummaryRelevantClinicalDetails(
         fhirBundle,
-        conditionsListKey
+        conditionsListKey,
       ),
       labDetails: evaluateEcrSummaryRelevantLabResults(
         fhirBundle,
         fhirIndex,
         conditionsListKey,
-        false
+        false,
       ),
     };
 
@@ -302,7 +302,7 @@ export const evaluateEcrSummaryRelevantLabResults = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
   snomedCode: string,
-  lastDividerLine: boolean = true
+  lastDividerLine: boolean = true,
 ): DisplayDataProps[] => {
   let resultsArray: DisplayDataProps[] = [];
 
@@ -310,16 +310,19 @@ export const evaluateEcrSummaryRelevantLabResults = (
     return [];
   }
 
-  const labReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport');
+  const labReports = getResourcesByType<DiagnosticReport>(
+    fhirIndex,
+    "DiagnosticReport",
+  );
   const labsWithCode = getRelevantResources(labReports, snomedCode);
   const labsWithCodeIds = new Set(labsWithCode.map((lab) => lab.id));
 
   const observationsList = getResourcesByType<Observation>(
     fhirIndex,
-    "Observation"
+    "Observation",
   );
   const relevantObsIds = new Set(
-    getRelevantResources(observationsList, snomedCode).map((entry) => entry.id)
+    getRelevantResources(observationsList, snomedCode).map((entry) => entry.id),
   );
 
   const labsFromObsWithCode = labReports.filter((lab) => {
@@ -345,14 +348,14 @@ export const evaluateEcrSummaryRelevantLabResults = (
     fhirBundle,
     fhirIndex,
     relevantLabs,
-    "h4"
+    "h4",
   );
 
   resultsArray = relevantLabElements.flatMap((element) =>
     element.diagnosticReportDataItems.map((reportItem) => ({
       value: <LabAccordion items={[reportItem]} />,
       dividerLine: false,
-    }))
+    })),
   );
 
   if (lastDividerLine) {

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -6,7 +6,6 @@ import {
   DiagnosticReport,
   DomainResource,
   Encounter,
-  Immunization,
   Observation,
   Organization,
 } from "fhir/r4";
@@ -345,7 +344,6 @@ export const evaluateEcrSummaryRelevantLabResults = (
     return [];
   }
   const relevantLabElements = evaluateLabInfoData(
-    fhirBundle,
     fhirIndex,
     relevantLabs,
     "h4",

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import {
   Bundle,
   Condition,
+  DiagnosticReport,
   DomainResource,
   Encounter,
+  Immunization,
   Observation,
   Organization,
 } from "fhir/r4";
@@ -48,6 +50,7 @@ import {
 } from "./evaluateFhirDataService";
 import { evaluateLabInfoData } from "./labsService";
 import { getReportabilityRulesReasons } from "./reportabilityService";
+import { FhirIndex, getResourcesByType } from "./fhirResourcesIndexService";
 
 /**
  * Evaluates and retrieves patient details from the FHIR bundle using the provided path mappings.
@@ -158,7 +161,8 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
  */
 export const evaluateEcrSummaryConditionSummary = (
   fhirBundle: Bundle,
-  snomedCode?: string,
+  fhirIndex: FhirIndex,
+  snomedCode?: string
 ): ConditionSummary[] => {
   const rrConditions = evaluateAll(fhirBundle, fhirPathMappings.rrConditions);
   const conditionsList: {
@@ -166,7 +170,7 @@ export const evaluateEcrSummaryConditionSummary = (
   } = {};
   for (const observation of rrConditions) {
     const coding = observation?.valueCodeableConcept?.coding?.find(
-      (coding) => coding.system === "http://snomed.info/sct",
+      (coding) => coding.system === "http://snomed.info/sct"
     );
 
     const displayText =
@@ -185,12 +189,12 @@ export const evaluateEcrSummaryConditionSummary = (
     observation?.hasMember?.forEach((ref) => {
       const rrInfoObs: Observation | undefined = evaluateReference(
         fhirBundle,
-        ref.reference,
+        ref.reference
       );
       const { rules } = getReportabilityRulesReasons(rrInfoObs);
 
       rules.forEach((rule: string) =>
-        conditionsList[conditionListKey].ruleSummaries.add(rule),
+        conditionsList[conditionListKey].ruleSummaries.add(rule)
       );
     });
   }
@@ -210,7 +214,7 @@ export const evaluateEcrSummaryConditionSummary = (
               {[...conditionsList[conditionsListKey].ruleSummaries].map(
                 (summary) => (
                   <p key={summary}>{summary}</p>
-                ),
+                )
               )}
             </div>
           ),
@@ -222,12 +226,13 @@ export const evaluateEcrSummaryConditionSummary = (
       ),
       clinicalDetails: evaluateEcrSummaryRelevantClinicalDetails(
         fhirBundle,
-        conditionsListKey,
+        conditionsListKey
       ),
       labDetails: evaluateEcrSummaryRelevantLabResults(
         fhirBundle,
+        fhirIndex,
         conditionsListKey,
-        false,
+        false
       ),
     };
 
@@ -293,8 +298,9 @@ export const evaluateEcrSummaryRelevantClinicalDetails = (
  */
 export const evaluateEcrSummaryRelevantLabResults = (
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
   snomedCode: string,
-  lastDividerLine: boolean = true,
+  lastDividerLine: boolean = true
 ): DisplayDataProps[] => {
   let resultsArray: DisplayDataProps[] = [];
 
@@ -302,19 +308,26 @@ export const evaluateEcrSummaryRelevantLabResults = (
     return [];
   }
 
-  const labReports = evaluateAll(
-    fhirBundle,
-    fhirPathMappings.diagnosticReports,
-  );
+  // const labReports = evaluateAll(
+  //   fhirBundle,
+  //   fhirPathMappings.diagnosticReports,
+  // );
+
+  const labReports = getResourcesByType<DiagnosticReport>(fhirIndex, 'DiagnosticReport');
   const labsWithCode = getRelevantResources(labReports, snomedCode);
   const labsWithCodeIds = new Set(labsWithCode.map((lab) => lab.id));
 
-  const observationsList = evaluateAll(
-    fhirBundle,
-    fhirPathMappings.observations,
+  // const observationsList = evaluateAll(
+  //   fhirBundle,
+  //   fhirPathMappings.observations,
+  // );
+  const observationsList = getResourcesByType<Observation>(
+    fhirIndex,
+    "Observation"
   );
+  // console.log(observationsList);
   const relevantObsIds = new Set(
-    getRelevantResources(observationsList, snomedCode).map((entry) => entry.id),
+    getRelevantResources(observationsList, snomedCode).map((entry) => entry.id)
   );
 
   const labsFromObsWithCode = labReports.filter((lab) => {
@@ -339,14 +352,15 @@ export const evaluateEcrSummaryRelevantLabResults = (
   const relevantLabElements = evaluateLabInfoData(
     fhirBundle,
     relevantLabs,
-    "h4",
+    fhirIndex,
+    "h4"
   );
 
   resultsArray = relevantLabElements.flatMap((element) =>
     element.diagnosticReportDataItems.map((reportItem) => ({
       value: <LabAccordion items={[reportItem]} />,
       dividerLine: false,
-    })),
+    }))
   );
 
   if (lastDividerLine) {

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -18,7 +18,7 @@ export interface FhirIndex {
 
 /**
  * Builds an index of FHIR resources from a given FHIR bundle.
- * 
+ *
  * Extracts all resources from a given FHIR bundle and organizes them into two maps:
  * 1. `fhirIndexByType` – an map of resources keyed by `resourceType` mapping to an array of all resources of that type.
  * 2. `fhirIndexByTypeAndId` – a map of resources keyed by `resourceType` and then by `id`.
@@ -54,12 +54,12 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
 
 /**
  * Returns array of all resources of a specific type (i.e. "Observation").
- * 
+ *
  * @template T - The expected FHIR Resource type (e.g., Observation, Patient).
  * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param type - The resourceType to retrieve (e.g., "Observation").
- * 
- * @returns Array of FHIR resources of type `T`, or empty array if 
+ *
+ * @returns Array of FHIR resources of type `T`, or empty array if
  * no resources of specified type exist.
  */
 // TODO ANGELA: How to guarantee that type & `T` match? `T` only exists at compile, whereas type exists at `runtime`
@@ -78,12 +78,12 @@ export function getResourcesByType<T extends Resource>(
 /**
  * Returns FHIR resource by ID and check resource type.
  * Expects only one resource to be returned.
- * 
+ *
  * @template T - The expected FHIR Resource type (e.g., Observation, Patient).
  * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param type - The resourceType to retrieve (e.g., "Observation").
  * @param id - The unique identifier of the resource.
- * 
+ *
  * @returns FHIR resource of type `T` if it exists and resourceType matches `type`
  * Returns undefined if no resource exists with given ID and resourceType
  */

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -51,10 +51,10 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
 // TODO ANGELA: ADD TESTS
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
-  type: T["resourceType"]
+  type: T["resourceType"],
 ): T[] {
   const resourceMap = fhirIndex.fhirIndexByType[type];
-  
+
   if (!resourceMap) return [];
 
   return resourceMap as T[];
@@ -67,9 +67,8 @@ export function getResourcesByType<T extends Resource>(
 export function getResourceById<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],
-  id: string
+  id: string,
 ): T | undefined {
-  
   const resource = fhirIndex.fhirIndexByTypeAndId[type]?.[id];
   if (resource?.resourceType === type) return resource as T;
   return undefined;

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -1,18 +1,19 @@
 import { Bundle, Resource } from "fhir/r4";
 
-export type ResourceType = Resource["resourceType"];
-export type FhirResourceByTypeIndex = {
-  // This says: If the key is 'Patient', the value is Record<string, Patient>
-  [K in ResourceType]?: Record<string, Extract<Resource, { resourceType: K }>>;
+type ResourceType = Resource["resourceType"];
+type ResourceWithType<K extends ResourceType> = Resource & { resourceType: K };
+
+export type FhirIndexByType = {
+  [K in ResourceType]?: ResourceWithType<K>[];
 };
 
-export interface FhirResourceByIdIndex {
-  [id: string]: Resource
-}
+export type FhirIndexByTypeAndId = {
+  [K in ResourceType]?: Record<string, ResourceWithType<K>>;
+};
 
 export interface FhirIndex {
-  fhirResourcesByType: FhirResourceByTypeIndex;
-  fhirResourcesById: FhirResourceByIdIndex;
+  fhirIndexByType: FhirIndexByType;
+  fhirIndexByTypeAndId: FhirIndexByTypeAndId;
 }
 
 /**
@@ -22,8 +23,8 @@ export interface FhirIndex {
  * If no matching observations are found, an empty object is returned.
  */
 export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
-  const fhirResourcesByType: FhirResourceByTypeIndex = {};
-  const fhirResourcesById: FhirResourceByIdIndex = {};
+  const fhirIndexByType: FhirIndexByType = {};
+  const fhirIndexByTypeAndId: FhirIndexByTypeAndId = {};
 
   fhirBundle.entry?.forEach((entry) => {
     const resource = entry.resource;
@@ -31,28 +32,45 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
     const resourceId = resource?.id;
 
     if (resourceType && resourceId) {
-      fhirResourcesById[resourceId] = resource;
+      // by Type (array)
+      fhirIndexByType[resourceType] ??= [];
+      fhirIndexByType[resourceType].push(resource);
 
-      fhirResourcesByType[resourceType] ??= {};
-      fhirResourcesByType[resourceType][resourceId] = resource;
+      // by Type and ID (map)
+      fhirIndexByTypeAndId[resourceType] ??= {};
+      fhirIndexByTypeAndId[resourceType][resourceId] = resource;
     }
   });
 
-  return { fhirResourcesByType, fhirResourcesById };
+  return { fhirIndexByType, fhirIndexByTypeAndId };
 };
 
 /**
- * Grabs all resources of a specific type.
+ * Returns array of all resources of a specific type.
  */
+// TODO ANGELA: ADD TESTS
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"]
 ): T[] {
-  const resourceMap = fhirIndex.fhirResourcesByType[type];
+  const resourceMap = fhirIndex.fhirIndexByType[type];
   
   if (!resourceMap) return [];
 
-  // We cast to 'any' internally to satisfy the complex mapped type,
-  // but the external return type is perfectly narrowed to T[]
-  return Object.values(resourceMap ?? {}) as T[];
+  return resourceMap as T[];
+}
+
+/**
+ * Returns FHIR resource by ID and check resource type.
+ */
+// TODO ANGELA: ADD TESTS. Returns undefined if the ID doesn’t exist. Returns undefined if the ID exists but is the wrong resourceType.
+export function getResourceById<T extends Resource>(
+  fhirIndex: FhirIndex,
+  type: T["resourceType"],
+  id: string
+): T | undefined {
+  
+  const resource = fhirIndex.fhirIndexByTypeAndId[type]?.[id];
+  if (resource?.resourceType === type) return resource as T;
+  return undefined;
 }

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -62,6 +62,8 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
  * @returns Array of FHIR resources of type `T`, or empty array if 
  * no resources of specified type exist.
  */
+// TODO ANGELA: How to guarantee that type & `T` match? `T` only exists at compile, whereas type exists at `runtime`
+// Is it enough to get this? Argument of type '"Composition"' is not assignable to parameter of type '"Observation"'.
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"]
@@ -85,7 +87,7 @@ export function getResourcesByType<T extends Resource>(
  * @returns FHIR resource of type `T` if it exists and resourceType matches `type`
  * Returns undefined if no resource exists with given ID and resourceType
  */
-// TODO ANGELA: ADD TESTS. Returns undefined if the ID doesn’t exist. Returns undefined if the ID exists but is the wrong resourceType.
+// TODO ANGELA: How to guarantee that type & `T` match? `T` only exists at compile, whereas type exists at `runtime`
 export function getResourceById<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -62,8 +62,6 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
  * @returns Array of FHIR resources of type `T`, or empty array if
  * no resources of specified type exist.
  */
-// TODO ANGELA: How to guarantee that type & `T` match? `T` only exists at compile, whereas type exists at `runtime`
-// Is it enough to get this? Argument of type '"Composition"' is not assignable to parameter of type '"Observation"'.
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],
@@ -87,7 +85,6 @@ export function getResourcesByType<T extends Resource>(
  * @returns FHIR resource of type `T` if it exists and resourceType matches `type`
  * Returns undefined if no resource exists with given ID and resourceType
  */
-// TODO ANGELA: How to guarantee that type & `T` match? `T` only exists at compile, whereas type exists at `runtime`
 export function getResourceById<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -1,0 +1,58 @@
+import { Bundle, Resource } from "fhir/r4";
+
+export type ResourceType = Resource["resourceType"];
+export type FhirResourceByTypeIndex = {
+  // This says: If the key is 'Patient', the value is Record<string, Patient>
+  [K in ResourceType]?: Record<string, Extract<Resource, { resourceType: K }>>;
+};
+
+export interface FhirResourceByIdIndex {
+  [id: string]: Resource
+}
+
+export interface FhirIndex {
+  fhirResourcesByType: FhirResourceByTypeIndex;
+  fhirResourcesById: FhirResourceByIdIndex;
+}
+
+/**
+ * Extracts all lab `Observation` resources from a given FHIR bundle across all diagnostic reports.
+ * @param fhirBundle - The FHIR bundle containing related resources for the lab report.
+ * @returns An object of `Observation` resources with the observation `id` (string) as the key.
+ * If no matching observations are found, an empty object is returned.
+ */
+export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
+  const fhirResourcesByType: FhirResourceByTypeIndex = {};
+  const fhirResourcesById: FhirResourceByIdIndex = {};
+
+  fhirBundle.entry?.forEach((entry) => {
+    const resource = entry.resource;
+    const resourceType = resource?.resourceType;
+    const resourceId = resource?.id;
+
+    if (resourceType && resourceId) {
+      fhirResourcesById[resourceId] = resource;
+
+      fhirResourcesByType[resourceType] ??= {};
+      fhirResourcesByType[resourceType][resourceId] = resource;
+    }
+  });
+
+  return { fhirResourcesByType, fhirResourcesById };
+};
+
+/**
+ * Grabs all resources of a specific type.
+ */
+export function getResourcesByType<T extends Resource>(
+  fhirIndex: FhirIndex,
+  type: T["resourceType"]
+): T[] {
+  const resourceMap = fhirIndex.fhirResourcesByType[type];
+  
+  if (!resourceMap) return [];
+
+  // We cast to 'any' internally to satisfy the complex mapped type,
+  // but the external return type is perfectly narrowed to T[]
+  return Object.values(resourceMap ?? {}) as T[];
+}

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -17,10 +17,17 @@ export interface FhirIndex {
 }
 
 /**
- * Extracts all lab `Observation` resources from a given FHIR bundle across all diagnostic reports.
- * @param fhirBundle - The FHIR bundle containing related resources for the lab report.
- * @returns An object of `Observation` resources with the observation `id` (string) as the key.
- * If no matching observations are found, an empty object is returned.
+ * Builds an index of FHIR resources from a given FHIR bundle.
+ * 
+ * Extracts all resources from a given FHIR bundle and organizes them into two maps:
+ * 1. `fhirIndexByType` – an map of resources keyed by `resourceType` mapping to an array of all resources of that type.
+ * 2. `fhirIndexByTypeAndId` – a map of resources keyed by `resourceType` and then by `id`.
+ *
+ * @param fhirBundle - FHIR bundle
+ * @returns A `FhirIndex` object containing:
+ *   - `fhirIndexByType`: FHIR resources grouped by type as arrays.
+ *   - `fhirIndexByTypeAndId`: FHIR resources grouped by type and ID for fast lookup.
+ * Both will return empty arrays/objects if no resources of a given type exist.
  */
 export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
   const fhirIndexByType: FhirIndexByType = {};
@@ -46,9 +53,15 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
 };
 
 /**
- * Returns array of all resources of a specific type.
+ * Returns array of all resources of a specific type (i.e. "Observation").
+ * 
+ * @template T - The expected FHIR Resource type (e.g., Observation, Patient).
+ * @param fhirIndex - FHIR resources indexed by type & by ID
+ * @param type - The resourceType to retrieve (e.g., "Observation").
+ * 
+ * @returns Array of FHIR resources of type `T`, or empty array if 
+ * no resources of specified type exist.
  */
-// TODO ANGELA: ADD TESTS
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"]
@@ -62,6 +75,15 @@ export function getResourcesByType<T extends Resource>(
 
 /**
  * Returns FHIR resource by ID and check resource type.
+ * Expects only one resource to be returned.
+ * 
+ * @template T - The expected FHIR Resource type (e.g., Observation, Patient).
+ * @param fhirIndex - FHIR resources indexed by type & by ID
+ * @param type - The resourceType to retrieve (e.g., "Observation").
+ * @param id - The unique identifier of the resource.
+ * 
+ * @returns FHIR resource of type `T` if it exists and resourceType matches `type`
+ * Returns undefined if no resource exists with given ID and resourceType
  */
 // TODO ANGELA: ADD TESTS. Returns undefined if the ID doesn’t exist. Returns undefined if the ID exists but is the wrong resourceType.
 export function getResourceById<T extends Resource>(

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -18,6 +18,7 @@ export interface FhirIndex {
 
 /**
  * Builds an index of FHIR resources from a given FHIR bundle.
+ * NOTE: Index should only be accessed indirectly via helper functions below.
  *
  * Extracts all resources from a given FHIR bundle and organizes them into two maps:
  * 1. `fhirIndexByType` – an map of resources keyed by `resourceType` mapping to an array of all resources of that type.
@@ -76,6 +77,7 @@ export function getResourcesByType<T extends Resource>(
 /**
  * Returns FHIR resource by ID and check resource type.
  * Expects only one resource to be returned.
+ * NOTE: should only be accessed by evaluateReference2
  *
  * @template T - The expected FHIR Resource type (e.g., Observation, Patient).
  * @param fhirIndex - FHIR resources indexed by type & by ID
@@ -91,6 +93,5 @@ export function getResourceById<T extends Resource>(
   id: string,
 ): T | undefined {
   const resource = fhirIndex.fhirIndexByTypeAndId[type]?.[id];
-  if (resource?.resourceType === type) return resource as T;
-  return undefined;
+  return resource as T | undefined;
 }

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -158,8 +158,8 @@ export const getObservations = (
   fhirIndex: FhirIndex,
 ): Observation[] => {
   const test = (report.result || [])
-    .map((obsRef) => 
-      evaluateReference2<Observation>(fhirIndex, obsRef.reference)
+    .map((obsRef) =>
+      evaluateReference2<Observation>(fhirIndex, obsRef.reference),
     )
     .filter(notEmpty);
   try {

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode } from "react";
 import { HeadingLevel, Tag } from "@trussworks/react-uswds";
 import {
   Bundle,
+  Composition,
   Device,
   DiagnosticReport,
   Observation,
@@ -36,6 +37,7 @@ import {
   evaluateAll,
   evaluateOne,
   evaluateReference,
+  evaluateReference2,
   evaluateValue,
 } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
@@ -53,6 +55,7 @@ import EvaluateTable, {
 } from "@/app/view-data/components/EvaluateTable";
 import { FieldValue } from "@/app/view-data/components/FieldValue";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
+import { FhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
 
 export interface ResultObject {
   [key: string]: AccordionItem[];
@@ -83,23 +86,61 @@ const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
 export const evaluateLabInfoData = (
   fhirBundle: Bundle,
   labReports: DiagnosticReport[],
-  accordionHeadingLevel: HeadingLevel = "h5",
+  fhirIndex: FhirIndex,
+  accordionHeadingLevel: HeadingLevel = "h5"
 ): LabReportElementData[] => {
-  // the keys are the organization id, the value is an array of jsx elements of diagnostic reports
+  const t0 = performance.now();
+
   let organizationItems: ResultObject = {};
-  const jsonLabs = getAllLabJsonObjects(fhirBundle);
+  const jsonLabs = getAllLabJsonObjects(fhirBundle, fhirIndex);
+
+  const tgetall0 = performance.now();
+  console.log("Time to getAllLabJsonObjects", tgetall0 - t0);
+  // const labObs = fhirIndex.fhirResourcesByType["Observation"];
+
+  const tgetall1 = performance.now();
+  console.log("Time to get all lab obs: ", tgetall1 - tgetall0);
+  // console.log(allObs);
+
+  const totals = {
+    getObservations: 0,
+    getJsonLab: 0,
+    getLabsContent: 0,
+    evaluateValue: 0,
+  };
 
   for (const report of labReports) {
-    const obs = getObservations(report, fhirBundle);
+    let t;
+
+    t = performance.now();
+    const obs = getObservations(report, fhirIndex);
+    totals.getObservations += performance.now() - t;
+
+    t = performance.now();
     const labReportJson = getJsonLab(jsonLabs, obs);
+    totals.getJsonLab += performance.now() - t;
 
     ensureReportHasDateTime(report, obs);
-    const content = getLabsContent(report, obs, fhirBundle, labReportJson);
+
+    t = performance.now();
+    const content = getLabsContent(
+      report,
+      obs,
+      fhirBundle,
+      fhirIndex,
+      labReportJson
+    );
     const organizationId = (report.performer?.[0].reference ?? "").replace(
       "Organization/",
-      "",
+      ""
     );
+    totals.getLabsContent += performance.now() - t;
+
     const title = formatCodeableConcept(report.code) ?? "Unknown";
+
+    t = performance.now();
+    totals.evaluateValue += performance.now() - t;
+
     const item = {
       title: (
         <div className="display-flex flex-row flex-justify flex-align-center gap-05">
@@ -133,8 +174,57 @@ export const evaluateLabInfoData = (
     );
   }
 
-  return combineOrgAndReportData(organizationItems, fhirBundle);
+  const t1 = performance.now();
+
+  console.log("evaluateLabInfoData TOTAL:", (t1 - t0).toFixed(2), "ms");
+  console.log("Breakdown:");
+  Object.entries(totals)
+    .sort((a, b) => b[1] - a[1])
+    .forEach(([k, v]) => {
+      console.log(`  ${k}: ${v.toFixed(2)} ms`);
+    });
+
+  return combineOrgAndReportData(organizationItems, fhirBundle, fhirIndex);
 };
+
+// /**
+//  * Extracts all lab `Observation` resources from a given FHIR bundle across all diagnostic reports.
+//  * @param fhirBundle - The FHIR bundle containing related resources for the lab report.
+//  * @returns An object of `Observation` resources with the observation `id` (string) as the key. 
+//  * If no matching observations are found, an empty object is returned.
+//  */
+// export const getAllObservationResources = (
+//   fhirBundle: Bundle
+// ): Record<string, Observation> => {
+//   // init the object
+//   const labObs: Record<string, Observation> = {};
+  
+//   // Get lab Composition section
+//   // const labObsRefs = evaluateAll(
+//   //   fhirBundle,
+//   //   fhirPathMappings.labResultObservations
+//   // );
+//   // console.log(labObsRefs);
+
+//   // For each reference
+//   // labObsRefs.forEach((ref) => {
+//   //   // TODO ANGELA: don't do reference lookups. just iterate through bundle once and record all observations
+//   //   const ob = evaluateReference<Observation>(fhirBundle, ref.reference);
+//   //   if (ob && ob.id) {
+//   //     labObs[ob.id] = ob
+//   //   };
+//   // });
+
+//   const obs = evaluateAll(fhirBundle, fhirPathMappings.observations);
+//   obs.forEach((ob) => {
+//     if (ob && ob.id) {
+//       labObs[ob.id] = ob
+//     };
+//   })
+
+//   //return the object
+//   return labObs;
+// };
 
 /**
  * Extracts an array of `Observation` resources from a given FHIR bundle based on a list of observation references.
@@ -146,17 +236,22 @@ export const evaluateLabInfoData = (
  */
 export const getObservations = (
   report: DiagnosticReport,
-  fhirBundle: Bundle,
-): Array<Observation> => {
-  return sortResourcesByDate(
-    (report.result || [])
-      .map((obsRef) =>
-        evaluateReference<Observation>(fhirBundle, obsRef.reference),
-      )
-      .filter(notEmpty),
-    fhirPathMappings.effectiveX,
-  );
+  fhirIndex: FhirIndex,
+): Observation[] => {
+  const test = (report.result || [])
+    .map((obsRef) => {
+      if (obsRef.reference) {
+        const [_, id] = obsRef.reference.split("/");
+        return fhirIndex.fhirResourcesById[id] as Observation;
+      }
+    })
+    .filter(notEmpty);
+  try {
+    return sortResourcesByDate(test, fhirPathMappings.effectiveX);
+  } finally {
+  }
 };
+
 
 const ensureReportHasDateTime = (
   report: DiagnosticReport,
@@ -233,9 +328,15 @@ export const getJsonLab = (
  * @param fhirBundle - The FHIR Bundle object containing relevant FHIR resources.
  * @returns The JSON representation of the lab report.
  */
-export const getAllLabJsonObjects = (fhirBundle: Bundle): HtmlTableJson[] => {
+export const getAllLabJsonObjects = (fhirBundle: Bundle, fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
-  const labsString = evaluateValue(fhirBundle, fhirPathMappings.labResultDiv);
+  const compositionLabs = getResourcesByType<Composition>(fhirIndex, 'Composition')[0];
+  const labsString = evaluateValue(
+    compositionLabs,
+    fhirPathMappings.labResultDiv
+  );
+  // const labsString = evaluateValue(fhirBundle, fhirPathMappings.labResultDiv);
+  // console.log(labsString);
   return formatTablesToJSON(labsString);
 };
 
@@ -440,6 +541,7 @@ export const returnAnalysisTime = (
 export const evaluateDiagnosticReportData = (
   obs: Observation[],
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
 ): React.JSX.Element | undefined => {
   if (!obs.length) return undefined;
 
@@ -463,7 +565,8 @@ export const evaluateDiagnosticReportData = (
       columnName: "Test Method",
       infoPath: "observationDeviceReference",
       applyToValue: (ref) => {
-        const device = evaluateReference<Device>(fhirBundle, ref);
+        // TODO: Angela review evaluateReference2
+        const device = evaluateReference2<Device>(fhirIndex, ref);
         return safeParse(device?.deviceName?.[0]?.name ?? "");
       },
       className: "minw-10 width-20",
@@ -564,12 +667,14 @@ export const evaluateOrganismsReportData = (
 export const combineOrgAndReportData = (
   organizationItems: ResultObject,
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
 ): LabReportElementData[] => {
   return Object.keys(organizationItems).map((key: string) => {
     const organizationId = key.replace("Organization/", "");
     const orgData = evaluateLabOrganizationData(
       organizationId,
       fhirBundle,
+      fhirIndex,
       organizationItems[key].length,
     );
     return {
@@ -590,9 +695,10 @@ export const combineOrgAndReportData = (
 export const evaluateLabOrganizationData = (
   id: string,
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
   labReportCount: number,
 ) => {
-  const orgMappings = evaluateAll(fhirBundle, fhirPathMappings.organizations);
+  const orgMappings = getResourcesByType<Organization>(fhirIndex, 'Organization');
   let matchingOrg: Organization = orgMappings.filter(
     (organization) => organization.id === id,
   )[0];
@@ -678,16 +784,22 @@ const groupItemByOrgId = (
  * @param labReportJson - The JSON representation of the lab results from HTML.
  * @returns An array of JSX elements representing the lab report content.
  */
+// TODO ANGELA: Review
 const getLabsContent = (
   report: DiagnosticReport,
   obs: Observation[],
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
   labReportJson?: HtmlTableJson,
 ) => {
-  const labTableDiagnostic = evaluateDiagnosticReportData(obs, fhirBundle);
-  const labTableOrganisms = evaluateOrganismsReportData(obs);
-  const labSpecimen = evaluateReference<Specimen>(
+  const labTableDiagnostic = evaluateDiagnosticReportData(
+    obs,
     fhirBundle,
+    fhirIndex
+  );
+  const labTableOrganisms = evaluateOrganismsReportData(obs);
+  const labSpecimen = evaluateReference2<Specimen>(
+    fhirIndex,
     report.specimen?.[0]?.reference,
   );
 
@@ -728,7 +840,7 @@ const getLabsContent = (
         evaluateValue(labSpecimen, fhirPathMappings.specimenBodySite) ||
         returnFieldValueFromLabHtmlString(
           labReportJson,
-          "Anatomical Location / Laterality",
+          "Anatomical Location / Laterality"
         ),
       className: "lab-text-content",
     },
@@ -736,7 +848,7 @@ const getLabsContent = (
       title: "Collection Method/Volume",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Collection Method / Volume",
+        "Collection Method / Volume"
       ),
       className: "lab-text-content",
     },
@@ -744,7 +856,7 @@ const getLabsContent = (
       title: "Resulting Agency Comment",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Resulting Agency Comment",
+        "Resulting Agency Comment"
       ),
       className: "lab-text-content",
     },
@@ -752,7 +864,7 @@ const getLabsContent = (
       title: "Authorizing Provider",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Authorizing Provider",
+        "Authorizing Provider"
       ),
       className: "lab-text-content",
     },

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -481,7 +481,6 @@ export const evaluateDiagnosticReportData = (
       columnName: "Test Method",
       infoPath: "observationDeviceReference",
       applyToValue: (ref) => {
-        // TODO ANGELA: review evaluateReference2
         const device = evaluateReference2<Device>(fhirIndex, ref);
         return safeParse(device?.deviceName?.[0]?.name ?? "");
       },

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -95,7 +95,6 @@ export const evaluateLabInfoData = (
   const jsonLabs = getAllLabJsonObjects(fhirIndex);
 
   for (const report of labReports) {
-    let t;
 
     const obs = getObservations(report, fhirIndex);
     const labReportJson = getJsonLab(jsonLabs, obs);
@@ -143,7 +142,7 @@ export const evaluateLabInfoData = (
 };
 
 /**
- * Extracts an array of `Observation` resources from a the FHIR index based on a list of observation references.
+ * Extracts an array of `Observation` resources from the FHIR index based on a list of observation references.
  * @param report - The lab report containing the results to be processed.
  * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns An array of `Observation` resources from the FHIR bundle that correspond to the
@@ -154,15 +153,13 @@ export const getObservations = (
   report: DiagnosticReport,
   fhirIndex: FhirIndex,
 ): Observation[] => {
-  const test = (report.result || [])
+    return sortResourcesByDate(
+    (report.result || [])
     .map((obsRef) =>
       evaluateReference2<Observation>(fhirIndex, obsRef.reference),
     )
-    .filter(notEmpty);
-  try {
-    return sortResourcesByDate(test, fhirPathMappings.effectiveX);
-  } finally {
-  }
+    .filter(notEmpty), fhirPathMappings.effectiveX
+    );
 };
 
 const ensureReportHasDateTime = (

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -55,7 +55,7 @@ import EvaluateTable, {
 } from "@/app/view-data/components/EvaluateTable";
 import { FieldValue } from "@/app/view-data/components/FieldValue";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
-import { FhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+import { FhirIndex, getResourceById, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
 
 export interface ResultObject {
   [key: string]: AccordionItem[];
@@ -90,7 +90,7 @@ export const evaluateLabInfoData = (
   labReports: DiagnosticReport[],
   accordionHeadingLevel: HeadingLevel = "h5"
 ): LabReportElementData[] => {
-
+  // the keys are the organization id, the value is an array of jsx elements of diagnostic reports
   let organizationItems: ResultObject = {};
   const jsonLabs = getAllLabJsonObjects(fhirIndex);
 
@@ -101,12 +101,7 @@ export const evaluateLabInfoData = (
     const labReportJson = getJsonLab(jsonLabs, obs);
     ensureReportHasDateTime(report, obs);
 
-    const content = getLabsContent(
-      report,
-      obs,
-      fhirIndex,
-      labReportJson
-    );
+    const content = getLabsContent(report, obs, fhirIndex, labReportJson);
     const organizationId = (report.performer?.[0].reference ?? "").replace(
       "Organization/",
       ""
@@ -143,7 +138,7 @@ export const evaluateLabInfoData = (
     organizationItems = groupItemByOrgId(
       organizationItems,
       organizationId,
-      item,
+      item
     );
   }
 
@@ -166,7 +161,7 @@ export const getObservations = (
     .map((obsRef) => {
       if (obsRef.reference) {
         const [_, id] = obsRef.reference.split("/");
-        return fhirIndex.fhirResourcesById[id] as Observation;
+        return getResourceById<Observation>(fhirIndex, "Observation", id)
       }
     })
     .filter(notEmpty);
@@ -259,8 +254,6 @@ export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
     compositionLabs,
     fhirPathMappings.labResultDiv
   );
-  // const labsString = evaluateValue(fhirBundle, fhirPathMappings.labResultDiv);
-  // console.log(labsString);
   return formatTablesToJSON(labsString);
 };
 

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -104,15 +104,12 @@ export const evaluateLabInfoData = (
     const obs = getObservations(report, fhirIndex);
     const labReportJson = getJsonLab(jsonLabs, obs);
     ensureReportHasDateTime(report, obs);
-
     const content = getLabsContent(report, obs, fhirIndex, labReportJson);
     const organizationId = (report.performer?.[0].reference ?? "").replace(
       "Organization/",
       "",
     );
-
     const title = formatCodeableConcept(report.code) ?? "Unknown";
-
     const item = {
       title: (
         <div className="display-flex flex-row flex-justify flex-align-center gap-05">

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -95,7 +95,6 @@ export const evaluateLabInfoData = (
   const jsonLabs = getAllLabJsonObjects(fhirIndex);
 
   for (const report of labReports) {
-
     const obs = getObservations(report, fhirIndex);
     const labReportJson = getJsonLab(jsonLabs, obs);
     ensureReportHasDateTime(report, obs);
@@ -153,13 +152,14 @@ export const getObservations = (
   report: DiagnosticReport,
   fhirIndex: FhirIndex,
 ): Observation[] => {
-    return sortResourcesByDate(
+  return sortResourcesByDate(
     (report.result || [])
-    .map((obsRef) =>
-      evaluateReference2<Observation>(fhirIndex, obsRef.reference),
-    )
-    .filter(notEmpty), fhirPathMappings.effectiveX
-    );
+      .map((obsRef) =>
+        evaluateReference2<Observation>(fhirIndex, obsRef.reference),
+      )
+      .filter(notEmpty),
+    fhirPathMappings.effectiveX,
+  );
 };
 
 const ensureReportHasDateTime = (

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -57,7 +57,6 @@ import { FieldValue } from "@/app/view-data/components/FieldValue";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
 import {
   FhirIndex,
-  getResourceById,
   getResourcesByType,
 } from "@/app/view-data/services/fhirResourcesIndexService";
 
@@ -159,12 +158,9 @@ export const getObservations = (
   fhirIndex: FhirIndex,
 ): Observation[] => {
   const test = (report.result || [])
-    .map((obsRef) => {
-      if (obsRef.reference) {
-        const [_, id] = obsRef.reference.split("/");
-        return getResourceById<Observation>(fhirIndex, "Observation", id);
-      }
-    })
+    .map((obsRef) => 
+      evaluateReference2<Observation>(fhirIndex, obsRef.reference)
+    )
     .filter(notEmpty);
   try {
     return sortResourcesByDate(test, fhirPathMappings.effectiveX);

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -79,54 +79,31 @@ const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
 /**
  * Evaluates lab information and RR data from the provided FHIR bundle and mappings.
  * @param fhirBundle - The FHIR bundle containing lab and RR data.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param labReports - An array of DiagnosticReport objects
  * @param accordionHeadingLevel - Heading level for the title of AccordionLabResults.
  * @returns An array of the Diagnostic reports Elements and Organization Display Data
  */
 export const evaluateLabInfoData = (
   fhirBundle: Bundle,
-  labReports: DiagnosticReport[],
   fhirIndex: FhirIndex,
+  labReports: DiagnosticReport[],
   accordionHeadingLevel: HeadingLevel = "h5"
 ): LabReportElementData[] => {
-  const t0 = performance.now();
 
   let organizationItems: ResultObject = {};
-  const jsonLabs = getAllLabJsonObjects(fhirBundle, fhirIndex);
-
-  const tgetall0 = performance.now();
-  console.log("Time to getAllLabJsonObjects", tgetall0 - t0);
-  // const labObs = fhirIndex.fhirResourcesByType["Observation"];
-
-  const tgetall1 = performance.now();
-  console.log("Time to get all lab obs: ", tgetall1 - tgetall0);
-  // console.log(allObs);
-
-  const totals = {
-    getObservations: 0,
-    getJsonLab: 0,
-    getLabsContent: 0,
-    evaluateValue: 0,
-  };
+  const jsonLabs = getAllLabJsonObjects(fhirIndex);
 
   for (const report of labReports) {
     let t;
 
-    t = performance.now();
     const obs = getObservations(report, fhirIndex);
-    totals.getObservations += performance.now() - t;
-
-    t = performance.now();
     const labReportJson = getJsonLab(jsonLabs, obs);
-    totals.getJsonLab += performance.now() - t;
-
     ensureReportHasDateTime(report, obs);
 
-    t = performance.now();
     const content = getLabsContent(
       report,
       obs,
-      fhirBundle,
       fhirIndex,
       labReportJson
     );
@@ -134,12 +111,8 @@ export const evaluateLabInfoData = (
       "Organization/",
       ""
     );
-    totals.getLabsContent += performance.now() - t;
 
     const title = formatCodeableConcept(report.code) ?? "Unknown";
-
-    t = performance.now();
-    totals.evaluateValue += performance.now() - t;
 
     const item = {
       title: (
@@ -174,62 +147,13 @@ export const evaluateLabInfoData = (
     );
   }
 
-  const t1 = performance.now();
-
-  console.log("evaluateLabInfoData TOTAL:", (t1 - t0).toFixed(2), "ms");
-  console.log("Breakdown:");
-  Object.entries(totals)
-    .sort((a, b) => b[1] - a[1])
-    .forEach(([k, v]) => {
-      console.log(`  ${k}: ${v.toFixed(2)} ms`);
-    });
-
-  return combineOrgAndReportData(organizationItems, fhirBundle, fhirIndex);
+  return combineOrgAndReportData(organizationItems, fhirIndex);
 };
 
-// /**
-//  * Extracts all lab `Observation` resources from a given FHIR bundle across all diagnostic reports.
-//  * @param fhirBundle - The FHIR bundle containing related resources for the lab report.
-//  * @returns An object of `Observation` resources with the observation `id` (string) as the key. 
-//  * If no matching observations are found, an empty object is returned.
-//  */
-// export const getAllObservationResources = (
-//   fhirBundle: Bundle
-// ): Record<string, Observation> => {
-//   // init the object
-//   const labObs: Record<string, Observation> = {};
-  
-//   // Get lab Composition section
-//   // const labObsRefs = evaluateAll(
-//   //   fhirBundle,
-//   //   fhirPathMappings.labResultObservations
-//   // );
-//   // console.log(labObsRefs);
-
-//   // For each reference
-//   // labObsRefs.forEach((ref) => {
-//   //   // TODO ANGELA: don't do reference lookups. just iterate through bundle once and record all observations
-//   //   const ob = evaluateReference<Observation>(fhirBundle, ref.reference);
-//   //   if (ob && ob.id) {
-//   //     labObs[ob.id] = ob
-//   //   };
-//   // });
-
-//   const obs = evaluateAll(fhirBundle, fhirPathMappings.observations);
-//   obs.forEach((ob) => {
-//     if (ob && ob.id) {
-//       labObs[ob.id] = ob
-//     };
-//   })
-
-//   //return the object
-//   return labObs;
-// };
-
 /**
- * Extracts an array of `Observation` resources from a given FHIR bundle based on a list of observation references.
+ * Extracts an array of `Observation` resources from a the FHIR index based on a list of observation references.
  * @param report - The lab report containing the results to be processed.
- * @param fhirBundle - The FHIR bundle containing related resources for the lab report.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns An array of `Observation` resources from the FHIR bundle that correspond to the
  * given references. If no matching observations are found or if the input references array is empty, an empty array
  * is returned.
@@ -325,10 +249,10 @@ export const getJsonLab = (
 
 /**
  * Retrieves the JSON representation of a lab report from the labs HTML string.
- * @param fhirBundle - The FHIR Bundle object containing relevant FHIR resources.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns The JSON representation of the lab report.
  */
-export const getAllLabJsonObjects = (fhirBundle: Bundle, fhirIndex: FhirIndex): HtmlTableJson[] => {
+export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
   const compositionLabs = getResourcesByType<Composition>(fhirIndex, 'Composition')[0];
   const labsString = evaluateValue(
@@ -535,12 +459,11 @@ export const returnAnalysisTime = (
 /**
  * Evaluates diagnostic report data and generates the lab observations for each report.
  * @param obs - An object containing an array of result observations.
- * @param fhirBundle - The FHIR bundle containing diagnostic report data.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns - An array of React elements representing the lab observations.
  */
 export const evaluateDiagnosticReportData = (
   obs: Observation[],
-  fhirBundle: Bundle,
   fhirIndex: FhirIndex,
 ): React.JSX.Element | undefined => {
   if (!obs.length) return undefined;
@@ -565,7 +488,7 @@ export const evaluateDiagnosticReportData = (
       columnName: "Test Method",
       infoPath: "observationDeviceReference",
       applyToValue: (ref) => {
-        // TODO: Angela review evaluateReference2
+        // TODO ANGELA: review evaluateReference2
         const device = evaluateReference2<Device>(fhirIndex, ref);
         return safeParse(device?.deviceName?.[0]?.name ?? "");
       },
@@ -661,19 +584,17 @@ export const evaluateOrganismsReportData = (
 /**
  * Combines the org display data with the diagnostic report elements
  * @param organizationItems - Object containing the keys of org data, values of the diagnostic report elements
- * @param fhirBundle - The FHIR bundle containing lab and RR data.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @returns An array of the Diagnostic reports Elements and Organization Display Data
  */
 export const combineOrgAndReportData = (
   organizationItems: ResultObject,
-  fhirBundle: Bundle,
   fhirIndex: FhirIndex,
 ): LabReportElementData[] => {
   return Object.keys(organizationItems).map((key: string) => {
     const organizationId = key.replace("Organization/", "");
     const orgData = evaluateLabOrganizationData(
       organizationId,
-      fhirBundle,
       fhirIndex,
       organizationItems[key].length,
     );
@@ -688,13 +609,12 @@ export const combineOrgAndReportData = (
 /**
  * Finds the Organization that matches the id and creates a DisplayDataProps array
  * @param id - id of the organization
- * @param fhirBundle - The FHIR bundle containing lab and RR data.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param labReportCount - A number representing the amount of lab reports for a specific organization
  * @returns The organization display data as an array
  */
 export const evaluateLabOrganizationData = (
   id: string,
-  fhirBundle: Bundle,
   fhirIndex: FhirIndex,
   labReportCount: number,
 ) => {
@@ -780,23 +700,17 @@ const groupItemByOrgId = (
  * Retrieves the content for a lab report.
  * @param report - The DiagnosticReport resource.
  * @param obs - The observations associated with the report
- * @param fhirBundle - The FHIR Bundle.
+ * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param labReportJson - The JSON representation of the lab results from HTML.
  * @returns An array of JSX elements representing the lab report content.
  */
-// TODO ANGELA: Review
 const getLabsContent = (
   report: DiagnosticReport,
   obs: Observation[],
-  fhirBundle: Bundle,
   fhirIndex: FhirIndex,
   labReportJson?: HtmlTableJson,
 ) => {
-  const labTableDiagnostic = evaluateDiagnosticReportData(
-    obs,
-    fhirBundle,
-    fhirIndex
-  );
+  const labTableDiagnostic = evaluateDiagnosticReportData(obs, fhirIndex);
   const labTableOrganisms = evaluateOrganismsReportData(obs);
   const labSpecimen = evaluateReference2<Specimen>(
     fhirIndex,

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -36,7 +36,6 @@ import {
 import {
   evaluateAll,
   evaluateOne,
-  evaluateReference,
   evaluateReference2,
   evaluateValue,
 } from "@/app/utils/evaluate";
@@ -81,14 +80,12 @@ const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
 
 /**
  * Evaluates lab information and RR data from the provided FHIR bundle and mappings.
- * @param fhirBundle - The FHIR bundle containing lab and RR data.
  * @param fhirIndex - FHIR resources indexed by type & by ID
  * @param labReports - An array of DiagnosticReport objects
  * @param accordionHeadingLevel - Heading level for the title of AccordionLabResults.
  * @returns An array of the Diagnostic reports Elements and Organization Display Data
  */
 export const evaluateLabInfoData = (
-  fhirBundle: Bundle,
   fhirIndex: FhirIndex,
   labReports: DiagnosticReport[],
   accordionHeadingLevel: HeadingLevel = "h5",

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -55,7 +55,11 @@ import EvaluateTable, {
 } from "@/app/view-data/components/EvaluateTable";
 import { FieldValue } from "@/app/view-data/components/FieldValue";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
-import { FhirIndex, getResourceById, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getResourceById,
+  getResourcesByType,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 export interface ResultObject {
   [key: string]: AccordionItem[];
@@ -88,7 +92,7 @@ export const evaluateLabInfoData = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
   labReports: DiagnosticReport[],
-  accordionHeadingLevel: HeadingLevel = "h5"
+  accordionHeadingLevel: HeadingLevel = "h5",
 ): LabReportElementData[] => {
   // the keys are the organization id, the value is an array of jsx elements of diagnostic reports
   let organizationItems: ResultObject = {};
@@ -104,7 +108,7 @@ export const evaluateLabInfoData = (
     const content = getLabsContent(report, obs, fhirIndex, labReportJson);
     const organizationId = (report.performer?.[0].reference ?? "").replace(
       "Organization/",
-      ""
+      "",
     );
 
     const title = formatCodeableConcept(report.code) ?? "Unknown";
@@ -138,7 +142,7 @@ export const evaluateLabInfoData = (
     organizationItems = groupItemByOrgId(
       organizationItems,
       organizationId,
-      item
+      item,
     );
   }
 
@@ -161,7 +165,7 @@ export const getObservations = (
     .map((obsRef) => {
       if (obsRef.reference) {
         const [_, id] = obsRef.reference.split("/");
-        return getResourceById<Observation>(fhirIndex, "Observation", id)
+        return getResourceById<Observation>(fhirIndex, "Observation", id);
       }
     })
     .filter(notEmpty);
@@ -170,7 +174,6 @@ export const getObservations = (
   } finally {
   }
 };
-
 
 const ensureReportHasDateTime = (
   report: DiagnosticReport,
@@ -249,10 +252,13 @@ export const getJsonLab = (
  */
 export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
-  const compositionLabs = getResourcesByType<Composition>(fhirIndex, 'Composition')[0];
+  const compositionLabs = getResourcesByType<Composition>(
+    fhirIndex,
+    "Composition",
+  )[0];
   const labsString = evaluateValue(
     compositionLabs,
-    fhirPathMappings.labResultDiv
+    fhirPathMappings.labResultDiv,
   );
   return formatTablesToJSON(labsString);
 };
@@ -611,7 +617,10 @@ export const evaluateLabOrganizationData = (
   fhirIndex: FhirIndex,
   labReportCount: number,
 ) => {
-  const orgMappings = getResourcesByType<Organization>(fhirIndex, 'Organization');
+  const orgMappings = getResourcesByType<Organization>(
+    fhirIndex,
+    "Organization",
+  );
   let matchingOrg: Organization = orgMappings.filter(
     (organization) => organization.id === id,
   )[0];
@@ -747,7 +756,7 @@ const getLabsContent = (
         evaluateValue(labSpecimen, fhirPathMappings.specimenBodySite) ||
         returnFieldValueFromLabHtmlString(
           labReportJson,
-          "Anatomical Location / Laterality"
+          "Anatomical Location / Laterality",
         ),
       className: "lab-text-content",
     },
@@ -755,7 +764,7 @@ const getLabsContent = (
       title: "Collection Method/Volume",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Collection Method / Volume"
+        "Collection Method / Volume",
       ),
       className: "lab-text-content",
     },
@@ -763,7 +772,7 @@ const getLabsContent = (
       title: "Resulting Agency Comment",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Resulting Agency Comment"
+        "Resulting Agency Comment",
       ),
       className: "lab-text-content",
     },
@@ -771,7 +780,7 @@ const getLabsContent = (
       title: "Authorizing Provider",
       value: returnFieldValueFromLabHtmlString(
         labReportJson,
-        "Authorizing Provider"
+        "Authorizing Provider",
       ),
       className: "lab-text-content",
     },

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -12,6 +12,7 @@ import {
   evaluateValue,
 } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
+import { FhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 describe("evaluate", () => {
   let fhirPathEvaluateSpy: jest.SpyInstance;
@@ -338,7 +339,7 @@ describe("Evaluate Reference 2", () => {
       id: "2",
     },
   };
-  const fhirIndexBundleSample = {
+  const fhirIndexBundleSample: FhirIndex = {
     fhirIndexByType: {
       Observation: [resource1.resource, resource2.resource],
     },
@@ -367,4 +368,24 @@ describe("Evaluate Reference 2", () => {
     expect(actual?.id).toEqual("2");
     expect(actual?.resourceType).toEqual("Observation");
   });
+  it("should error when resource is found but resourceType does not match expected resourceType", () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const fhirIndexMismatch: FhirIndex = {
+      fhirIndexByType: {
+        "Patient": [resource1.resource] // Resource 1 = Observation
+      },
+      fhirIndexByTypeAndId: {
+        "Patient": {
+          "1": resource1.resource
+        }
+      }
+    }
+    evaluateReference2<Patient>(fhirIndexMismatch, "Patient/1");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Resource type mismatch")
+    );
+    consoleSpy.mockRestore();
+  })
 });

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -8,6 +8,7 @@ import {
   evaluateAllAndCheck,
   evaluateOne,
   evaluateReference,
+  evaluateReference2,
   evaluateValue,
 } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
@@ -319,5 +320,52 @@ describe("Evaluate Reference", () => {
 
     expect(actual?.id).toEqual("99999999-4p89-4b96-b6ab-c46406839cea");
     expect(actual?.resourceType).toEqual("Patient");
+  });
+});
+
+// TODO ANGELA: Rename?
+describe("Evaluate Reference 2", () => {
+  const resource1 = {
+    fullUrl: "urn:uuid:1",
+    resource: {
+      resourceType: "Observation",
+      id: "1",
+    },
+  };
+  const resource2 = {
+    fullUrl: "urn:uuid:2",
+    resource: {
+      resourceType: "Observation",
+      id: "2",
+    },
+  };
+  const fhirIndexBundleSample = {
+    fhirIndexByType: {
+      Observation: [resource1.resource, resource2.resource],
+    },
+    fhirIndexByTypeAndId: {
+      Observation: {
+        "1": resource1.resource,
+        "2": resource2.resource,
+      },
+    },
+  };
+
+  it("should return undefined if resource not found", () => {
+    const actual = evaluateReference2<Observation>(
+      fhirIndexBundleSample,
+      "Observation/not-valid-id"
+    );
+
+    expect(actual).toBeUndefined();
+  });
+  it("should return the resource if the resource is available", () => {
+    const actual = evaluateReference2<Observation>(
+      fhirIndexBundleSample,
+      "Observation/2"
+    );
+
+    expect(actual?.id).toEqual("2");
+    expect(actual?.resourceType).toEqual("Observation");
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -354,7 +354,7 @@ describe("Evaluate Reference 2", () => {
   it("should return undefined if resource not found", () => {
     const actual = evaluateReference2<Observation>(
       fhirIndexBundleSample,
-      "Observation/not-valid-id"
+      "Observation/not-valid-id",
     );
 
     expect(actual).toBeUndefined();
@@ -362,7 +362,7 @@ describe("Evaluate Reference 2", () => {
   it("should return the resource if the resource is available", () => {
     const actual = evaluateReference2<Observation>(
       fhirIndexBundleSample,
-      "Observation/2"
+      "Observation/2",
     );
 
     expect(actual?.id).toEqual("2");

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -323,7 +323,6 @@ describe("Evaluate Reference", () => {
   });
 });
 
-// TODO ANGELA: Rename?
 describe("Evaluate Reference 2", () => {
   const resource1 = {
     fullUrl: "urn:uuid:1",

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -374,18 +374,18 @@ describe("Evaluate Reference 2", () => {
       .mockImplementation(() => {});
     const fhirIndexMismatch: FhirIndex = {
       fhirIndexByType: {
-        "Patient": [resource1.resource] // Resource 1 = Observation
+        Patient: [resource1.resource], // Resource 1 = Observation
       },
       fhirIndexByTypeAndId: {
-        "Patient": {
-          "1": resource1.resource
-        }
-      }
-    }
+        Patient: {
+          "1": resource1.resource,
+        },
+      },
+    };
     evaluateReference2<Patient>(fhirIndexMismatch, "Patient/1");
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Resource type mismatch")
+      expect.stringContaining("Resource type mismatch"),
     );
     consoleSpy.mockRestore();
-  })
+  });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -32,7 +32,7 @@ describe("Snapshot test for eCR Document", () => {
 
     const items = getEcrDocumentAccordionItems(
       bundleEmpty,
-      fhirIndexBundleEmpty
+      fhirIndexBundleEmpty,
     );
 
     const { container } = render(<EcrDocument initialAccordionItems={items} />);

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -17,6 +17,7 @@ import {
   evaluateClinicalData,
   returnCareTeamTable,
 } from "@/app/view-data/components/EcrDocument/clinical-data";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
 
@@ -27,8 +28,12 @@ describe("Snapshot test for eCR Document", () => {
       type: "batch",
       entry: [],
     };
+    const fhirIndexBundleEmpty = getFhirIndex(bundleEmpty);
 
-    const items = getEcrDocumentAccordionItems(bundleEmpty);
+    const items = getEcrDocumentAccordionItems(
+      bundleEmpty,
+      fhirIndexBundleEmpty
+    );
 
     const { container } = render(<EcrDocument initialAccordionItems={items} />);
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -13,7 +13,10 @@ import {
   evaluateLabInfoData,
   LabReportElementData,
 } from "@/app/view-data/services/labsService";
-import { getFhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  getFhirIndex,
+  getResourcesByType,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
@@ -24,11 +27,14 @@ describe("LabInfo", () => {
   describe("when labResults is LabReportElementData[]", () => {
     let labInfoJsx: React.ReactElement;
     beforeAll(() => {
-      const diagnosticReports = getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, "DiagnosticReport");
+      const diagnosticReports = getResourcesByType<DiagnosticReport>(
+        fhirIndexBundleLab,
+        "DiagnosticReport",
+      );
       const labInfoOrg = evaluateLabInfoData(
         BundleLab,
         fhirIndexBundleLab,
-        diagnosticReports
+        diagnosticReports,
       ) as LabReportElementData[];
 
       // Empty out one of the lab names for testing
@@ -112,12 +118,12 @@ describe("LabInfo", () => {
     beforeAll(() => {
       const diagnosticReports = getResourcesByType<DiagnosticReport>(
         fhirIndexBundleLabNoLabIds,
-        "DiagnosticReport"
+        "DiagnosticReport",
       );
       labInfo = evaluateLabInfoData(
         BundleLabNoLabIds,
         fhirIndexBundleLabNoLabIds,
-        diagnosticReports
+        diagnosticReports,
       );
     });
     it("should be collapsed by default", () => {

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -6,8 +6,6 @@ import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
-import { evaluateAll } from "@/app/utils/evaluate";
-import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import LabInfo from "@/app/view-data/components/LabInfo";
 import {
   evaluateLabInfoData,
@@ -32,7 +30,6 @@ describe("LabInfo", () => {
         "DiagnosticReport",
       );
       const labInfoOrg = evaluateLabInfoData(
-        BundleLab,
         fhirIndexBundleLab,
         diagnosticReports,
       ) as LabReportElementData[];
@@ -121,7 +118,6 @@ describe("LabInfo", () => {
         "DiagnosticReport",
       );
       labInfo = evaluateLabInfoData(
-        BundleLabNoLabIds,
         fhirIndexBundleLabNoLabIds,
         diagnosticReports,
       );

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Bundle } from "fhir/r4";
+import { Bundle, DiagnosticReport } from "fhir/r4";
 
-import BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
-import BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
+import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
+import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
 import { evaluateAll } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import LabInfo from "@/app/view-data/components/LabInfo";
@@ -13,14 +13,22 @@ import {
   evaluateLabInfoData,
   LabReportElementData,
 } from "@/app/view-data/services/labsService";
+import { getFhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+
+const BundleLab = _BundleLab as unknown as Bundle;
+const fhirIndexBundleLab = getFhirIndex(BundleLab);
+const BundleLabNoLabIds = _BundleLabNoLabIds as unknown as Bundle;
+const fhirIndexBundleLabNoLabIds = getFhirIndex(BundleLabNoLabIds);
 
 describe("LabInfo", () => {
   describe("when labResults is LabReportElementData[]", () => {
     let labInfoJsx: React.ReactElement;
     beforeAll(() => {
+      const diagnosticReports = getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, "DiagnosticReport");
       const labInfoOrg = evaluateLabInfoData(
-        BundleLab as unknown as Bundle,
-        evaluateAll(BundleLab as Bundle, fhirPathMappings.diagnosticReports),
+        BundleLab,
+        fhirIndexBundleLab,
+        diagnosticReports
       ) as LabReportElementData[];
 
       // Empty out one of the lab names for testing
@@ -100,15 +108,19 @@ describe("LabInfo", () => {
   });
 
   describe("when labResults is DisplayDataProps[]", () => {
-    it("should be collapsed by default", () => {
-      const labInfo = evaluateLabInfoData(
-        BundleLabNoLabIds as unknown as Bundle,
-        evaluateAll(
-          BundleLabNoLabIds as Bundle,
-          fhirPathMappings.diagnosticReports,
-        ),
+    let labInfo: LabReportElementData[];
+    beforeAll(() => {
+      const diagnosticReports = getResourcesByType<DiagnosticReport>(
+        fhirIndexBundleLabNoLabIds,
+        "DiagnosticReport"
       );
-
+      labInfo = evaluateLabInfoData(
+        BundleLabNoLabIds,
+        fhirIndexBundleLabNoLabIds,
+        diagnosticReports
+      );
+    });
+    it("should be collapsed by default", () => {
       render(<LabInfo labResults={labInfo} />);
       screen
         .getAllByTestId("accordionButton", { exact: false })
@@ -129,14 +141,6 @@ describe("LabInfo", () => {
     });
 
     it("should match snapshot test", () => {
-      const labInfo = evaluateLabInfoData(
-        BundleLabNoLabIds as unknown as Bundle,
-        evaluateAll(
-          BundleLabNoLabIds as Bundle,
-          fhirPathMappings.diagnosticReports,
-        ),
-      );
-
       const { container } = render(<LabInfo labResults={labInfo} />);
       expect(container).toMatchSnapshot();
     });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -14,7 +14,10 @@ import {
   evaluateEcrSummaryRelevantClinicalDetails,
   evaluateEcrSummaryRelevantLabResults,
 } from "@/app/view-data/services/ecrSummaryService";
-import { FhirIndex, getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getFhirIndex,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
@@ -22,9 +25,10 @@ const fhirIndexBundleLab = getFhirIndex(BundleLab);
 const BundleEcrSummary = _BundleEcrSummary as unknown as Bundle;
 const fhirIndexBundleEcrSummary = getFhirIndex(BundleEcrSummary);
 
-const BundleRRConditionValueString = _BundleRRConditionValueString as unknown as Bundle;
+const BundleRRConditionValueString =
+  _BundleRRConditionValueString as unknown as Bundle;
 const fhirIndexBundleRRConditionValueString = getFhirIndex(
-  BundleRRConditionValueString
+  BundleRRConditionValueString,
 );
 
 describe("ecrSummaryService Tests", () => {
@@ -71,7 +75,7 @@ describe("ecrSummaryService Tests", () => {
       const actual = evaluateEcrSummaryRelevantLabResults(
         BundleLab,
         fhirIndexBundleLab,
-        ""
+        "",
       );
 
       expect(actual).toBeEmpty();
@@ -81,7 +85,7 @@ describe("ecrSummaryService Tests", () => {
       const actual = evaluateEcrSummaryRelevantLabResults(
         BundleLab,
         fhirIndexBundleLab,
-        "invalid-snomed-code"
+        "invalid-snomed-code",
       );
 
       expect(actual).toBeEmpty();
@@ -124,7 +128,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return titles based on snomed code, and return human-readable name if available", () => {
       const actual = evaluateEcrSummaryConditionSummary(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       expect(actual[0].title).toEqual("Hepatitis C");
@@ -135,7 +139,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return human-readable name if available", () => {
       const actual = evaluateEcrSummaryConditionSummary(
         BundleRRConditionValueString,
-        fhirIndexBundleRRConditionValueString
+        fhirIndexBundleRRConditionValueString,
       );
 
       expect(actual[0].title).toEqual("COVID");
@@ -143,7 +147,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return summaries based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
       render(
         actual[1].conditionDetails.map((detail, i) => (
@@ -168,7 +172,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return clinical details based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       render(
@@ -182,7 +186,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return lab details based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       render(
@@ -243,11 +247,11 @@ describe("ecrSummaryService Tests", () => {
         ],
       } as unknown as Bundle;
       const fhirIndexBundleNonRelatedImmuns = getFhirIndex(
-        BundleNonRelatedImmuns
+        BundleNonRelatedImmuns,
       );
       const actual = evaluateEcrSummaryConditionSummary(
         BundleNonRelatedImmuns,
-        fhirIndexBundleNonRelatedImmuns
+        fhirIndexBundleNonRelatedImmuns,
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -259,14 +263,17 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.queryByText("anthrax")).not.toBeInTheDocument();
     });
     it("should return empty array if none found", () => {
-      const actual = evaluateEcrSummaryConditionSummary({} as Bundle, {} as FhirIndex);
+      const actual = evaluateEcrSummaryConditionSummary(
+        {} as Bundle,
+        {} as FhirIndex,
+      );
 
       expect(actual).toBeEmpty();
     });
     it("should return the the requested snomed first", () => {
       const verifyNotFirst = evaluateEcrSummaryConditionSummary(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       expect(verifyNotFirst[0].title).not.toEqual(

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -4,16 +4,28 @@ import { render, screen } from "@testing-library/react";
 import { Bundle } from "fhir/r4";
 
 import BundleWithClinicalInfo from "../../../../../../../test-data/fhir/BundleClinicalInfo.json";
-import BundleEcrSummary from "../../../../../../../test-data/fhir/BundleEcrSummary.json";
-import BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
+import _BundleEcrSummary from "../../../../../../../test-data/fhir/BundleEcrSummary.json";
+import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import BundlePatient from "../../../../../../../test-data/fhir/BundlePatient.json";
-import BundleRRConditionValueString from "../../../../../../../test-data/fhir/BundleRRConditionValueString.json";
+import _BundleRRConditionValueString from "../../../../../../../test-data/fhir/BundleRRConditionValueString.json";
 import {
   evaluateEcrSummaryConditionSummary,
   evaluateEcrSummaryPatientDetails,
   evaluateEcrSummaryRelevantClinicalDetails,
   evaluateEcrSummaryRelevantLabResults,
 } from "@/app/view-data/services/ecrSummaryService";
+import { FhirIndex, getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+
+const BundleLab = _BundleLab as unknown as Bundle;
+const fhirIndexBundleLab = getFhirIndex(BundleLab);
+
+const BundleEcrSummary = _BundleEcrSummary as unknown as Bundle;
+const fhirIndexBundleEcrSummary = getFhirIndex(BundleEcrSummary);
+
+const BundleRRConditionValueString = _BundleRRConditionValueString as unknown as Bundle;
+const fhirIndexBundleRRConditionValueString = getFhirIndex(
+  BundleRRConditionValueString
+);
 
 describe("ecrSummaryService Tests", () => {
   describe("Evaluate eCR Summary Relevant Clinical Details", () => {
@@ -57,8 +69,9 @@ describe("ecrSummaryService Tests", () => {
   describe("Evaluate eCR Summary Relevant Lab Results", () => {
     it("should return an empty list when no SNOMED code is provided", () => {
       const actual = evaluateEcrSummaryRelevantLabResults(
-        BundleLab as unknown as Bundle,
-        "",
+        BundleLab,
+        fhirIndexBundleLab,
+        ""
       );
 
       expect(actual).toBeEmpty();
@@ -66,8 +79,9 @@ describe("ecrSummaryService Tests", () => {
 
     it("should return 'No Data' string when the provided SNOMED code has no matches", () => {
       const actual = evaluateEcrSummaryRelevantLabResults(
-        BundleLab as unknown as Bundle,
-        "invalid-snomed-code",
+        BundleLab,
+        fhirIndexBundleLab,
+        "invalid-snomed-code"
       );
 
       expect(actual).toBeEmpty();
@@ -75,7 +89,8 @@ describe("ecrSummaryService Tests", () => {
 
     it("should return the correct lab result(s) when the provided SNOMED code matches", () => {
       const result = evaluateEcrSummaryRelevantLabResults(
-        BundleLab as unknown as Bundle,
+        BundleLab,
+        fhirIndexBundleLab,
         "test-snomed",
       );
       expect(result).toHaveLength(3); // 2 results, plus last item is divider line
@@ -95,7 +110,8 @@ describe("ecrSummaryService Tests", () => {
 
     it("should not include the last empty divider line when lastDividerLine is false", () => {
       const result = evaluateEcrSummaryRelevantLabResults(
-        BundleLab as unknown as Bundle,
+        BundleLab,
+        fhirIndexBundleLab,
         "test-snomed",
         false,
       );
@@ -107,7 +123,8 @@ describe("ecrSummaryService Tests", () => {
   describe("Evaluate eCR Summary Condition Summary", () => {
     it("should return titles based on snomed code, and return human-readable name if available", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       expect(actual[0].title).toEqual("Hepatitis C");
@@ -117,14 +134,16 @@ describe("ecrSummaryService Tests", () => {
     });
     it("should return human-readable name if available", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleRRConditionValueString as unknown as Bundle,
+        BundleRRConditionValueString,
+        fhirIndexBundleRRConditionValueString
       );
 
       expect(actual[0].title).toEqual("COVID");
     });
     it("should return summaries based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
       render(
         actual[1].conditionDetails.map((detail, i) => (
@@ -148,7 +167,8 @@ describe("ecrSummaryService Tests", () => {
     });
     it("should return clinical details based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       render(
@@ -161,7 +181,8 @@ describe("ecrSummaryService Tests", () => {
     });
     it("should return lab details based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       render(
@@ -177,7 +198,8 @@ describe("ecrSummaryService Tests", () => {
     });
     it("should return immunization details based on snomed code", () => {
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary,
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -188,10 +210,10 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.getByText("SARS-CoV-2 PCR Vaccine")).toBeInTheDocument();
     });
     it("should not display non-related immunization details", () => {
-      const actual = evaluateEcrSummaryConditionSummary({
-        ...BundleEcrSummary,
+      const BundleNonRelatedImmuns = {
+        ..._BundleEcrSummary,
         entry: [
-          ...BundleEcrSummary.entry,
+          ..._BundleEcrSummary.entry,
           {
             fullUrl: "urn:uuid:6689c3f5-f256-9c28-bd98-89905630f28d",
             resource: {
@@ -219,7 +241,14 @@ describe("ecrSummaryService Tests", () => {
             },
           },
         ],
-      } as unknown as Bundle);
+      } as unknown as Bundle;
+      const fhirIndexBundleNonRelatedImmuns = getFhirIndex(
+        BundleNonRelatedImmuns
+      );
+      const actual = evaluateEcrSummaryConditionSummary(
+        BundleNonRelatedImmuns,
+        fhirIndexBundleNonRelatedImmuns
+      );
       render(
         actual[1].immunizationDetails.map((detail) => (
           <React.Fragment key={Math.random()}>{detail.value}</React.Fragment>
@@ -230,13 +259,14 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.queryByText("anthrax")).not.toBeInTheDocument();
     });
     it("should return empty array if none found", () => {
-      const actual = evaluateEcrSummaryConditionSummary({} as Bundle);
+      const actual = evaluateEcrSummaryConditionSummary({} as Bundle, {} as FhirIndex);
 
       expect(actual).toBeEmpty();
     });
     it("should return the the requested snomed first", () => {
       const verifyNotFirst = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       expect(verifyNotFirst[0].title).not.toEqual(
@@ -244,7 +274,8 @@ describe("ecrSummaryService Tests", () => {
       );
 
       const actual = evaluateEcrSummaryConditionSummary(
-        BundleEcrSummary as unknown as Bundle,
+        BundleEcrSummary,
+        fhirIndexBundleEcrSummary,
         "840539006",
       );
       expect(actual[0].title).toEqual(

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -1,6 +1,9 @@
 import { Bundle, Composition, Observation, Patient } from "fhir/r4";
-import { getFhirIndex, getResourceById, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
-
+import {
+  getFhirIndex,
+  getResourceById,
+  getResourcesByType,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 const resource1 = {
   fullUrl: "urn:uuid:1",
@@ -26,9 +29,7 @@ const resource3 = {
 const BundleSample = {
   resourceType: "Bundle",
   type: "document",
-  entry: [
-    resource1, resource2, resource3
-  ],
+  entry: [resource1, resource2, resource3],
 } as unknown as Bundle;
 const fhirIndexBundleSample = {
   fhirIndexByType: {
@@ -58,8 +59,8 @@ describe("fhirResourcesIndexService Tests", () => {
       const actual = getFhirIndex(bundleEmpty);
       const expected = {
         fhirIndexByType: {},
-        fhirIndexByTypeAndId: {}
-      }
+        fhirIndexByTypeAndId: {},
+      };
       expect(actual).toEqual(expected);
     });
     it("Does not index resources with no id", () => {
@@ -67,9 +68,9 @@ describe("fhirResourcesIndexService Tests", () => {
         fullUrl: "urn:uuid:",
         resource: {
           resourceType: "Observation",
-          id: ""
-        }
-      }
+          id: "",
+        },
+      };
       const bundleWithResourceNoId = {
         ...BundleSample,
         entry: [...(BundleSample.entry ?? []), resourceNoId],
@@ -98,12 +99,18 @@ describe("fhirResourcesIndexService Tests", () => {
   });
   describe("getResourcesByType Tests", () => {
     it("Returns all resources of a specified type", () => {
-      const actual = getResourcesByType<Observation>(fhirIndexBundleSample, "Observation");
+      const actual = getResourcesByType<Observation>(
+        fhirIndexBundleSample,
+        "Observation",
+      );
       expect(actual.length).toEqual(2);
       expect(actual).toEqual([resource2.resource, resource3.resource]);
     });
     it("Returns an empty array when no resources exist of specified type", () => {
-      const actual = getResourcesByType<Patient>(fhirIndexBundleSample, "Patient");
+      const actual = getResourcesByType<Patient>(
+        fhirIndexBundleSample,
+        "Patient",
+      );
       expect(actual).toEqual([]);
     });
   });
@@ -112,7 +119,7 @@ describe("fhirResourcesIndexService Tests", () => {
       const actual = getResourceById<Composition>(
         fhirIndexBundleSample,
         "Composition",
-        "1"
+        "1",
       );
       expect(actual).toEqual(resource1.resource);
     });
@@ -120,17 +127,17 @@ describe("fhirResourcesIndexService Tests", () => {
       const actual = getResourceById<Observation>(
         fhirIndexBundleSample,
         "Observation",
-        "4"
+        "4",
       );
-      expect(actual).toEqual(undefined);      
+      expect(actual).toEqual(undefined);
     });
     it("Returns undefined if resource exists with specified ID BUT has the wrong resource Type", () => {
       const actual = getResourceById<Composition>(
         fhirIndexBundleSample,
         "Composition",
-        "2"
+        "2",
       );
-      expect(actual).toEqual(undefined);      
+      expect(actual).toEqual(undefined);
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -117,12 +117,9 @@ describe("fhirResourcesIndexService Tests", () => {
     it("Returns an empty array when FHIR index is empty", () => {
       const fhirIndexEmpty: FhirIndex = {
         fhirIndexByType: {},
-        fhirIndexByTypeAndId: {}
+        fhirIndexByTypeAndId: {},
       };
-      const actual = getResourcesByType<Patient>(
-        fhirIndexEmpty,
-        "Patient"
-      )
+      const actual = getResourcesByType<Patient>(fhirIndexEmpty, "Patient");
       expect(actual).toEqual([]);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -1,5 +1,6 @@
 import { Bundle, Composition, Observation, Patient } from "fhir/r4";
 import {
+  FhirIndex,
   getFhirIndex,
   getResourceById,
   getResourcesByType,
@@ -113,6 +114,17 @@ describe("fhirResourcesIndexService Tests", () => {
       );
       expect(actual).toEqual([]);
     });
+    it("Returns an empty array when FHIR index is empty", () => {
+      const fhirIndexEmpty: FhirIndex = {
+        fhirIndexByType: {},
+        fhirIndexByTypeAndId: {}
+      };
+      const actual = getResourcesByType<Patient>(
+        fhirIndexEmpty,
+        "Patient"
+      )
+      expect(actual).toEqual([]);
+    });
   });
   describe("getResourceById Tests", () => {
     it("Returns resource with specified ID", () => {
@@ -137,6 +149,14 @@ describe("fhirResourcesIndexService Tests", () => {
         "Composition",
         "2",
       );
+      expect(actual).toEqual(undefined);
+    });
+    it("Returns undefined if when FHIR index is empty", () => {
+      const fhirIndexEmpty: FhirIndex = {
+        fhirIndexByType: {},
+        fhirIndexByTypeAndId: {},
+      };
+      const actual = getResourceById<Patient>(fhirIndexEmpty, "Patient", "1");
       expect(actual).toEqual(undefined);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -1,0 +1,136 @@
+import { Bundle, Composition, Observation, Patient } from "fhir/r4";
+import { getFhirIndex, getResourceById, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+
+
+const resource1 = {
+  fullUrl: "urn:uuid:1",
+  resource: {
+    resourceType: "Composition",
+    id: "1",
+  },
+};
+const resource2 = {
+  fullUrl: "urn:uuid:2",
+  resource: {
+    resourceType: "Observation",
+    id: "2",
+  },
+};
+const resource3 = {
+  fullUrl: "urn:uuid:3",
+  resource: {
+    resourceType: "Observation",
+    id: "3",
+  },
+};
+const BundleSample = {
+  resourceType: "Bundle",
+  type: "document",
+  entry: [
+    resource1, resource2, resource3
+  ],
+} as unknown as Bundle;
+const fhirIndexBundleSample = {
+  fhirIndexByType: {
+    Composition: [resource1.resource],
+    Observation: [resource2.resource, resource3.resource],
+  },
+  fhirIndexByTypeAndId: {
+    Composition: {
+      "1": resource1.resource,
+    },
+    Observation: {
+      "2": resource2.resource,
+      "3": resource3.resource,
+    },
+  },
+};
+
+describe("fhirResourcesIndexService Tests", () => {
+  describe("getFhirIndex Tests", () => {
+    it("Returns a valid FhirIndex", () => {
+      const actual = getFhirIndex(BundleSample);
+
+      expect(actual).toEqual(fhirIndexBundleSample);
+    });
+    it("Returns an empty FhirIndex when a bundle has no resources", () => {
+      const bundleEmpty = {} as unknown as Bundle;
+      const actual = getFhirIndex(bundleEmpty);
+      const expected = {
+        fhirIndexByType: {},
+        fhirIndexByTypeAndId: {}
+      }
+      expect(actual).toEqual(expected);
+    });
+    it("Does not index resources with no id", () => {
+      const resourceNoId = {
+        fullUrl: "urn:uuid:",
+        resource: {
+          resourceType: "Observation",
+          id: ""
+        }
+      }
+      const bundleWithResourceNoId = {
+        ...BundleSample,
+        entry: [...(BundleSample.entry ?? []), resourceNoId],
+      } as Bundle;
+
+      const actual = getFhirIndex(bundleWithResourceNoId);
+      expect(actual).toEqual(fhirIndexBundleSample);
+    });
+    it("Does not index resources with no resourceType", () => {
+      // Note: this should not be possible. Adding test for safeguarding anyways
+      const resourceNoType = {
+        fullUrl: "urn:uuid:4",
+        resource: {
+          resourceType: "",
+          id: "4",
+        },
+      };
+      const bundleWithResourceNoType = {
+        ...BundleSample,
+        entry: [...(BundleSample.entry ?? []), resourceNoType],
+      } as Bundle;
+
+      const actual = getFhirIndex(bundleWithResourceNoType);
+      expect(actual).toEqual(fhirIndexBundleSample);
+    });
+  });
+  describe("getResourcesByType Tests", () => {
+    it("Returns all resources of a specified type", () => {
+      const actual = getResourcesByType<Observation>(fhirIndexBundleSample, "Observation");
+      expect(actual.length).toEqual(2);
+      expect(actual).toEqual([resource2.resource, resource3.resource]);
+    });
+    it("Returns an empty array when no resources exist of specified type", () => {
+      const actual = getResourcesByType<Patient>(fhirIndexBundleSample, "Patient");
+      expect(actual).toEqual([]);
+    });
+  });
+  describe("getResourceById Tests", () => {
+    it("Returns resource with specified ID", () => {
+      const actual = getResourceById<Composition>(
+        fhirIndexBundleSample,
+        "Composition",
+        "1"
+      );
+      expect(actual).toEqual(resource1.resource);
+    });
+    it("Returns undefined when no resource exists with spcified ID", () => {
+      const actual = getResourceById<Observation>(
+        fhirIndexBundleSample,
+        "Observation",
+        "4"
+      );
+      expect(actual).toEqual(undefined);      
+    });
+    it("Returns undefined if resource exists with specified ID BUT has the wrong resource Type", () => {
+      const actual = getResourceById<Composition>(
+        fhirIndexBundleSample,
+        "Composition",
+        "2"
+      );
+      expect(actual).toEqual(undefined);      
+    });
+  });
+});

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -7,10 +7,7 @@ import _BundleLabInvalidResultsDiv from "../../../../../../../test-data/fhir/Bun
 import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
 import { AccordionItem } from "@/app/types";
 import { noData } from "@/app/utils/data-utils";
-import {
-  evaluateAllAndCheck,
-  evaluateOneAndCheck,
-} from "@/app/utils/evaluate";
+import { evaluateAllAndCheck, evaluateOneAndCheck } from "@/app/utils/evaluate";
 import {
   checkAbnormalTag,
   searchResultRecord,

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -31,11 +31,19 @@ import {
   getObservations,
   LabInterpretationTag,
 } from "@/app/view-data/services/labsService";
+import { FhirIndex, getFhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
+const fhirIndexBundleLab = getFhirIndex(BundleLab);
+
 const BundleLabInvalidResultsDiv =
   _BundleLabInvalidResultsDiv as unknown as Bundle;
+const fhirIndexBundleLabInvalidResultsDiv = getFhirIndex(
+  BundleLabInvalidResultsDiv
+);
+
 const BundleLabNoLabIds = _BundleLabNoLabIds as unknown as Bundle;
+const fhirIndexBundleLabNoLabIds = getFhirIndex(BundleLabNoLabIds);
 
 const pathLabReportNormal =
   "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(id = 'c090d379-9aea-f26e-4ddc-378223841e3b')";
@@ -174,10 +182,10 @@ const labReportAbnormal = evaluateOneAndCheck<DiagnosticReport>(
   pathLabReportAbnormal,
   "DiagnosticReport",
 );
-const jsonLabs = getAllLabJsonObjects(BundleLab);
+const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
 const labReportAbnormalJsonObject = getJsonLab(
   jsonLabs,
-  getObservations(labReportAbnormal!, BundleLab),
+  getObservations(labReportAbnormal!, fhirIndexBundleLab)
 );
 
 const pathLabOrganismsTableAndNarr =
@@ -203,7 +211,7 @@ describe("LabsService tests", () => {
             code: {},
             status: "entered-in-error",
           },
-          BundleLab,
+          fhirIndexBundleLab
         );
 
         const expectedObservationPath =
@@ -228,7 +236,7 @@ describe("LabsService tests", () => {
             code: {},
             status: "final",
           },
-          BundleLab,
+          fhirIndexBundleLab
         );
         expect(result).toStrictEqual([]);
       });
@@ -238,10 +246,10 @@ describe("LabsService tests", () => {
       it("returns correct Json Object for table with data-id", () => {
         const expectedResult = labReportNormalJsonObject;
 
-        const jsonLabs = getAllLabJsonObjects(BundleLab);
+        const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportNormal!, BundleLab),
+          getObservations(labReportNormal!, fhirIndexBundleLab)
         );
 
         expect(result).toEqual(expectedResult);
@@ -254,20 +262,20 @@ describe("LabsService tests", () => {
           "DiagnosticReport",
         );
 
-        const jsonLabs = getAllLabJsonObjects(BundleLabNoLabIds);
+        const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLabNoLabIds);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportWithoutIds!, BundleLabNoLabIds),
+          getObservations(labReportWithoutIds!, fhirIndexBundleLabNoLabIds)
         );
 
         expect(result).toBeUndefined();
       });
 
       it("returns undefined if lab results html contains no tables", () => {
-        const jsonLabs = getAllLabJsonObjects(BundleLab);
+        const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportNormal!, BundleLabInvalidResultsDiv),
+          getObservations(labReportNormal!, fhirIndexBundleLabInvalidResultsDiv)
         );
 
         expect(result).toBeUndefined();
@@ -483,9 +491,12 @@ describe("LabsService tests", () => {
       it("should fallback to checkAbnormalTag logic when lab report is abnormal, but not one of the abnormal observation interpretations", () => {
         render(
           <LabInterpretationTag
-            observations={getObservations(labReportAbnormal!, BundleLab)}
+            observations={getObservations(
+              labReportAbnormal!,
+              fhirIndexBundleLab
+            )}
             labReportJson={labReportAbnormalJsonObject}
-          />,
+          />
         );
         const tagElement = screen.getByText("Abnormal");
         expect(tagElement).toBeInTheDocument();
@@ -660,7 +671,7 @@ describe("LabsService tests", () => {
   describe("evaluateOrganismsReportData", () => {
     it("should return the correct organisms table when the data exists for a lab report", () => {
       const result = evaluateOrganismsReportData(
-        getObservations(labOrganismsTableAndNarr!, BundleLab),
+        getObservations(labOrganismsTableAndNarr!, fhirIndexBundleLab)
       )!;
       render(result);
 
@@ -672,7 +683,7 @@ describe("LabsService tests", () => {
     });
     it("should return undefined if lab organisms data does not exist for a lab report", () => {
       const result = evaluateOrganismsReportData(
-        getObservations(labReportNormal!, BundleLab),
+        getObservations(labReportNormal!, fhirIndexBundleLab)
       );
 
       expect(result).toBeUndefined();
@@ -681,13 +692,10 @@ describe("LabsService tests", () => {
 
   describe("Evaluate Diagnostic Report", () => {
     it("should evaluate diagnostic report results", () => {
-      const report = evaluateAll(
-        BundleLab,
-        fhirPathMappings.diagnosticReports,
-      )[0];
+      const report = getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, 'DiagnosticReport')[0];
       const actual = evaluateDiagnosticReportData(
-        getObservations(report, BundleLab),
-        BundleLab,
+        getObservations(report, fhirIndexBundleLab),
+        fhirIndexBundleLab
       );
 
       render(actual);
@@ -708,19 +716,19 @@ describe("LabsService tests", () => {
         status: "final",
       };
       const actual = evaluateDiagnosticReportData(
-        getObservations(diagnosticReport, null as unknown as Bundle),
-        null as unknown as Bundle,
+        getObservations(diagnosticReport, null as unknown as FhirIndex),
+        null as unknown as FhirIndex,
       );
       expect(actual).toBeUndefined();
     });
     it("should evaluate test method results", () => {
-      const report = evaluateAll(
-        BundleLab,
-        fhirPathMappings.diagnosticReports,
+      const report = getResourcesByType<DiagnosticReport>(
+        fhirIndexBundleLab,
+        "DiagnosticReport"
       )[0];
       const actual = evaluateDiagnosticReportData(
-        getObservations(report, BundleLab),
-        BundleLab,
+        getObservations(report, fhirIndexBundleLab),
+        fhirIndexBundleLab
       );
 
       render(actual);
@@ -730,13 +738,13 @@ describe("LabsService tests", () => {
       ).not.toBeEmpty();
     });
     it("should display comment", async () => {
-      const report = evaluateAll(
-        BundleLab,
-        fhirPathMappings.diagnosticReports,
+      const report = getResourcesByType<DiagnosticReport>(
+        fhirIndexBundleLab,
+        "DiagnosticReport"
       )[2];
       const actual = evaluateDiagnosticReportData(
-        getObservations(report, BundleLab),
-        BundleLab,
+        getObservations(report, fhirIndexBundleLab),
+        fhirIndexBundleLab,
       );
       render(actual!);
 
@@ -765,7 +773,7 @@ describe("LabsService tests", () => {
     it("should return a matching org", () => {
       const result = evaluateLabOrganizationData(
         "14394818-a1e9-4882-ca8b-FAKE793bb5cc",
-        BundleLab,
+        fhirIndexBundleLab,
         0,
       );
       expect(result[0].value).toEqual("Tatooine Hospital");
@@ -776,7 +784,10 @@ describe("LabsService tests", () => {
           {} as AccordionItem,
         ],
       };
-      const result = combineOrgAndReportData(testResultObject, BundleLab);
+      const result = combineOrgAndReportData(
+        testResultObject,
+        fhirIndexBundleLab
+      );
       expect(result[0].organizationDisplayDataProps).toBeArray();
     });
   });
@@ -785,7 +796,8 @@ describe("LabsService tests", () => {
     it("should return a list of LabReportElementData if the lab results in the HTML table have ID's", () => {
       const result = evaluateLabInfoData(
         BundleLab,
-        evaluateAll(BundleLab, fhirPathMappings.diagnosticReports),
+        fhirIndexBundleLab,
+        getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, 'DiagnosticReport')
       );
       expect(result[0]).toHaveProperty("diagnosticReportDataItems");
       expect(result[0]).toHaveProperty("organizationDisplayDataProps");
@@ -794,7 +806,8 @@ describe("LabsService tests", () => {
     it("should return a list of LabReportElementData even if the lab results in the HTML table do not have ID's", () => {
       const result = evaluateLabInfoData(
         BundleLabNoLabIds,
-        evaluateAll(BundleLabNoLabIds, fhirPathMappings.diagnosticReports),
+        fhirIndexBundleLabNoLabIds,
+        getResourcesByType<DiagnosticReport>(fhirIndexBundleLabNoLabIds, 'DiagnosticReport')
       );
       expect(result[0]).toHaveProperty("diagnosticReportDataItems");
       expect(result[0]).toHaveProperty("organizationDisplayDataProps");
@@ -803,7 +816,11 @@ describe("LabsService tests", () => {
     it("should properly count the number of labs", () => {
       const result = evaluateLabInfoData(
         BundleLab,
-        evaluateAll(BundleLab, fhirPathMappings.diagnosticReports),
+        fhirIndexBundleLab,
+        getResourcesByType<DiagnosticReport>(
+          fhirIndexBundleLab,
+          "DiagnosticReport"
+        )
       );
       const props = (result[0] as LabReportElementData)
         .organizationDisplayDataProps;

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -1003,8 +1003,8 @@ describe("LabsService tests", () => {
     // Might be able to remove these tests down the line
     const fhirIndexEmpty: FhirIndex = {
       fhirIndexByType: {},
-      fhirIndexByTypeAndId: {}
-    }
+      fhirIndexByTypeAndId: {},
+    };
     it("getAllLabJsonObjects should return [] when FhirIndex is empty", () => {
       const actual = getAllLabJsonObjects(fhirIndexEmpty);
       expect(actual).toEqual([]);

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -8,11 +8,9 @@ import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoL
 import { AccordionItem } from "@/app/types";
 import { noData } from "@/app/utils/data-utils";
 import {
-  evaluateAll,
   evaluateAllAndCheck,
   evaluateOneAndCheck,
 } from "@/app/utils/evaluate";
-import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import {
   checkAbnormalTag,
   searchResultRecord,
@@ -805,7 +803,6 @@ describe("LabsService tests", () => {
   describe("Evaluate the lab info section", () => {
     it("should return a list of LabReportElementData if the lab results in the HTML table have ID's", () => {
       const result = evaluateLabInfoData(
-        BundleLab,
         fhirIndexBundleLab,
         getResourcesByType<DiagnosticReport>(
           fhirIndexBundleLab,
@@ -818,7 +815,6 @@ describe("LabsService tests", () => {
 
     it("should return a list of LabReportElementData even if the lab results in the HTML table do not have ID's", () => {
       const result = evaluateLabInfoData(
-        BundleLabNoLabIds,
         fhirIndexBundleLabNoLabIds,
         getResourcesByType<DiagnosticReport>(
           fhirIndexBundleLabNoLabIds,
@@ -831,7 +827,6 @@ describe("LabsService tests", () => {
 
     it("should properly count the number of labs", () => {
       const result = evaluateLabInfoData(
-        BundleLab,
         fhirIndexBundleLab,
         getResourcesByType<DiagnosticReport>(
           fhirIndexBundleLab,

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -31,7 +31,11 @@ import {
   getObservations,
   LabInterpretationTag,
 } from "@/app/view-data/services/labsService";
-import { FhirIndex, getFhirIndex, getResourcesByType } from "@/app/view-data/services/fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getFhirIndex,
+  getResourcesByType,
+} from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
@@ -39,7 +43,7 @@ const fhirIndexBundleLab = getFhirIndex(BundleLab);
 const BundleLabInvalidResultsDiv =
   _BundleLabInvalidResultsDiv as unknown as Bundle;
 const fhirIndexBundleLabInvalidResultsDiv = getFhirIndex(
-  BundleLabInvalidResultsDiv
+  BundleLabInvalidResultsDiv,
 );
 
 const BundleLabNoLabIds = _BundleLabNoLabIds as unknown as Bundle;
@@ -185,7 +189,7 @@ const labReportAbnormal = evaluateOneAndCheck<DiagnosticReport>(
 const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
 const labReportAbnormalJsonObject = getJsonLab(
   jsonLabs,
-  getObservations(labReportAbnormal!, fhirIndexBundleLab)
+  getObservations(labReportAbnormal!, fhirIndexBundleLab),
 );
 
 const pathLabOrganismsTableAndNarr =
@@ -211,7 +215,7 @@ describe("LabsService tests", () => {
             code: {},
             status: "entered-in-error",
           },
-          fhirIndexBundleLab
+          fhirIndexBundleLab,
         );
 
         const expectedObservationPath =
@@ -236,7 +240,7 @@ describe("LabsService tests", () => {
             code: {},
             status: "final",
           },
-          fhirIndexBundleLab
+          fhirIndexBundleLab,
         );
         expect(result).toStrictEqual([]);
       });
@@ -249,7 +253,7 @@ describe("LabsService tests", () => {
         const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportNormal!, fhirIndexBundleLab)
+          getObservations(labReportNormal!, fhirIndexBundleLab),
         );
 
         expect(result).toEqual(expectedResult);
@@ -265,7 +269,7 @@ describe("LabsService tests", () => {
         const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLabNoLabIds);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportWithoutIds!, fhirIndexBundleLabNoLabIds)
+          getObservations(labReportWithoutIds!, fhirIndexBundleLabNoLabIds),
         );
 
         expect(result).toBeUndefined();
@@ -275,7 +279,10 @@ describe("LabsService tests", () => {
         const jsonLabs = getAllLabJsonObjects(fhirIndexBundleLab);
         const result = getJsonLab(
           jsonLabs,
-          getObservations(labReportNormal!, fhirIndexBundleLabInvalidResultsDiv)
+          getObservations(
+            labReportNormal!,
+            fhirIndexBundleLabInvalidResultsDiv,
+          ),
         );
 
         expect(result).toBeUndefined();
@@ -493,10 +500,10 @@ describe("LabsService tests", () => {
           <LabInterpretationTag
             observations={getObservations(
               labReportAbnormal!,
-              fhirIndexBundleLab
+              fhirIndexBundleLab,
             )}
             labReportJson={labReportAbnormalJsonObject}
-          />
+          />,
         );
         const tagElement = screen.getByText("Abnormal");
         expect(tagElement).toBeInTheDocument();
@@ -671,7 +678,7 @@ describe("LabsService tests", () => {
   describe("evaluateOrganismsReportData", () => {
     it("should return the correct organisms table when the data exists for a lab report", () => {
       const result = evaluateOrganismsReportData(
-        getObservations(labOrganismsTableAndNarr!, fhirIndexBundleLab)
+        getObservations(labOrganismsTableAndNarr!, fhirIndexBundleLab),
       )!;
       render(result);
 
@@ -683,7 +690,7 @@ describe("LabsService tests", () => {
     });
     it("should return undefined if lab organisms data does not exist for a lab report", () => {
       const result = evaluateOrganismsReportData(
-        getObservations(labReportNormal!, fhirIndexBundleLab)
+        getObservations(labReportNormal!, fhirIndexBundleLab),
       );
 
       expect(result).toBeUndefined();
@@ -692,10 +699,13 @@ describe("LabsService tests", () => {
 
   describe("Evaluate Diagnostic Report", () => {
     it("should evaluate diagnostic report results", () => {
-      const report = getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, 'DiagnosticReport')[0];
+      const report = getResourcesByType<DiagnosticReport>(
+        fhirIndexBundleLab,
+        "DiagnosticReport",
+      )[0];
       const actual = evaluateDiagnosticReportData(
         getObservations(report, fhirIndexBundleLab),
-        fhirIndexBundleLab
+        fhirIndexBundleLab,
       );
 
       render(actual);
@@ -724,11 +734,11 @@ describe("LabsService tests", () => {
     it("should evaluate test method results", () => {
       const report = getResourcesByType<DiagnosticReport>(
         fhirIndexBundleLab,
-        "DiagnosticReport"
+        "DiagnosticReport",
       )[0];
       const actual = evaluateDiagnosticReportData(
         getObservations(report, fhirIndexBundleLab),
-        fhirIndexBundleLab
+        fhirIndexBundleLab,
       );
 
       render(actual);
@@ -740,7 +750,7 @@ describe("LabsService tests", () => {
     it("should display comment", async () => {
       const report = getResourcesByType<DiagnosticReport>(
         fhirIndexBundleLab,
-        "DiagnosticReport"
+        "DiagnosticReport",
       )[2];
       const actual = evaluateDiagnosticReportData(
         getObservations(report, fhirIndexBundleLab),
@@ -786,7 +796,7 @@ describe("LabsService tests", () => {
       };
       const result = combineOrgAndReportData(
         testResultObject,
-        fhirIndexBundleLab
+        fhirIndexBundleLab,
       );
       expect(result[0].organizationDisplayDataProps).toBeArray();
     });
@@ -797,7 +807,10 @@ describe("LabsService tests", () => {
       const result = evaluateLabInfoData(
         BundleLab,
         fhirIndexBundleLab,
-        getResourcesByType<DiagnosticReport>(fhirIndexBundleLab, 'DiagnosticReport')
+        getResourcesByType<DiagnosticReport>(
+          fhirIndexBundleLab,
+          "DiagnosticReport",
+        ),
       );
       expect(result[0]).toHaveProperty("diagnosticReportDataItems");
       expect(result[0]).toHaveProperty("organizationDisplayDataProps");
@@ -807,7 +820,10 @@ describe("LabsService tests", () => {
       const result = evaluateLabInfoData(
         BundleLabNoLabIds,
         fhirIndexBundleLabNoLabIds,
-        getResourcesByType<DiagnosticReport>(fhirIndexBundleLabNoLabIds, 'DiagnosticReport')
+        getResourcesByType<DiagnosticReport>(
+          fhirIndexBundleLabNoLabIds,
+          "DiagnosticReport",
+        ),
       );
       expect(result[0]).toHaveProperty("diagnosticReportDataItems");
       expect(result[0]).toHaveProperty("organizationDisplayDataProps");
@@ -819,8 +835,8 @@ describe("LabsService tests", () => {
         fhirIndexBundleLab,
         getResourcesByType<DiagnosticReport>(
           fhirIndexBundleLab,
-          "DiagnosticReport"
-        )
+          "DiagnosticReport",
+        ),
       );
       const props = (result[0] as LabReportElementData)
         .organizationDisplayDataProps;

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/labsService.test.tsx
@@ -998,4 +998,24 @@ describe("LabsService tests", () => {
       ).not.toBeDefined();
     });
   });
+
+  describe("Using FhirIndex in labsService", () => {
+    // Might be able to remove these tests down the line
+    const fhirIndexEmpty: FhirIndex = {
+      fhirIndexByType: {},
+      fhirIndexByTypeAndId: {}
+    }
+    it("getAllLabJsonObjects should return [] when FhirIndex is empty", () => {
+      const actual = getAllLabJsonObjects(fhirIndexEmpty);
+      expect(actual).toEqual([]);
+    });
+    it("evaluateDiagnosticReportData should return undefined when FhirIndex is empty and no observation resources", () => {
+      const actual = evaluateDiagnosticReportData([], fhirIndexEmpty);
+      expect(actual).toEqual(undefined);
+    });
+    it("combineOrgAndReportData should return [] when FhirIndex is empty and no organizationItems", () => {
+      const actual = combineOrgAndReportData({}, fhirIndexEmpty);
+      expect(actual).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

Philly is experiencing a significant amount of lag when trying to view eCRs. 

- Create a FHIR index that indexes each resource in the FHIR bundle 1) by resourceType, and 2) by resourceType and by ID
- Add helper functions to get resources by type or by ID (w/ type checking)
    - 1. `getResourcesbyType` - returns an array of resources for a given type (i.e. Observation)
    - 2. `getResourcebyId` - returns a resource for a given ID (and checks the type)
- Create new `evaluateReference2` function that uses the fhirIndex instead of the fhirBundle to evaluate a reference ID. (this is a Work In Progress)
- Create new unit tests in `evaluate.test.ts` and `fhirResourceIndexService.test.tsx`. Update unit test fixtures elsewhere to get tests passing again. (No snapshot tests needed updating because these changes shouldn't cause the Viewer to display things differently)
- Remove any unused FHIR paths

## Related Issue

Fixes #1360 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Ran some performance.now() tests on an eCR, and example stats below:
**Before:**
Time to run evaluateLabInfoData 34412.242915999996 (ms)
Time to run EcrViewerPage: 35062.469583

**After**
Time to run evaluateLabInfoData 5629.431375
Time to run EcrViewerPage: 5812.276333

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
