### PR TITLE
fix: Add `no information` to unavailableTerms

### DIFF
--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -53,6 +53,7 @@ export const isDataAvailable = (item: DisplayDataProps): Boolean => {
     "do not know",
     "no history of present illness information available",
     "no information available",
+    "no information"
   ];
   const valStr = removeHtmlElements(`${item.value}`).trim().toLowerCase();
   return !unavailableTerms.some((t) => t === valStr);

--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -53,7 +53,7 @@ export const isDataAvailable = (item: DisplayDataProps): Boolean => {
     "do not know",
     "no history of present illness information available",
     "no information available",
-    "no information"
+    "no information",
   ];
   const valStr = removeHtmlElements(`${item.value}`).trim().toLowerCase();
   return !unavailableTerms.some((t) => t === valStr);


### PR DESCRIPTION
# PULL REQUEST

## Summary

Added `no information` as an unavailable data term

## Related Issue

N/A - just found example of `No Information` showing up in Viewer instead of in Unavailable info section

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
