### PR TITLE
feat: Add immunization variables to the extended schema

### DIFF
--- a/containers/ecr-viewer/README.md
+++ b/containers/ecr-viewer/README.md
@@ -30,7 +30,7 @@ Congratulations, the eCR Viewer should now be running on `localhost:8080`!
 
 ### Running from Node.js Source Code
 
-We recommend running the eCR Viewer from a container, but if that isn't feasible for a given use-case, please see the [Development section](##Development) for instruction to run the eCR Viewer locally
+We recommend running the eCR Viewer from a container, but if that isn't feasible for a given use-case, please see the [Development section](#Development) for instruction to run the eCR Viewer locally
 
 ## Building the Docker Image
 
@@ -93,6 +93,26 @@ By default, the seed data in the `star-wars` subfolder converts. To convert othe
 ### Developer Commands
 
 Additional commands can be found in [`package.json`](package.json).
+
+#### Creating a Migration
+
+To create a new Kysely migration file, run:
+
+```sh
+npm run migration:create -- <type> <name>
+```
+
+- `<type>` — either `core` or `extended` (required)
+- `<name>` — a short snake_case description of the migration (required)
+
+For example:
+
+```sh
+npm run migration:create -- core add_user_roles
+npm run migration:create -- extended add_immunization_columns
+```
+
+This generates a timestamped file (e.g. `20260403162000_add_user_roles.ts`) in `src/app/api/migrate-db/migrations/<type>/` with empty `up` and `down` exports ready to fill in.
 
 ### Testing
 

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -123,6 +123,17 @@ This table stores laboratory results associated with eCRs. Note that the primary
 | `specimen_collection_date`               | `date`         | NULL        |               | Date of specimen collection                                                                   |
 | `performing_lab`                         | `varchar(255)` | NULL        |               | Performing laboratory                                                                         |
 
+### `ecr_immunizations` Table
+
+This table stores immunization records associated with eCRs.
+
+| Column Name           | Data Type      | Nullability | Default Value | Description                                        |
+| :-------------------- | :------------- | :---------- | :------------ | :------------------------------------------------- |
+| `uuid`                | `varchar(200)` | NOT NULL    |               | Primary key, unique identifier for the immunization record |
+| `eicr_id`             | `varchar(200)` | NOT NULL    |               | Foreign key, references `ecr_data.eicr_id`         |
+| `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                   |
+| `administration_date` | `date`         | NULL        |               | Date the vaccine was administered                  |
+
 ### `patient_address` Table
 
 This table stores patient address information. Note that the primary key for this table is a compound primary key consisting of `uuid` and `eicr_id`.

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -99,7 +99,7 @@ The following columns are added to the `ecr_data` table in the extended schema:
 
 This table stores laboratory results associated with eCRs. Note that the primary key for this table is a compound primary key consisting of `uuid` and `eicr_id`.
 
-| Column Name                              | Data Type      | Nullability | Default Value | Description                                                                                   |
+| Column Name                              | Data Type      | Nullability | Default Value | Description                                `                                                   |
 | :--------------------------------------- | :------------- | :---------- | :------------ | :-------------------------------------------------------------------------------------------- |
 | `uuid`                                   | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], unique identifier for the lab record       |
 | `eicr_id`                                | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], Foreign key, references `ecr_data.eicr_id` |
@@ -127,12 +127,12 @@ This table stores laboratory results associated with eCRs. Note that the primary
 
 This table stores immunization records associated with eCRs.
 
-| Column Name           | Data Type      | Nullability | Default Value | Description                                                |
-| :-------------------- | :------------- | :---------- | :------------ | :--------------------------------------------------------- |
-| `uuid`                | `varchar(200)` | NOT NULL    |               | Primary key, unique identifier for the immunization record |
-| `eicr_id`             | `varchar(200)` | NOT NULL    |               | Foreign key, references `ecr_data.eicr_id`                 |
-| `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                           |
-| `administration_date` | `date`         | NULL        |               | Date the vaccine was administered                          |
+| Column Name           | Data Type      | Nullability | Default Value | Description                                                                                      |
+| :-------------------- | :------------- | :---------- | :------------ |:-------------------------------------------------------------------------------------------------|
+| `uuid`                | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], unique identifier for the immunization record |
+| `eicr_id`             | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], Foreign key, references `ecr_data.eicr_id`    |
+| `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                                                                 |
+| `administration_date` | `date`         | NULL        |               | Date the vaccine was administered                                                                |
 
 ### `patient_address` Table
 

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -99,7 +99,7 @@ The following columns are added to the `ecr_data` table in the extended schema:
 
 This table stores laboratory results associated with eCRs. Note that the primary key for this table is a compound primary key consisting of `uuid` and `eicr_id`.
 
-| Column Name                              | Data Type      | Nullability | Default Value | Description                                `                                                   |
+| Column Name                              | Data Type      | Nullability | Default Value | Description `                                                                                 |
 | :--------------------------------------- | :------------- | :---------- | :------------ | :-------------------------------------------------------------------------------------------- |
 | `uuid`                                   | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], unique identifier for the lab record       |
 | `eicr_id`                                | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], Foreign key, references `ecr_data.eicr_id` |
@@ -128,7 +128,7 @@ This table stores laboratory results associated with eCRs. Note that the primary
 This table stores immunization records associated with eCRs.
 
 | Column Name           | Data Type      | Nullability | Default Value | Description                                                                                      |
-| :-------------------- | :------------- | :---------- | :------------ |:-------------------------------------------------------------------------------------------------|
+| :-------------------- | :------------- | :---------- | :------------ | :----------------------------------------------------------------------------------------------- |
 | `uuid`                | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], unique identifier for the immunization record |
 | `eicr_id`             | `varchar(200)` | NOT NULL    |               | Part of the composite primary key [uuid, eicr_id], Foreign key, references `ecr_data.eicr_id`    |
 | `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                                                                 |

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -127,12 +127,12 @@ This table stores laboratory results associated with eCRs. Note that the primary
 
 This table stores immunization records associated with eCRs.
 
-| Column Name           | Data Type      | Nullability | Default Value | Description                                        |
-| :-------------------- | :------------- | :---------- | :------------ | :------------------------------------------------- |
+| Column Name           | Data Type      | Nullability | Default Value | Description                                                |
+| :-------------------- | :------------- | :---------- | :------------ | :--------------------------------------------------------- |
 | `uuid`                | `varchar(200)` | NOT NULL    |               | Primary key, unique identifier for the immunization record |
-| `eicr_id`             | `varchar(200)` | NOT NULL    |               | Foreign key, references `ecr_data.eicr_id`         |
-| `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                   |
-| `administration_date` | `date`         | NULL        |               | Date the vaccine was administered                  |
+| `eicr_id`             | `varchar(200)` | NOT NULL    |               | Foreign key, references `ecr_data.eicr_id`                 |
+| `name`                | `varchar(255)` | NULL        |               | Name of the vaccine administered                           |
+| `administration_date` | `date`         | NULL        |               | Date the vaccine was administered                          |
 
 ### `patient_address` Table
 

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -33,7 +33,8 @@
     "test:load:local": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'docker compose -f ./seed-scripts/docker-compose-load-local.yaml --profile ${CONFIG_NAME} --profile ecr-viewer up --build'",
     "clear-local": "docker compose -f ./seed-scripts/docker-compose-seed.yaml --profile \"*\" down -v",
     "convert-seed-data": "npx @dotenvx/dotenvx run -f .env.local -- sh -c 'docker compose -f ./seed-scripts/docker-compose-seed.yaml --profile ${CONFIG_NAME} --profile ecr-viewer up --abort-on-container-exit ${CONVERT_FLAGS}'",
-    "convert-seed-data:build": "CONVERT_FLAGS=--build npm run convert-seed-data"
+    "convert-seed-data:build": "CONVERT_FLAGS=--build npm run convert-seed-data",
+    "migration:create": "node scripts/create-migration.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.982.0",

--- a/containers/ecr-viewer/scripts/create-migration.mjs
+++ b/containers/ecr-viewer/scripts/create-migration.mjs
@@ -1,0 +1,31 @@
+import { writeFileSync, readFileSync } from "fs";
+import { join } from "path";
+
+const [type = "core", name = "migration"] = process.argv.slice(2);
+
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[-:T]/g, "")
+  .slice(0, 14);
+
+const filename = `${timestamp}_${name}.ts`;
+const filenameNoExt = `${timestamp}_${name}`;
+const dir = join("src/app/api/migrate-db/migrations", type);
+const filepath = join(dir, filename);
+
+const template = `import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {}
+
+export async function down(db: Kysely<unknown>): Promise<void> {}
+`;
+
+writeFileSync(filepath, template);
+console.log("Created", filepath);
+
+const indexPath = join(dir, "index.ts");
+const indexContent = readFileSync(indexPath, "utf8");
+const newEntry = `  "${filename}": require("./${filenameNoExt}"),\n`;
+const updated = indexContent.replace(/^};$/m, `${newEntry}};`);
+writeFileSync(indexPath, updated);
+console.log("Updated", indexPath);

--- a/containers/ecr-viewer/scripts/create-migration.mjs
+++ b/containers/ecr-viewer/scripts/create-migration.mjs
@@ -3,10 +3,7 @@ import { join } from "path";
 
 const [type = "core", name = "migration"] = process.argv.slice(2);
 
-const timestamp = new Date()
-  .toISOString()
-  .replace(/[-:T]/g, "")
-  .slice(0, 14);
+const timestamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
 
 const filename = `${timestamp}_${name}.ts`;
 const filenameNoExt = `${timestamp}_${name}`;

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
@@ -40,6 +40,11 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
         .select("name")
         .where("type", "=", "PK")
         .where(sql`OBJECT_NAME(parent_object_id)`, "=", table)
+        .where(
+          sql`OBJECT_SCHEMA_NAME(parent_object_id)`,
+          "=",
+          dbNamespace(),
+        )
         .executeTakeFirstOrThrow();
       pkey_name = name;
 

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
@@ -40,11 +40,7 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
         .select("name")
         .where("type", "=", "PK")
         .where(sql`OBJECT_NAME(parent_object_id)`, "=", table)
-        .where(
-          sql`OBJECT_SCHEMA_NAME(parent_object_id)`,
-          "=",
-          dbNamespace(),
-        )
+        .where(sql`OBJECT_SCHEMA_NAME(parent_object_id)`, "=", dbNamespace())
         .executeTakeFirstOrThrow();
       pkey_name = name;
 

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
@@ -19,21 +19,7 @@ const sqlServerAlterColumnNull = (
 };
 
 /**
- * Change the pks to be compound instead of just uuid.
- *
- * Why the schema filter was added to the SQL Server key constraint lookup:
- * `sys.key_constraints` is a server-wide view, so querying by table name alone
- * can return matching constraints from multiple schemas. SQL Server generates constraint
- * names randomly, so collisions across schemas are intermittent, the e2e tests
- * would only fail sometimes, and the migration would need to be re-run
- * repeatedly until SQL Server happened to generate unique names.
- *
- * This migration is updated in place (instead of creating a new one) since 
- * Kysely records which migration files have already been applied by filename
- * and environments that already ran it have the correct state and will not re-run
- * it. The change only affects new environments or test runs initialized from
- * scratch.
- *
+ * Change the pks to be compound instead of just uuid
  * @param db - the database connection
  */
 export async function up(db: Kysely<AnyDb>): Promise<void> {
@@ -54,7 +40,6 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
         .select("name")
         .where("type", "=", "PK")
         .where(sql`OBJECT_NAME(parent_object_id)`, "=", table)
-        .where(sql`OBJECT_SCHEMA_NAME(parent_object_id)`, "=", dbNamespace())
         .executeTakeFirstOrThrow();
       pkey_name = name;
 

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
@@ -28,7 +28,7 @@ const sqlServerAlterColumnNull = (
  * would only fail sometimes, and the migration would need to be re-run
  * repeatedly until SQL Server happened to generate unique names.
  *
- * This migration is updated in place (instead of creating a new one) since 
+ * This migration is updated in place (instead of creating a new one) since
  * Kysely records which migration files have already been applied by filename
  * and environments that already ran it have the correct state and will not re-run
  * it. The change only affects new environments or test runs initialized from

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20250612143900_compound_pks.ts
@@ -19,7 +19,21 @@ const sqlServerAlterColumnNull = (
 };
 
 /**
- * Change the pks to be compound instead of just uuid
+ * Change the pks to be compound instead of just uuid.
+ *
+ * Why the schema filter was added to the SQL Server key constraint lookup:
+ * `sys.key_constraints` is a server-wide view, so querying by table name alone
+ * can return matching constraints from multiple schemas. SQL Server generates constraint
+ * names randomly, so collisions across schemas are intermittent, the e2e tests
+ * would only fail sometimes, and the migration would need to be re-run
+ * repeatedly until SQL Server happened to generate unique names.
+ *
+ * This migration is updated in place (instead of creating a new one) since 
+ * Kysely records which migration files have already been applied by filename
+ * and environments that already ran it have the correct state and will not re-run
+ * it. The change only affects new environments or test runs initialized from
+ * scratch.
+ *
  * @param db - the database connection
  */
 export async function up(db: Kysely<AnyDb>): Promise<void> {

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
@@ -15,7 +15,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("eicr_id", "varchar(200)")
     .addColumn("name", "varchar(255)")
     .addColumn("administration_date", getSql("datetimeType"))
-    .addPrimaryKeyConstraint("ecr_immunizations_pk_uuid_eicr_id", ["uuid", "eicr_id"])
+    .addPrimaryKeyConstraint("ecr_immunizations_pk_uuid_eicr_id", [
+      "uuid",
+      "eicr_id",
+    ])
     .addForeignKeyConstraint(
       "ecr_immunizations_fk_eicr_id",
       ["eicr_id"],

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
@@ -1,5 +1,6 @@
 import { Kysely } from "kysely";
 import { dbNamespace, dbSchema } from "@/app/data/metadataDb/utils/db-config";
+import { getSql } from "@/app/data/metadataDb/dialects/common";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   if (dbSchema() !== "extended") {
@@ -10,10 +11,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   const _db = db.withSchema(dbNamespace());
   await _db.schema
     .createTable("ecr_immunizations")
-    .addColumn("uuid", "varchar(200)", (cb) => cb.primaryKey())
+    .addColumn("uuid", "varchar(200)")
     .addColumn("eicr_id", "varchar(200)")
     .addColumn("name", "varchar(255)")
-    .addColumn("administration_date", "date")
+    .addColumn("administration_date", getSql("datetimeType"))
+    .addPrimaryKeyConstraint("ecr_immunizations_pk_uuid_eicr_id", ["uuid", "eicr_id"])
     .addForeignKeyConstraint(
       "ecr_immunizations_fk_eicr_id",
       ["eicr_id"],

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
@@ -2,24 +2,28 @@ import { Kysely } from "kysely";
 import { dbNamespace, dbSchema } from "@/app/data/metadataDb/utils/db-config";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
-    if (dbSchema() !== "extended") {
-        console.log(`${dbSchema()} schema detected. Skipping extended migration.`);
-        return;
-    }
+  if (dbSchema() !== "extended") {
+    console.log(`${dbSchema()} schema detected. Skipping extended migration.`);
+    return;
+  }
 
-    const _db = db.withSchema(dbNamespace());
-    await _db.schema
-        .createTable("ecr_immunizations")
-        .addColumn("uuid", "varchar(200)", (cb) => cb.primaryKey())
-        .addColumn("eicr_id", "varchar(200)")
-        .addColumn("name", "varchar(255)")
-        .addColumn("administration_date", "date")
-        .addForeignKeyConstraint("ecr_immunizations_fk_eicr_id", ["eicr_id"],
-            "ecr_data",["eicr_id"])
-        .execute();
+  const _db = db.withSchema(dbNamespace());
+  await _db.schema
+    .createTable("ecr_immunizations")
+    .addColumn("uuid", "varchar(200)", (cb) => cb.primaryKey())
+    .addColumn("eicr_id", "varchar(200)")
+    .addColumn("name", "varchar(255)")
+    .addColumn("administration_date", "date")
+    .addForeignKeyConstraint(
+      "ecr_immunizations_fk_eicr_id",
+      ["eicr_id"],
+      "ecr_data",
+      ["eicr_id"],
+    )
+    .execute();
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-    const _db = db.withSchema(dbNamespace());
-    await _db.schema.dropTable("ecr_immunizations").ifExists().execute();
+  const _db = db.withSchema(dbNamespace());
+  await _db.schema.dropTable("ecr_immunizations").ifExists().execute();
 }

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260403143048_add_immunization_variables.ts
@@ -1,0 +1,25 @@
+import { Kysely } from "kysely";
+import { dbNamespace, dbSchema } from "@/app/data/metadataDb/utils/db-config";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    if (dbSchema() !== "extended") {
+        console.log(`${dbSchema()} schema detected. Skipping extended migration.`);
+        return;
+    }
+
+    const _db = db.withSchema(dbNamespace());
+    await _db.schema
+        .createTable("ecr_immunizations")
+        .addColumn("uuid", "varchar(200)", (cb) => cb.primaryKey())
+        .addColumn("eicr_id", "varchar(200)")
+        .addColumn("name", "varchar(255)")
+        .addColumn("administration_date", "date")
+        .addForeignKeyConstraint("ecr_immunizations_fk_eicr_id", ["eicr_id"],
+            "ecr_data",["eicr_id"])
+        .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    const _db = db.withSchema(dbNamespace());
+    await _db.schema.dropTable("ecr_immunizations").ifExists().execute();
+}

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
@@ -4,5 +4,5 @@ export default {
   "20250612143900_compound_pks.ts": require("./20250612143900_compound_pks"),
   "20251114100000_lab_qual_varchar_max": require("./20251114100000_lab_qual_varchar_max"),
   "20260320162000_add_ehr_extended": require("./20260320162000_add_ehr_extended"),
-  "20260403143048_add_immunization_variables.ts": require("./20260403143048_add_immunization_variables"),
+  "20260403143048_add_immunization_variables": require("./20260403143048_add_immunization_variables"),
 };

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
@@ -4,4 +4,5 @@ export default {
   "20250612143900_compound_pks.ts": require("./20250612143900_compound_pks"),
   "20251114100000_lab_qual_varchar_max": require("./20251114100000_lab_qual_varchar_max"),
   "20260320162000_add_ehr_extended": require("./20260320162000_add_ehr_extended"),
+  "20260403143048_add_immunization_variables.ts": require("./20260403143048_add_immunization_variables"),
 };

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/service.ts
@@ -282,6 +282,20 @@ const saveExtendedMetadata = async (
         .execute();
     }
   }
+
+  if (metadata.immunizations) {
+    for (const immunization of metadata.immunizations) {
+      await trx
+        .insertInto("ecr_immunizations")
+        .values({
+          uuid: randomUUID(),
+          eicr_id: ecrId,
+          administration_date: asDate(immunization.administration_date),
+          name: immunization.name,
+        })
+        .execute();
+    }
+  }
 };
 
 /**

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/types.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/types.ts
@@ -35,6 +35,12 @@ interface Lab {
   specimen_collection_date: string | undefined;
 }
 
+interface Immunization {
+  uuid: string | undefined;
+  name: string | undefined;
+  administration_date: string | undefined;
+}
+
 interface ruleSummary {
   rule_summary: string;
 }
@@ -81,6 +87,7 @@ export interface BundleExtendedMetadata extends BundleMetadata {
   reason_for_visit: string | undefined;
   active_problems: string | undefined;
   labs: Lab[] | undefined;
+  immunizations: Immunization[] | undefined;
   birth_sex: string | undefined;
   gender_identity: string | undefined;
   homelessness_status: string | undefined;

--- a/containers/ecr-viewer/src/app/data/metadataDb/types/extended.ts
+++ b/containers/ecr-viewer/src/app/data/metadataDb/types/extended.ts
@@ -79,6 +79,13 @@ export interface ecr_labs {
   performing_lab: string | undefined;
 }
 
+export interface ecr_immunizations {
+  uuid: Generated<string>;
+  eicr_id: string;
+  name: string | undefined;
+  administration_date: Date | undefined;
+}
+
 export type ExtendedECR = Selectable<extended_ecr_data>;
 export type NewExtendedECR = Insertable<extended_ecr_data>;
 
@@ -88,8 +95,12 @@ export type NewPatientAddress = Insertable<patient_address>;
 export type ECRLabs = Selectable<ecr_labs>;
 export type NewECRLabs = Insertable<ecr_labs>;
 
+export type ImmunizationLabs = Selectable<ecr_immunizations>;
+export type NewImmunizationLabs = Insertable<ecr_immunizations>;
+
 export interface Extended extends Core {
   ecr_data: extended_ecr_data;
   patient_address: patient_address;
   ecr_labs: ecr_labs;
+  ecr_immunizations: ecr_immunizations;
 }

--- a/containers/ecr-viewer/src/app/data/metadataDb/types/extended.ts
+++ b/containers/ecr-viewer/src/app/data/metadataDb/types/extended.ts
@@ -95,8 +95,8 @@ export type NewPatientAddress = Insertable<patient_address>;
 export type ECRLabs = Selectable<ecr_labs>;
 export type NewECRLabs = Insertable<ecr_labs>;
 
-export type ImmunizationLabs = Selectable<ecr_immunizations>;
-export type NewImmunizationLabs = Insertable<ecr_immunizations>;
+export type ECRImmunizations = Selectable<ecr_immunizations>;
+export type NewECRImmunizations = Insertable<ecr_immunizations>;
 
 export interface Extended extends Core {
   ecr_data: extended_ecr_data;

--- a/containers/ecr-viewer/tests/integration/helpers/ddl.ts
+++ b/containers/ecr-viewer/tests/integration/helpers/ddl.ts
@@ -9,7 +9,7 @@ import { dbSchema } from "@/app/data/metadataDb/utils/db-config";
  */
 export const dropExisting = async () => {
   if (dbSchema()) {
-    await migrateDown("all");
+    migrateDown("all");
   }
 };
 

--- a/containers/ecr-viewer/tests/integration/helpers/ddl.ts
+++ b/containers/ecr-viewer/tests/integration/helpers/ddl.ts
@@ -4,12 +4,13 @@ import { Core } from "@/app/data/metadataDb/types/core";
 import { Extended } from "@/app/data/metadataDb/types/extended";
 import { dbSchema } from "@/app/data/metadataDb/utils/db-config";
 
+
 /**
  * Drops the common schema tables
  */
 export const dropExisting = async () => {
   if (dbSchema()) {
-    migrateDown("all");
+    await migrateDown("all");
   }
 };
 
@@ -58,6 +59,7 @@ export const clearExtended = async () => {
   const db = getDb<Extended>();
   await db.deleteFrom("patient_address").execute();
   await db.deleteFrom("ecr_labs").execute();
+  await db.deleteFrom("ecr_immunizations").execute();
   await clearCore();
 };
 
@@ -68,5 +70,6 @@ export const clearEcrExtended = async () => {
   const db = getDb<Extended>();
   await db.deleteFrom("patient_address").execute();
   await db.deleteFrom("ecr_labs").execute();
+  await db.deleteFrom("ecr_immunizations").execute();
   await clearEcrCore();
 };

--- a/containers/ecr-viewer/tests/integration/helpers/ddl.ts
+++ b/containers/ecr-viewer/tests/integration/helpers/ddl.ts
@@ -4,7 +4,6 @@ import { Core } from "@/app/data/metadataDb/types/core";
 import { Extended } from "@/app/data/metadataDb/types/extended";
 import { dbSchema } from "@/app/data/metadataDb/utils/db-config";
 
-
 /**
  * Drops the common schema tables
  */

--- a/containers/ecr-viewer/tests/integration/helpers/extended.ts
+++ b/containers/ecr-viewer/tests/integration/helpers/extended.ts
@@ -1,5 +1,9 @@
 import { getDb } from "@/app/data/metadataDb/database";
-import { NewExtendedECR, Extended } from "@/app/data/metadataDb/types/extended";
+import {
+  NewExtendedECR,
+  Extended,
+  NewECRImmunizations,
+} from "@/app/data/metadataDb/types/extended";
 
 /**
  * Creates an eICR object
@@ -8,4 +12,18 @@ import { NewExtendedECR, Extended } from "@/app/data/metadataDb/types/extended";
  */
 export async function createExtendedEcr(ecr: NewExtendedECR): Promise<void> {
   await getDb<Extended>().insertInto("ecr_data").values(ecr).execute();
+}
+
+/**
+ * Creates an ecr immunization object
+ * @param immunization - the NewImmunizationLabs to be persisted
+ * @returns promise
+ */
+export async function createEcrImmunization(
+  immunization: NewECRImmunizations,
+): Promise<void> {
+  await getDb<Extended>()
+    .insertInto("ecr_immunizations")
+    .values(immunization)
+    .execute();
 }

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -8,7 +8,10 @@ import {
   getLastAuditLog,
 } from "../helpers/core";
 import { buildExtended, dropExisting, clearEcrExtended } from "../helpers/ddl";
-import { createExtendedEcr } from "../helpers/extended";
+import {
+  createExtendedEcr,
+  createEcrImmunization,
+} from "../helpers/extended";
 import { seedUserProgramData } from "../helpers/seed";
 import { NewExtendedECR } from "@/app/data/metadataDb/types/extended";
 import {

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/extended.test.ts
@@ -8,10 +8,7 @@ import {
   getLastAuditLog,
 } from "../helpers/core";
 import { buildExtended, dropExisting, clearEcrExtended } from "../helpers/ddl";
-import {
-  createExtendedEcr,
-  createEcrImmunization,
-} from "../helpers/extended";
+import { createExtendedEcr, createEcrImmunization } from "../helpers/extended";
 import { seedUserProgramData } from "../helpers/seed";
 import { NewExtendedECR } from "@/app/data/metadataDb/types/extended";
 import {

--- a/containers/ecr-viewer/tests/integration/saveFhirDataService/extended.test.ts
+++ b/containers/ecr-viewer/tests/integration/saveFhirDataService/extended.test.ts
@@ -78,6 +78,7 @@ const baseExtendedMetadata: BundleExtendedMetadata = {
       specimen_collection_date: "2024-01-01",
     },
   ],
+  immunizations: [],
   birth_sex: "Chill Guy",
   gender_identity: "Chiller Guy",
   homelessness_status: "Not Homeless",
@@ -289,6 +290,38 @@ describe("saveFhirData - extended", () => {
     expect(resp.status).toEqual(500);
     expect(rolledBack).toBeTrue();
     expect(res).toHaveLength(0);
+  });
+
+  it("should save immunizations", async () => {
+    const metadata: BundleExtendedMetadata = {
+      ...baseExtendedMetadata,
+      immunizations: [
+        {
+          uuid: undefined,
+          name: "COVID-19 Vaccine",
+          administration_date: "2023-06-15",
+        },
+      ],
+    };
+
+    const resp = await saveFhirMetadata(
+      "1-2-3-4",
+      "extended",
+      metadata,
+      makePromiseResolveWithStatus(200),
+      () => makePromiseResolveWithStatus(200),
+    );
+
+    expect(resp.status).toEqual(200);
+
+    const immunizations = await getDb<Extended>()
+      .selectFrom("ecr_immunizations")
+      .selectAll()
+      .execute();
+
+    expect(immunizations).toHaveLength(1);
+    expect(immunizations[0].name).toEqual("COVID-19 Vaccine");
+    expect(immunizations[0].eicr_id).toEqual("1-2-3-4");
   });
 
   it("should return an error and roll back db when fhir bundle save fails", async () => {

--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -193,7 +193,7 @@
     "nullable": true,
     "secondary_schema": {
       "name": {
-        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "fhir_path": "Immunization.vaccineCode.coding.display | Immunization.vaccineCode.text",
         "data_type": "string",
         "nullable": true
       },

--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -187,6 +187,23 @@
       }
     }
   },
+  "immunizations": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType='Immunization')",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "name": {
+        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "data_type": "string",
+        "nullable": true
+      },
+      "administration_date": {
+        "fhir_path": "Immunization.occurrenceDateTime",
+        "data_type": "datetime",
+        "nullable": true
+      }
+    }
+  },
   "labs": {
     "fhir_path": "Bundle.entry.resource.where(resourceType='Observation').where(category.coding.code='laboratory')",
     "data_type": "array",

--- a/containers/message-parser/app/default_schemas/ecr_with_metadata.json
+++ b/containers/message-parser/app/default_schemas/ecr_with_metadata.json
@@ -261,7 +261,7 @@
     "nullable": true,
     "secondary_schema": {
       "name": {
-        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "fhir_path": "Immunization.vaccineCode.coding.display | Immunization.vaccineCode.text",
         "data_type": "string",
         "nullable": true
       },

--- a/containers/message-parser/app/default_schemas/ecr_with_metadata.json
+++ b/containers/message-parser/app/default_schemas/ecr_with_metadata.json
@@ -255,6 +255,23 @@
       }
     }
   },
+  "immunizations": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType='Immunization')",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "name": {
+        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "data_type": "string",
+        "nullable": true
+      },
+      "administration_date": {
+        "fhir_path": "Immunization.occurrenceDateTime",
+        "data_type": "datetime",
+        "nullable": true
+      }
+    }
+  },
   "labs": {
     "fhir_path": "Bundle.entry.resource.where(resourceType='Observation').where(category.coding.code='laboratory')",
     "data_type": "array",

--- a/containers/message-parser/app/default_schemas/extended.json
+++ b/containers/message-parser/app/default_schemas/extended.json
@@ -196,7 +196,7 @@
     "nullable": true,
     "secondary_schema": {
       "name": {
-        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "fhir_path": "Immunization.vaccineCode.coding.display | Immunization.vaccineCode.text",
         "data_type": "string",
         "nullable": true
       },

--- a/containers/message-parser/app/default_schemas/extended.json
+++ b/containers/message-parser/app/default_schemas/extended.json
@@ -190,6 +190,23 @@
     "data_type": "array",
     "nullable": true
   },
+  "immunizations": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType='Immunization')",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "name": {
+        "fhir_path": "Immunization.vaccineCode.coding.display",
+        "data_type": "string",
+        "nullable": true
+      },
+      "administration_date": {
+        "fhir_path": "Immunization.occurrenceDateTime",
+        "data_type": "datetime",
+        "nullable": true
+      }
+    }
+  },
   "labs": {
     "fhir_path": "Bundle.entry.resource.where(resourceType='Observation').where(category.coding.code='laboratory')",
     "data_type": "array",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "lint": "cd containers/ecr-viewer && eslint --ext=.ts,.tsx --fix . && cd ../..",
-    "typecheck": "cd containers/ecr-viewer && tsc --noEmit && cd ../.."
+    "typecheck": "cd containers/ecr-viewer && tsc --noEmit && cd ../..",
+    "migration:create": "cd containers/ecr-viewer && node scripts/create-migration.mjs"
   },
   "devDependencies": {
     "@dword-design/eslint-plugin-import-alias": "^5.1.1",


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

UAT request

- Add Immunization variables to the extended schema `immunization name` and `administered date`
- Update integration tests, documentation, and schemas

## Related Issue

Fixes #1335 

## Acceptance Criteria

- [ ] Immunization variables added to extended schema

## Additional Information

Migrations will need to run for this release.
Added a script that generates kysely migration files
Updated readme to include instructions on how to create new kysely migration files.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
