### PR TITLE
perf: Reduce lag on Viewer - Pt. 2 Patient Info

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -230,19 +230,19 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientRace: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('ombCategory').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('ombCategory').value",
   },
   patientRaceDetailed: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('detailed').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('detailed').value",
   },
   patientEthnicity: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension('ombCategory').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension('ombCategory').value",
   },
   patientEthnicityDetailed: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension('detailed').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension('detailed').value",
   },
   patientCommunication: {
     type: "PatientCommunication",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -260,7 +260,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "PatientContact",
     path: "Patient.contact",
   },
-  // TODO ANGELA: many to many
+  // TODO ANGELA: many finds many
   patientGuardian: {
     type: "RelatedPerson",
     path: "entry.resource.RelatedPerson.where(relationship.coding.exists(system = 'http://terminology.hl7.org/CodeSystem/v3-RoleCode' and code = 'GUARD'))",
@@ -310,15 +310,15 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientGenderIdentity: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-genderidentity-extension').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-genderidentity-extension').value",
   },
   patientReligion: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/StructureDefinition/patient-religion').value",
+    path: "Patient.extension('http://hl7.org/fhir/StructureDefinition/patient-religion').value",
   },
   patientMaritalStatus: {
     type: "ValueX",
-    path: "entry.resource.Patient.maritalStatus",
+    path: "Patient.maritalStatus",
   },
   patientNationality: {
     type: "ValueX",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -195,22 +195,22 @@ export interface FhirPath<K> {
 // Make sure the "type" here matches the type-land type described in `PathTypes`
 // "name" field is added programmatically below
 const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
+  // Demographics
   patientNameList: {
     type: "HumanName",
     path: "Patient.name",
   },
   patientAddressList: {
     type: "Address",
-    path: "entry.resource.Patient.address",
+    path: "Patient.address",
   },
   patientTelecom: {
     type: "ContactPoint",
-    path: "entry.resource.Patient.telecom",
+    path: "Patient.telecom",
   },
-
   patientIds: {
     type: "string",
-    path: "entry.resource.Patient.identifier.where(system != 'urn:ietf:rfc:3986').value.join('\n')",
+    path: "Patient.identifier.where(system != 'urn:ietf:rfc:3986').value.join('\n')",
   },
   patientDOB: {
     type: "string",
@@ -246,7 +246,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientCommunication: {
     type: "PatientCommunication",
-    path: "entry.resource.Patient.communication",
+    path: "Patient.communication",
   },
   patientProficiencyExtension: {
     type: "Extension",
@@ -254,12 +254,13 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientTribalAffiliation: {
     type: "ValueX",
-    path: "entry.resource.Patient.extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension('TribeName').value",
+    path: "Patient.extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension('TribeName').value",
   },
   patientEmergencyContact: {
     type: "PatientContact",
-    path: "entry.resource.Patient.contact",
+    path: "Patient.contact",
   },
+  // TODO ANGELA: many to many
   patientGuardian: {
     type: "RelatedPerson",
     path: "entry.resource.RelatedPerson.where(relationship.coding.exists(system = 'http://terminology.hl7.org/CodeSystem/v3-RoleCode' and code = 'GUARD'))",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -197,7 +197,7 @@ export interface FhirPath<K> {
 const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   patientNameList: {
     type: "HumanName",
-    path: "entry.resource.Patient.name",
+    path: "Patient.name",
   },
   patientAddressList: {
     type: "Address",
@@ -214,7 +214,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientDOB: {
     type: "string",
-    path: "entry.resource.Patient.birthDate",
+    path: "Patient.birthDate",
   },
   patientVitalStatus: {
     type: "boolean",
@@ -226,7 +226,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientGender: {
     type: "string",
-    path: "entry.resource.Patient.gender",
+    path: "Patient.gender",
   },
   patientRace: {
     type: "ValueX",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -260,7 +260,6 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "PatientContact",
     path: "Patient.contact",
   },
-  // TODO ANGELA: many finds many
   patientGuardian: {
     type: "RelatedPerson",
     path: "entry.resource.RelatedPerson.where(relationship.coding.exists(system = 'http://terminology.hl7.org/CodeSystem/v3-RoleCode' and code = 'GUARD'))",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -218,11 +218,11 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   patientVitalStatus: {
     type: "boolean",
-    path: "entry.resource.Patient.deceasedBoolean",
+    path: "Patient.deceasedBoolean",
   },
   patientDOD: {
     type: "string",
-    path: "entry.resource.Patient.deceasedDate",
+    path: "Patient.deceasedDate",
   },
   patientGender: {
     type: "string",

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -41,7 +41,7 @@ export const getEcrDocumentAccordionItems = (
   fhirIndex: FhirIndex,
 ): AccordionItem[] => {
   const demographicsData = evaluateDemographicsData(fhirBundle, fhirIndex);
-  const socialData = evaluateSocialData(fhirBundle);
+  const socialData = evaluateSocialData(fhirBundle, fhirIndex);
   const pregnancyData = evaluatePregnancyData(fhirBundle);
   const hospitalEncounterData = evaluateHospitalEncounterData(fhirBundle);
   const encounterData = evaluateEncounterData(fhirBundle);

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -40,13 +40,13 @@ export const getEcrDocumentAccordionItems = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
 ): AccordionItem[] => {
-  const demographicsData = evaluateDemographicsData(fhirBundle);
+  const demographicsData = evaluateDemographicsData(fhirBundle, fhirIndex);
   const socialData = evaluateSocialData(fhirBundle);
   const pregnancyData = evaluatePregnancyData(fhirBundle);
   const hospitalEncounterData = evaluateHospitalEncounterData(fhirBundle);
   const encounterData = evaluateEncounterData(fhirBundle);
   const providerData = evaluateProviderData(fhirBundle);
-  const clinicalData = evaluateClinicalData(fhirBundle);
+  const clinicalData = evaluateClinicalData(fhirBundle, fhirIndex);
   const ecrMetadata = evaluateEcrMetadata(fhirBundle);
   const facilityData = evaluateFacilityData(fhirBundle);
   const diagnosticReports = getResourcesByType<DiagnosticReport>(

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -77,7 +77,10 @@ import { FhirIndex } from "../../services/fhirResourcesIndexService";
  * @property {DisplayDataProps[]} vitalData - Vital signs data.
  * @property {DisplayDataProps[]} immunizationsDetails - Immunization details.
  */
-export const evaluateClinicalData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+export const evaluateClinicalData = (
+  fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
+) => {
   const clinicalNotesTooltip =
     "Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.";
   const clinicalNotes: DisplayDataProps[] = [

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/app/view-data/components/common";
 import { sortResourcesByDate } from "../../utils/fhir-data-utils";
 import { ExpandCollapseAccordion } from "@/app/components/ExpandCollapseAccordion";
+import { FhirIndex } from "../../services/fhirResourcesIndexService";
 
 /**
  * Evaluates clinical data from the FHIR bundle and formats it into structured data for display.
@@ -76,7 +77,7 @@ import { ExpandCollapseAccordion } from "@/app/components/ExpandCollapseAccordio
  * @property {DisplayDataProps[]} vitalData - Vital signs data.
  * @property {DisplayDataProps[]} immunizationsDetails - Immunization details.
  */
-export const evaluateClinicalData = (fhirBundle: Bundle) => {
+export const evaluateClinicalData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
   const clinicalNotesTooltip =
     "Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.";
   const clinicalNotes: DisplayDataProps[] = [
@@ -100,6 +101,7 @@ export const evaluateClinicalData = (fhirBundle: Bundle) => {
       title: "Problems List",
       value: returnProblemsTable(
         fhirBundle,
+        fhirIndex,
         evaluateAll(fhirBundle, fhirPathMappings.activeProblems),
       ),
     },

--- a/containers/ecr-viewer/src/app/view-data/components/common.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/common.tsx
@@ -14,7 +14,10 @@ import { safeParse } from "@/app/utils/data-utils";
 import { evaluateReference } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { makePlural } from "@/app/utils/format-utils";
-import { calculatePatientAge, getPatient } from "@/app/view-data/services/evaluateFhirDataService";
+import {
+  calculatePatientAge,
+  getPatient,
+} from "@/app/view-data/services/evaluateFhirDataService";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
 
 import EvaluateTable, { ColumnInfoInput } from "./EvaluateTable";
@@ -161,7 +164,7 @@ type ConditionWithFormattedOnsetAge = Omit<Condition, "onsetAge"> & {
 const createFormattedCondition = (
   condition: Condition,
   fhirBundle: Bundle,
-  fhirIndex: FhirIndex
+  fhirIndex: FhirIndex,
 ): ConditionWithFormattedOnsetAge => {
   const formattedOnsetDateTime = formatDateTime(condition.onsetDateTime);
 
@@ -172,7 +175,7 @@ const createFormattedCondition = (
       condition.onsetAge,
       formattedOnsetDateTime,
       fhirBundle,
-      fhirIndex
+      fhirIndex,
     ),
   };
 
@@ -183,7 +186,7 @@ const getFormattedOnsetAge = (
   onsetAge: Condition["onsetAge"],
   onsetDateTime: Condition["onsetDateTime"],
   fhirBundle: Bundle,
-  fhirIndex: FhirIndex
+  fhirIndex: FhirIndex,
 ) => {
   const patient = getPatient(fhirIndex);
 

--- a/containers/ecr-viewer/src/app/view-data/components/common.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/common.tsx
@@ -14,11 +14,12 @@ import { safeParse } from "@/app/utils/data-utils";
 import { evaluateReference } from "@/app/utils/evaluate";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { makePlural } from "@/app/utils/format-utils";
-import { calculatePatientAge } from "@/app/view-data/services/evaluateFhirDataService";
+import { calculatePatientAge, getPatient } from "@/app/view-data/services/evaluateFhirDataService";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
 
 import EvaluateTable, { ColumnInfoInput } from "./EvaluateTable";
 import { FieldValue } from "./FieldValue";
+import { FhirIndex } from "../services/fhirResourcesIndexService";
 
 type ModifiedImmunization = Omit<Immunization, "manufacturer"> & {
   manufacturer?: Reference & {
@@ -101,6 +102,7 @@ export const returnImmunizations = (
  */
 export const returnProblemsTable = (
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
   problemsArray: Condition[],
 ): React.JSX.Element | undefined => {
   problemsArray = problemsArray.filter((entry) =>
@@ -128,7 +130,7 @@ export const returnProblemsTable = (
   ];
 
   const conditions: ConditionWithFormattedOnsetAge[] = problemsArray.map((pr) =>
-    createFormattedCondition(pr, fhirBundle),
+    createFormattedCondition(pr, fhirBundle, fhirIndex),
   );
 
   if (conditions.length === 0) {
@@ -159,6 +161,7 @@ type ConditionWithFormattedOnsetAge = Omit<Condition, "onsetAge"> & {
 const createFormattedCondition = (
   condition: Condition,
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex
 ): ConditionWithFormattedOnsetAge => {
   const formattedOnsetDateTime = formatDateTime(condition.onsetDateTime);
 
@@ -169,6 +172,7 @@ const createFormattedCondition = (
       condition.onsetAge,
       formattedOnsetDateTime,
       fhirBundle,
+      fhirIndex
     ),
   };
 
@@ -179,7 +183,10 @@ const getFormattedOnsetAge = (
   onsetAge: Condition["onsetAge"],
   onsetDateTime: Condition["onsetDateTime"],
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex
 ) => {
+  const patient = getPatient(fhirIndex);
+
   // when an onset age value is provided in the patient data (in years) we'll use that
   if (onsetAge?.value) {
     return {
@@ -190,6 +197,6 @@ const getFormattedOnsetAge = (
   if (!onsetDateTime) return undefined;
 
   return {
-    value: formatAge(calculatePatientAge(fhirBundle, onsetDateTime)),
+    value: formatAge(calculatePatientAge(patient, onsetDateTime)),
   };
 };

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -14,6 +14,7 @@ import SideNav from "./components/SideNav";
 import {
   evaluatePatientDOB,
   evaluatePatientName,
+  getPatient,
 } from "./services/evaluateFhirDataService";
 import { getFhirData, isSuccessResponse } from "./services/fhirDataService";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
@@ -63,8 +64,10 @@ const ECRViewerPage = async ({
 
   const fhirBundle = resp.payload.fhirBundle;
   const fhirIndex = getFhirIndex(fhirBundle);
-  const patientName = evaluatePatientName(fhirBundle, true);
-  const patientDOB = evaluatePatientDOB(fhirBundle);
+
+  const patient = getPatient(fhirIndex);
+  const patientName = evaluatePatientName(patient, true);
+  const patientDOB = evaluatePatientDOB(patient);
 
   const accordionItems = getEcrDocumentAccordionItems(fhirBundle, fhirIndex);
   return (
@@ -81,7 +84,7 @@ const ECRViewerPage = async ({
         </div>
         <EcrSummary
           patientDetails={
-            evaluateEcrSummaryPatientDetails(fhirBundle).availableData
+            evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex).availableData
           }
           encounterDetails={
             evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
@@ -89,7 +92,7 @@ const ECRViewerPage = async ({
           conditionSummary={evaluateEcrSummaryConditionSummary(
             fhirBundle,
             fhirIndex,
-            snomedCode,
+            snomedCode
           )}
           snomed={snomedCode}
         />

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -84,7 +84,8 @@ const ECRViewerPage = async ({
         </div>
         <EcrSummary
           patientDetails={
-            evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex).availableData
+            evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex)
+              .availableData
           }
           encounterDetails={
             evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
@@ -92,7 +93,7 @@ const ECRViewerPage = async ({
           conditionSummary={evaluateEcrSummaryConditionSummary(
             fhirBundle,
             fhirIndex,
-            snomedCode
+            snomedCode,
           )}
           snomed={snomedCode}
         />

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -102,13 +102,13 @@ export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle, fhirIndex: 
     {
       title: "Patient Address",
       value: formatCurrentAddress(
-        evaluateAll(fhirBundle, fhirPathMappings.patientAddressList),
+        evaluateAll(patient, fhirPathMappings.patientAddressList),
       ),
     },
     {
       title: "Patient Contact",
       value: formatContactPoint(
-        evaluateAll(fhirBundle, fhirPathMappings.patientTelecom),
+        evaluateAll(patient, fhirPathMappings.patientTelecom),
       ),
     },
     ...parentGuardian,

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -58,11 +58,14 @@ import { FhirIndex, getResourcesByType } from "./fhirResourcesIndexService";
  * @param fhirBundle - The FHIR bundle containing patient data.
  * @returns An array of patient details objects containing title and value pairs.
  */
-export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+export const evaluateEcrSummaryPatientDetails = (
+  fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
+) => {
   const patient = getPatient(fhirIndex);
 
   const patientSex = toTitleCase(
-    evaluateOne(patient, fhirPathMappings.patientGender)
+    evaluateOne(patient, fhirPathMappings.patientGender),
   );
   const age = calculatePatientAge(patient);
   const parentGuardian =

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -93,11 +93,11 @@ export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle, fhirIndex: 
     },
     {
       title: "Race",
-      value: evaluatePatientRace(fhirBundle),
+      value: evaluatePatientRace(patient),
     },
     {
       title: "Ethnicity",
-      value: evaluatePatientEthnicity(fhirBundle),
+      value: evaluatePatientEthnicity(patient),
     },
     {
       title: "Patient Address",

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -46,6 +46,8 @@ import {
   calculatePatientAge,
   evaluateEncounterDiagnosis,
   getLocationName,
+  getPatient,
+  evaluatePatientDOB,
 } from "./evaluateFhirDataService";
 import { evaluateLabInfoData } from "./labsService";
 import { getReportabilityRulesReasons } from "./reportabilityService";
@@ -56,12 +58,13 @@ import { FhirIndex, getResourcesByType } from "./fhirResourcesIndexService";
  * @param fhirBundle - The FHIR bundle containing patient data.
  * @returns An array of patient details objects containing title and value pairs.
  */
-export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle) => {
-  const patientSex = toTitleCase(
-    evaluateOne(fhirBundle, fhirPathMappings.patientGender),
-  );
+export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+  const patient = getPatient(fhirIndex);
 
-  const age = calculatePatientAge(fhirBundle);
+  const patientSex = toTitleCase(
+    evaluateOne(patient, fhirPathMappings.patientGender)
+  );
+  const age = calculatePatientAge(patient);
   const parentGuardian =
     !age || age.years < 18
       ? [
@@ -77,11 +80,11 @@ export const evaluateEcrSummaryPatientDetails = (fhirBundle: Bundle) => {
   return evaluateData([
     {
       title: "Patient Name",
-      value: evaluatePatientName(fhirBundle, false),
+      value: evaluatePatientName(patient, false),
     },
     {
       title: "DOB",
-      value: formatDate(evaluateOne(fhirBundle, fhirPathMappings.patientDOB)),
+      value: evaluatePatientDOB(patient),
     },
     {
       title: "Sex",
@@ -226,6 +229,7 @@ export const evaluateEcrSummaryConditionSummary = (
       ),
       clinicalDetails: evaluateEcrSummaryRelevantClinicalDetails(
         fhirBundle,
+        fhirIndex,
         conditionsListKey,
       ),
       labDetails: evaluateEcrSummaryRelevantLabResults(
@@ -268,6 +272,7 @@ const getRelevantResources = <T extends DomainResource>(
  */
 export const evaluateEcrSummaryRelevantClinicalDetails = (
   fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
   snomedCode: string,
 ): DisplayDataProps[] => {
   if (!snomedCode) {
@@ -283,6 +288,7 @@ export const evaluateEcrSummaryRelevantClinicalDetails = (
 
   const problemsElement = returnProblemsTable(
     fhirBundle,
+    fhirIndex,
     problemsListFiltered as Condition[],
   );
 

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -296,13 +296,13 @@ export const censorGender = (gender: string | undefined) => {
  * @param fhirBundle - The FHIR bundle containing patient contact info.
  * @returns - The patient's race information, including race OMB category and detailed extension (if available).
  */
-export const evaluatePatientRace = (fhirBundle: Bundle) => {
+export const evaluatePatientRace = (patient: Patient | undefined) => {
   const raceCat: string = evaluateValue(
-    fhirBundle,
+    patient,
     fhirPathMappings.patientRace,
   );
   const raceDetailed: string = evaluateValue(
-    fhirBundle,
+    patient,
     fhirPathMappings.patientRaceDetailed,
   );
 
@@ -314,15 +314,17 @@ export const evaluatePatientRace = (fhirBundle: Bundle) => {
  * @param fhirBundle - The FHIR bundle containing patient contact info.
  * @returns - The patient's ethnicity information, including additional ethnicity extension (if available).
  */
-export const evaluatePatientEthnicity = (fhirBundle: Bundle) => {
+export const evaluatePatientEthnicity = (patient: Patient | undefined) => {
   const ethnicity: string = evaluateValue(
-    fhirBundle,
-    fhirPathMappings.patientEthnicity,
+    patient,
+    fhirPathMappings.patientEthnicity
   );
   const ethnicityDetailed = evaluateValue(
-    fhirBundle,
-    fhirPathMappings.patientEthnicityDetailed,
+    patient,
+    fhirPathMappings.patientEthnicityDetailed
   );
+  console.log("eth: ", ethnicity);
+  console.log("eth detailed: ", ethnicityDetailed);
 
   return [ethnicity, ethnicityDetailed].filter(Boolean).join("\n");
 };
@@ -421,11 +423,11 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     },
     {
       title: "Race",
-      value: evaluatePatientRace(fhirBundle),
+      value: evaluatePatientRace(patient),
     },
     {
       title: "Ethnicity",
-      value: evaluatePatientEthnicity(fhirBundle),
+      value: evaluatePatientEthnicity(patient),
     },
     {
       title: "Tribal Affiliation",

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -323,8 +323,6 @@ export const evaluatePatientEthnicity = (patient: Patient | undefined) => {
     patient,
     fhirPathMappings.patientEthnicityDetailed
   );
-  console.log("eth: ", ethnicity);
-  console.log("eth detailed: ", ethnicityDetailed);
 
   return [ethnicity, ethnicityDetailed].filter(Boolean).join("\n");
 };
@@ -711,7 +709,9 @@ export const evaluateOccupationHistory = (fhirBundle: Bundle) => {
  * @param fhirBundle - The FHIR bundle containing social data.
  * @returns An array of evaluated and formatted social data.
  */
-export const evaluateSocialData = (fhirBundle: Bundle) => {
+export const evaluateSocialData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+  const patient = getPatient(fhirIndex);
+
   const socialData: DisplayDataProps[] = [
     {
       title: "Exposure Contacts",
@@ -753,11 +753,11 @@ export const evaluateSocialData = (fhirBundle: Bundle) => {
     },
     {
       title: "Religious Affiliation",
-      value: evaluateValue(fhirBundle, fhirPathMappings.patientReligion),
+      value: evaluateValue(patient, fhirPathMappings.patientReligion),
     },
     {
       title: "Marital Status",
-      value: evaluateValue(fhirBundle, fhirPathMappings.patientMaritalStatus),
+      value: evaluateValue(patient, fhirPathMappings.patientMaritalStatus),
     },
     {
       title: "Nationality",

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -82,8 +82,11 @@ import { FhirIndex, getOneResourceByType, getResourcesByType } from "./fhirResou
 // Patient Info: Demographics
 // =============================================================================
 
-// TODO ANGELA 2: Add test
-// TODO ANGELA 2: Add JSDoc
+/**
+ * Finds patient resource from FHIR bundle
+ * @param fhirIndex - FHIR resources indexed by tpe & by ID
+ * @returns Patient resource if it exists, or undefined if not
+ */
 export const getPatient = (
   fhirIndex: FhirIndex
 ): Patient | undefined => {

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -76,7 +76,7 @@ import {
   evaluateTravelHistoryTable,
   returnDisabilityStatusTable,
 } from "./socialHistoryService";
-import { FhirIndex, getOneResourceByType } from "./fhirResourcesIndexService";
+import { FhirIndex, getOneResourceByType, getResourcesByType } from "./fhirResourcesIndexService";
 
 // =============================================================================
 // Patient Info: Demographics
@@ -334,9 +334,9 @@ export const evaluatePatientEthnicity = (patient: Patient | undefined) => {
  * @param fhirBundle - The FHIR bundle containing resources.
  * @returns String containing language, proficiency, and mode
  */
-export const evaluatePatientLanguage = (fhirBundle: Bundle) => {
+export const evaluatePatientLanguage = (patient: Patient | undefined) => {
   let patientCommunication = evaluateAll(
-    fhirBundle,
+    patient,
     fhirPathMappings.patientCommunication,
   );
   const preferredPatientCommunication = patientCommunication.filter(
@@ -377,9 +377,9 @@ export const evaluatePatientLanguage = (fhirBundle: Bundle) => {
  * @param fhirBundle - The FHIR bundle containing patient contact info.
  * @returns The formatted patient address
  */
-export const evaluatePatientAddress = (fhirBundle: Bundle) => {
+export const evaluatePatientAddress = (patient: Patient | undefined) => {
   const addresses = evaluateAll(
-    fhirBundle,
+    patient,
     fhirPathMappings.patientAddressList,
   );
 
@@ -393,6 +393,7 @@ export const evaluatePatientAddress = (fhirBundle: Bundle) => {
  */
 export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
   const patient = getPatient(fhirIndex);
+  const resourcesRelatedPerson = getResourcesByType<RelatedPerson>(fhirIndex, "RelatedPerson");
 
   const patientSex = toTitleCase(
     evaluateOne(patient, fhirPathMappings.patientGender)
@@ -432,28 +433,28 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     {
       title: "Tribal Affiliation",
       value: evaluateValue(
-        fhirBundle,
+        patient,
         fhirPathMappings.patientTribalAffiliation
       ),
     },
     {
       title: "Preferred Language",
-      value: evaluatePatientLanguage(fhirBundle),
+      value: evaluatePatientLanguage(patient),
     },
     {
       title: "Patient Address",
-      value: evaluatePatientAddress(fhirBundle),
+      value: evaluatePatientAddress(patient),
     },
     {
       title: "Recent County",
       value: findCurrentAddress(
-        evaluateAll(fhirBundle, fhirPathMappings.patientAddressList)
+        evaluateAll(patient, fhirPathMappings.patientAddressList)
       )?.district,
     },
     {
       title: "Contact",
       value: formatContactPoint(
-        evaluateAll(fhirBundle, fhirPathMappings.patientTelecom)
+        evaluateAll(patient, fhirPathMappings.patientTelecom)
       ),
     },
     {
@@ -466,14 +467,14 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     {
       title: "Emergency Contact",
       value: formatPatientContactList(
-        evaluateAll(fhirBundle, fhirPathMappings.patientEmergencyContact)
+        evaluateAll(patient, fhirPathMappings.patientEmergencyContact)
       ),
     },
     {
       title: "Patient IDs",
       toolTip:
         "Unique patient identifier(s) from their medical record. For example, a patient's social security number or medical record number.",
-      value: evaluateValue(fhirBundle, fhirPathMappings.patientIds),
+      value: evaluateValue(patient, fhirPathMappings.patientIds),
     },
   ];
   return evaluateData(demographicsData);

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -193,10 +193,10 @@ export const createPatientAgeDataProp = (
   let value;
 
   // If patient has death date, return empty object
-  if (isPatientDeceased(fhirBundle)) {
+  if (isPatientDeceased(patient)) {
     title = "Age at Death";
     const patientDODString = evaluateOne(
-      fhirBundle,
+      patient,
       fhirPathMappings.patientDOD,
     );
     if (patientDOBString && patientDODString) {
@@ -259,8 +259,8 @@ export const createPatientAgeDataProp = (
  * @param fhirBundle The FHIR bundle containing the patient's vital status
  * @returns The vital status of the patient, either `Alive`, `Deceased`, or `""` (if not found)
  */
-export const evaluatePatientVitalStatus = (fhirBundle: Bundle) => {
-  const isDeceased = isPatientDeceased(fhirBundle);
+export const evaluatePatientVitalStatus = (patient: Patient | undefined) => {
+  const isDeceased = isPatientDeceased(patient);
   if (isDeceased === undefined) {
     return "";
   } else {
@@ -272,12 +272,12 @@ export const evaluatePatientVitalStatus = (fhirBundle: Bundle) => {
  * A patient is deceased if `patient.deceasedBoolean` is true or if there is a date of death. If both are `undefined`
  * return `undefined`.
  */
-const isPatientDeceased = (fhirBundle: Bundle) => {
+const isPatientDeceased = (patient: Patient | undefined) => {
   const vitalStatus = evaluateOne(
-    fhirBundle,
+    patient,
     fhirPathMappings.patientVitalStatus,
   );
-  const dod = evaluateOne(fhirBundle, fhirPathMappings.patientDOD);
+  const dod = evaluateOne(patient, fhirPathMappings.patientDOD);
 
   return dod ? true : vitalStatus;
 };
@@ -408,11 +408,11 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     createPatientAgeDataProp(fhirBundle, patient),
     {
       title: "Vital Status",
-      value: evaluatePatientVitalStatus(fhirBundle),
+      value: evaluatePatientVitalStatus(patient),
     },
     {
       title: "Date of Death",
-      value: evaluateOne(fhirBundle, fhirPathMappings.patientDOD),
+      value: evaluateOne(patient, fhirPathMappings.patientDOD),
     },
     {
       title: "Sex",

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -9,6 +9,7 @@ import {
   Encounter,
   Location,
   Organization,
+  Patient,
   Practitioner,
   PractitionerRole,
   RelatedPerson,
@@ -75,10 +76,19 @@ import {
   evaluateTravelHistoryTable,
   returnDisabilityStatusTable,
 } from "./socialHistoryService";
+import { FhirIndex, getOneResourceByType } from "./fhirResourcesIndexService";
 
 // =============================================================================
 // Patient Info: Demographics
 // =============================================================================
+
+// TODO ANGELA 2: Add test
+// TODO ANGELA 2: Add JSDoc
+export const getPatient = (
+  fhirIndex: FhirIndex
+): Patient | undefined => {
+  return getOneResourceByType<Patient>(fhirIndex, "Patient");
+}
 
 /**
  * Evaluates patient name from the FHIR bundle and formats it into structured data for display.
@@ -87,10 +97,10 @@ import {
  * @returns The formatted patient name
  */
 export const evaluatePatientName = (
-  fhirBundle: Bundle,
+  patient: Patient | undefined,
   isPatientBanner: boolean,
 ) => {
-  const nameList = evaluateAll(fhirBundle, fhirPathMappings.patientNameList);
+  const nameList = evaluateAll(patient, fhirPathMappings.patientNameList);
 
   // Return early if there's no name
   if (nameList.length === 0) {
@@ -110,8 +120,8 @@ export const evaluatePatientName = (
  * @param fhirBundle - The FHIR bundle containing patient information.
  * @returns - The formatted patient DOB.
  */
-export const evaluatePatientDOB = (fhirBundle: Bundle) =>
-  formatDate(evaluateOne(fhirBundle, fhirPathMappings.patientDOB));
+export const evaluatePatientDOB = (patient: Patient | undefined) =>
+  formatDate(evaluateOne(patient, fhirPathMappings.patientDOB));
 
 /**
  * Calculates the patient's age at a specific point in time or the current date.
@@ -120,10 +130,10 @@ export const evaluatePatientDOB = (fhirBundle: Bundle) =>
  * @returns The patient's age in years, or undefined if patient has no birth date.
  */
 export const calculatePatientAge = (
-  fhirBundle: Bundle,
+  patient: Patient | undefined,
   givenDate?: string,
 ): Age | undefined => {
-  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
+  const patientDOBString = evaluateOne(patient, fhirPathMappings.patientDOB);
 
   // If no patient DOB is available, return undefined.
   if (!patientDOBString) {
@@ -170,12 +180,13 @@ const calculateAge = (laterDate: DateTime, earlierDate: DateTime): Age => {
  */
 export const createPatientAgeDataProp = (
   fhirBundle: Bundle,
+  patient: Patient | undefined,
 ): DisplayDataProps => {
   const encounter = evaluateOneReference<Encounter>(
     fhirBundle,
     fhirPathMappings.compositionEncounterRef,
   );
-  const patientDOBString = evaluateOne(fhirBundle, fhirPathMappings.patientDOB);
+  const patientDOBString = evaluateOne(patient, fhirPathMappings.patientDOB);
 
   let title = "Age at Encounter";
   let toolTip;
@@ -189,7 +200,7 @@ export const createPatientAgeDataProp = (
       fhirPathMappings.patientDOD,
     );
     if (patientDOBString && patientDODString) {
-      value = formatAge(calculatePatientAge(fhirBundle, patientDODString));
+      value = formatAge(calculatePatientAge(patient, patientDODString));
     }
 
     return {
@@ -201,7 +212,7 @@ export const createPatientAgeDataProp = (
 
   // Handle encounter start date
   if (encounter?.period?.start) {
-    value = formatAge(calculatePatientAge(fhirBundle, encounter.period.start));
+    value = formatAge(calculatePatientAge(patient, encounter.period.start));
     return { title, toolTip, value };
   }
 
@@ -212,11 +223,11 @@ export const createPatientAgeDataProp = (
     if (encounterEnd <= DateTime.now()) {
       toolTip =
         "Age at end date of encounter. Start date of encounter is not available.";
-      value = formatAge(calculatePatientAge(fhirBundle, encounter.period.end));
+      value = formatAge(calculatePatientAge(patient, encounter.period.end));
     } else {
       value = formatAge(
         calculatePatientAge(
-          fhirBundle,
+          patient,
           evaluateOne(fhirBundle, fhirPathMappings.dateTimeEcrCreated),
         ),
       );
@@ -231,7 +242,7 @@ export const createPatientAgeDataProp = (
   // Handle no encounter dates
   value = formatAge(
     calculatePatientAge(
-      fhirBundle,
+      patient,
       evaluateOne(fhirBundle, fhirPathMappings.dateTimeEcrCreated),
     ),
   );
@@ -378,21 +389,23 @@ export const evaluatePatientAddress = (fhirBundle: Bundle) => {
  * @param fhirBundle - The FHIR bundle containing demographic data.
  * @returns An array of evaluated and formatted demographic data.
  */
-export const evaluateDemographicsData = (fhirBundle: Bundle) => {
+export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+  const patient = getPatient(fhirIndex);
+
   const patientSex = toTitleCase(
-    evaluateOne(fhirBundle, fhirPathMappings.patientGender),
+    evaluateOne(patient, fhirPathMappings.patientGender)
   );
 
   const demographicsData: DisplayDataProps[] = [
     {
       title: "Patient Name",
-      value: evaluatePatientName(fhirBundle, false),
+      value: evaluatePatientName(patient, false),
     },
     {
       title: "DOB",
-      value: evaluatePatientDOB(fhirBundle),
+      value: evaluatePatientDOB(patient),
     },
-    createPatientAgeDataProp(fhirBundle),
+    createPatientAgeDataProp(fhirBundle, patient),
     {
       title: "Vital Status",
       value: evaluatePatientVitalStatus(fhirBundle),
@@ -418,7 +431,7 @@ export const evaluateDemographicsData = (fhirBundle: Bundle) => {
       title: "Tribal Affiliation",
       value: evaluateValue(
         fhirBundle,
-        fhirPathMappings.patientTribalAffiliation,
+        fhirPathMappings.patientTribalAffiliation
       ),
     },
     {
@@ -432,26 +445,26 @@ export const evaluateDemographicsData = (fhirBundle: Bundle) => {
     {
       title: "Recent County",
       value: findCurrentAddress(
-        evaluateAll(fhirBundle, fhirPathMappings.patientAddressList),
+        evaluateAll(fhirBundle, fhirPathMappings.patientAddressList)
       )?.district,
     },
     {
       title: "Contact",
       value: formatContactPoint(
-        evaluateAll(fhirBundle, fhirPathMappings.patientTelecom),
+        evaluateAll(fhirBundle, fhirPathMappings.patientTelecom)
       ),
     },
     {
       title: "Parent/Guardian",
       value: formatPatientContactList(
         evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-        true,
+        true
       ),
     },
     {
       title: "Emergency Contact",
       value: formatPatientContactList(
-        evaluateAll(fhirBundle, fhirPathMappings.patientEmergencyContact),
+        evaluateAll(fhirBundle, fhirPathMappings.patientEmergencyContact)
       ),
     },
     {

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -76,7 +76,11 @@ import {
   evaluateTravelHistoryTable,
   returnDisabilityStatusTable,
 } from "./socialHistoryService";
-import { FhirIndex, getOneResourceByType, getResourcesByType } from "./fhirResourcesIndexService";
+import {
+  FhirIndex,
+  getOneResourceByType,
+  getResourcesByType,
+} from "./fhirResourcesIndexService";
 
 // =============================================================================
 // Patient Info: Demographics
@@ -87,11 +91,9 @@ import { FhirIndex, getOneResourceByType, getResourcesByType } from "./fhirResou
  * @param fhirIndex - FHIR resources indexed by tpe & by ID
  * @returns Patient resource if it exists, or undefined if not
  */
-export const getPatient = (
-  fhirIndex: FhirIndex
-): Patient | undefined => {
+export const getPatient = (fhirIndex: FhirIndex): Patient | undefined => {
   return getOneResourceByType<Patient>(fhirIndex, "Patient");
-}
+};
 
 /**
  * Evaluates patient name from the FHIR bundle and formats it into structured data for display.
@@ -198,10 +200,7 @@ export const createPatientAgeDataProp = (
   // If patient has death date, return empty object
   if (isPatientDeceased(patient)) {
     title = "Age at Death";
-    const patientDODString = evaluateOne(
-      patient,
-      fhirPathMappings.patientDOD,
-    );
+    const patientDODString = evaluateOne(patient, fhirPathMappings.patientDOD);
     if (patientDOBString && patientDODString) {
       value = formatAge(calculatePatientAge(patient, patientDODString));
     }
@@ -276,10 +275,7 @@ export const evaluatePatientVitalStatus = (patient: Patient | undefined) => {
  * return `undefined`.
  */
 const isPatientDeceased = (patient: Patient | undefined) => {
-  const vitalStatus = evaluateOne(
-    patient,
-    fhirPathMappings.patientVitalStatus,
-  );
+  const vitalStatus = evaluateOne(patient, fhirPathMappings.patientVitalStatus);
   const dod = evaluateOne(patient, fhirPathMappings.patientDOD);
 
   return dod ? true : vitalStatus;
@@ -300,10 +296,7 @@ export const censorGender = (gender: string | undefined) => {
  * @returns - The patient's race information, including race OMB category and detailed extension (if available).
  */
 export const evaluatePatientRace = (patient: Patient | undefined) => {
-  const raceCat: string = evaluateValue(
-    patient,
-    fhirPathMappings.patientRace,
-  );
+  const raceCat: string = evaluateValue(patient, fhirPathMappings.patientRace);
   const raceDetailed: string = evaluateValue(
     patient,
     fhirPathMappings.patientRaceDetailed,
@@ -320,11 +313,11 @@ export const evaluatePatientRace = (patient: Patient | undefined) => {
 export const evaluatePatientEthnicity = (patient: Patient | undefined) => {
   const ethnicity: string = evaluateValue(
     patient,
-    fhirPathMappings.patientEthnicity
+    fhirPathMappings.patientEthnicity,
   );
   const ethnicityDetailed = evaluateValue(
     patient,
-    fhirPathMappings.patientEthnicityDetailed
+    fhirPathMappings.patientEthnicityDetailed,
   );
 
   return [ethnicity, ethnicityDetailed].filter(Boolean).join("\n");
@@ -379,10 +372,7 @@ export const evaluatePatientLanguage = (patient: Patient | undefined) => {
  * @returns The formatted patient address
  */
 export const evaluatePatientAddress = (patient: Patient | undefined) => {
-  const addresses = evaluateAll(
-    patient,
-    fhirPathMappings.patientAddressList,
-  );
+  const addresses = evaluateAll(patient, fhirPathMappings.patientAddressList);
 
   return formatAddressList(addresses);
 };
@@ -392,12 +382,18 @@ export const evaluatePatientAddress = (patient: Patient | undefined) => {
  * @param fhirBundle - The FHIR bundle containing demographic data.
  * @returns An array of evaluated and formatted demographic data.
  */
-export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+export const evaluateDemographicsData = (
+  fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
+) => {
   const patient = getPatient(fhirIndex);
-  const resourcesRelatedPerson = getResourcesByType<RelatedPerson>(fhirIndex, "RelatedPerson");
+  const resourcesRelatedPerson = getResourcesByType<RelatedPerson>(
+    fhirIndex,
+    "RelatedPerson",
+  );
 
   const patientSex = toTitleCase(
-    evaluateOne(patient, fhirPathMappings.patientGender)
+    evaluateOne(patient, fhirPathMappings.patientGender),
   );
 
   const demographicsData: DisplayDataProps[] = [
@@ -433,10 +429,7 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     },
     {
       title: "Tribal Affiliation",
-      value: evaluateValue(
-        patient,
-        fhirPathMappings.patientTribalAffiliation
-      ),
+      value: evaluateValue(patient, fhirPathMappings.patientTribalAffiliation),
     },
     {
       title: "Preferred Language",
@@ -449,26 +442,26 @@ export const evaluateDemographicsData = (fhirBundle: Bundle, fhirIndex: FhirInde
     {
       title: "Recent County",
       value: findCurrentAddress(
-        evaluateAll(patient, fhirPathMappings.patientAddressList)
+        evaluateAll(patient, fhirPathMappings.patientAddressList),
       )?.district,
     },
     {
       title: "Contact",
       value: formatContactPoint(
-        evaluateAll(patient, fhirPathMappings.patientTelecom)
+        evaluateAll(patient, fhirPathMappings.patientTelecom),
       ),
     },
     {
       title: "Parent/Guardian",
       value: formatPatientContactList(
         evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-        true
+        true,
       ),
     },
     {
       title: "Emergency Contact",
       value: formatPatientContactList(
-        evaluateAll(patient, fhirPathMappings.patientEmergencyContact)
+        evaluateAll(patient, fhirPathMappings.patientEmergencyContact),
       ),
     },
     {
@@ -712,7 +705,10 @@ export const evaluateOccupationHistory = (fhirBundle: Bundle) => {
  * @param fhirBundle - The FHIR bundle containing social data.
  * @returns An array of evaluated and formatted social data.
  */
-export const evaluateSocialData = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
+export const evaluateSocialData = (
+  fhirBundle: Bundle,
+  fhirIndex: FhirIndex,
+) => {
   const patient = getPatient(fhirIndex);
 
   const socialData: DisplayDataProps[] = [

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -39,8 +39,6 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
     const resourceType = resource?.resourceType;
     const resourceId = resource?.id;
 
-    // TODO ANGELA 2: Is this assumption correct? Some of the tests don't have resourceId, 
-    // so I have to add to those test fixtures to get them to work
     if (resourceType && resourceId) {
       // by Type (array)
       fhirIndexByType[resourceType] ??= [];
@@ -65,7 +63,6 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
  * @returns Array of FHIR resources of type `T`, or empty array if
  * no resources of specified type exist.
  */
-// TODO ANGELA 2: Rename to getAllResourcesByType
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],
@@ -89,7 +86,6 @@ export function getResourcesByType<T extends Resource>(
  * no resources of specified type exist.
  * @error When multiple resources are found for the resource type
  */
-// TODO ANGELA 2: Add test
 export function getOneResourceByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -39,6 +39,8 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
     const resourceType = resource?.resourceType;
     const resourceId = resource?.id;
 
+    // TODO ANGELA 2: Is this assumption correct? Some of the tests don't have resourceId, 
+    // so I have to add to those test fixtures to get them to work
     if (resourceType && resourceId) {
       // by Type (array)
       fhirIndexByType[resourceType] ??= [];

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -94,7 +94,7 @@ export function getOneResourceByType<T extends Resource>(
 
   if (resourceMap && resourceMap.length > 1) {
     throw new Error(
-      `Expected one result of type ${type}, but got ${resourceMap.length}.`
+      `Expected one result of type ${type}, but got ${resourceMap.length}.`,
     );
   }
 
@@ -102,7 +102,7 @@ export function getOneResourceByType<T extends Resource>(
     return undefined;
   }
 
-  return (resourceMap[0]) as T;
+  return resourceMap[0] as T;
 }
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/fhirResourcesIndexService.tsx
@@ -63,6 +63,7 @@ export const getFhirIndex = (fhirBundle: Bundle): FhirIndex => {
  * @returns Array of FHIR resources of type `T`, or empty array if
  * no resources of specified type exist.
  */
+// TODO ANGELA 2: Rename to getAllResourcesByType
 export function getResourcesByType<T extends Resource>(
   fhirIndex: FhirIndex,
   type: T["resourceType"],
@@ -72,6 +73,38 @@ export function getResourcesByType<T extends Resource>(
   if (!resourceMap) return [];
 
   return resourceMap as T[];
+}
+
+/**
+ * Returns a single resources of a specific type (i.e. "Patient").
+ * Expects one result or none. If multiple results, will error.
+ *
+ * @template T - The expected FHIR Resource type (e.g. Patient).
+ * @param fhirIndex - FHIR resources indexed by type & by ID
+ * @param type - The resourceType to retrieve (e.g., "Patient").
+ *
+ * @returns A single FHIR resource of type `T`, or undefined if
+ * no resources of specified type exist.
+ * @error When multiple resources are found for the resource type
+ */
+// TODO ANGELA 2: Add test
+export function getOneResourceByType<T extends Resource>(
+  fhirIndex: FhirIndex,
+  type: T["resourceType"],
+): T | undefined {
+  const resourceMap = fhirIndex.fhirIndexByType[type];
+
+  if (resourceMap && resourceMap.length > 1) {
+    throw new Error(
+      `Expected one result of type ${type}, but got ${resourceMap.length}.`
+    );
+  }
+
+  if (!resourceMap || resourceMap.length === 0) {
+    return undefined;
+  }
+
+  return (resourceMap[0]) as T;
 }
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -56,6 +56,7 @@ import { FieldValue } from "@/app/view-data/components/FieldValue";
 import { sortResourcesByDate } from "@/app/view-data/utils/fhir-data-utils";
 import {
   FhirIndex,
+  getOneResourceByType,
   getResourcesByType,
 } from "@/app/view-data/services/fhirResourcesIndexService";
 
@@ -239,11 +240,10 @@ export const getJsonLab = (
  */
 export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
-  // TODO ANGELA 2: Change call to get composition to use getOneResourceByType
-  const compositionLabs = getResourcesByType<Composition>(
+  const compositionLabs = getOneResourceByType<Composition>(
     fhirIndex,
-    "Composition",
-  )[0];
+    "Composition"
+  );
   const labsString = evaluateValue(
     compositionLabs,
     fhirPathMappings.labResultDiv,

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -239,6 +239,7 @@ export const getJsonLab = (
  */
 export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
+  // TODO ANGELA 2: Change call to get composition to use getOneResourceByType
   const compositionLabs = getResourcesByType<Composition>(
     fhirIndex,
     "Composition",

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -242,7 +242,7 @@ export const getAllLabJsonObjects = (fhirIndex: FhirIndex): HtmlTableJson[] => {
   // Get lab reports HTML String (for all lab reports) & convert to JSON
   const compositionLabs = getOneResourceByType<Composition>(
     fhirIndex,
-    "Composition"
+    "Composition",
   );
   const labsString = evaluateValue(
     compositionLabs,

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/ActiveProblems.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/ActiveProblems.test.tsx
@@ -2,8 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { Bundle, Condition } from "fhir/r4";
 import { axe } from "jest-axe";
 
-import BundleWithPatient from "../../../../../../../test-data/fhir/BundlePatient.json";
+import _BundleWithPatient from "../../../../../../../test-data/fhir/BundlePatient.json";
 import { returnProblemsTable } from "@/app/view-data/components/common";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+
+const BundleWithPatient = _BundleWithPatient as unknown as Bundle;
+const fhirIndexBundleWithPatient = getFhirIndex(BundleWithPatient);
 
 describe("Active Problems Table", () => {
   let container: HTMLElement;
@@ -235,7 +239,8 @@ describe("Active Problems Table", () => {
     ];
     container = render(
       returnProblemsTable(
-        BundleWithPatient as unknown as Bundle,
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
         activeProblemsData,
       )!,
     ).container;

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
@@ -11,9 +11,15 @@ import {
   evaluateNotes,
   returnProceduresTable,
 } from "@/app/view-data/components/EcrDocument/clinical-data";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
-const fhirBundleClinicalInfo = require("../../../../../../../test-data/fhir/BundleClinicalInfo.json");
-const testClinicalData = evaluateClinicalData(fhirBundleClinicalInfo);
+const BundleClinicalInfo = require("../../../../../../../test-data/fhir/BundleClinicalInfo.json") as unknown as Bundle;
+const fhirIndexBundleClinicalInfo = getFhirIndex(BundleClinicalInfo)
+
+const testClinicalData = evaluateClinicalData(
+  BundleClinicalInfo,
+  fhirIndexBundleClinicalInfo
+);
 
 const testImmunizationsData =
   testClinicalData.immunizationsDetails.availableData;

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
@@ -13,12 +13,13 @@ import {
 } from "@/app/view-data/components/EcrDocument/clinical-data";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
-const BundleClinicalInfo = require("../../../../../../../test-data/fhir/BundleClinicalInfo.json") as unknown as Bundle;
-const fhirIndexBundleClinicalInfo = getFhirIndex(BundleClinicalInfo)
+const BundleClinicalInfo =
+  require("../../../../../../../test-data/fhir/BundleClinicalInfo.json") as unknown as Bundle;
+const fhirIndexBundleClinicalInfo = getFhirIndex(BundleClinicalInfo);
 
 const testClinicalData = evaluateClinicalData(
   BundleClinicalInfo,
-  fhirIndexBundleClinicalInfo
+  fhirIndexBundleClinicalInfo,
 );
 
 const testImmunizationsData =

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -21,7 +21,9 @@ import {
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleAdmissionMedications = _BundleAdmissionMedications as Bundle;
-const fhirIndexBundleAdmissionMedications = getFhirIndex(BundleAdmissionMedications);
+const fhirIndexBundleAdmissionMedications = getFhirIndex(
+  BundleAdmissionMedications,
+);
 const BundleWithPatient = _BundleWithPatient as Bundle;
 const BundleWithMiscNotes = _BundleWithMiscNotes as Bundle;
 const fhirIndexBundleWithMiscNotes = getFhirIndex(BundleWithMiscNotes);
@@ -154,7 +156,7 @@ describe("Snapshot test for eCR Document", () => {
     it("should include dosage text when present", () => {
       const actual = evaluateClinicalData(
         BundleAdmissionMedications,
-        fhirIndexBundleAdmissionMedications
+        fhirIndexBundleAdmissionMedications,
       );
       const adminMedsItem = actual.treatmentData.availableData.find(
         (d) => d.title === "Administered Medications",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -5,11 +5,11 @@ import { Bundle } from "fhir/r4";
 import { axe } from "jest-axe";
 
 import BundleCareTeam from "@/../../../test-data/fhir/BundleCareTeam.json";
-import BundleWithMiscNotes from "@/../../../test-data/fhir/BundleMiscNotes.json";
+import * as _BundleWithMiscNotes from "@/../../../test-data/fhir/BundleMiscNotes.json";
 import * as _BundleWithPatient from "@/../../../test-data/fhir/BundlePatient.json";
-import BundleWithPendingResultsOnly from "@/../../../test-data/fhir/BundlePendingResultsOnly.json";
-import BundleWithPlannedMedsOnly from "@/../../../test-data/fhir/BundlePlannedMedsOnly.json";
-import BundleWithScheduledApptsOnly from "@/../../../test-data/fhir/BundleScheduledApptsOnly.json";
+import * as _BundleWithPendingResultsOnly from "@/../../../test-data/fhir/BundlePendingResultsOnly.json";
+import * as _BundleWithPlannedMedsOnly from "@/../../../test-data/fhir/BundlePlannedMedsOnly.json";
+import * as _BundleWithScheduledApptsOnly from "@/../../../test-data/fhir/BundleScheduledApptsOnly.json";
 import { DataDisplay } from "@/app/view-data/components/DataDisplay";
 import { EcrDocument } from "@/app/view-data/components/EcrDocument";
 import { getEcrDocumentAccordionItems } from "@/app/view-data/components/EcrDocument/accordion-items";
@@ -20,6 +20,12 @@ import {
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
+const BundleWithMiscNotes = _BundleWithMiscNotes as Bundle;
+const fhirIndexBundleWithMiscNotes = getFhirIndex(BundleWithMiscNotes);
+const BundleWithPendingResultsOnly = _BundleWithPendingResultsOnly as Bundle;
+const BundleWithPlannedMedsOnly = _BundleWithPlannedMedsOnly as Bundle;
+const BundleWithScheduledApptsOnly = _BundleWithScheduledApptsOnly as Bundle;
+
 
 describe("Snapshot test for eCR Document", () => {
   it("Given no data, info message for empty sections should appear", async () => {
@@ -75,7 +81,8 @@ describe("Snapshot test for eCR Document", () => {
   describe("Evaluate Clinical Info", () => {
     it("Should return notes", () => {
       const actual = evaluateClinicalData(
-        BundleWithMiscNotes as unknown as Bundle,
+        BundleWithMiscNotes,
+        fhirIndexBundleWithMiscNotes
       );
       render(actual.clinicalNotes.availableData[0].value as React.JSX.Element);
       expect(actual.clinicalNotes.availableData[0].title).toEqual(
@@ -86,13 +93,18 @@ describe("Snapshot test for eCR Document", () => {
     });
     it("Should not include Treatment details if medications is not available", () => {
       const actual = evaluateClinicalData(
-        BundleWithMiscNotes as unknown as Bundle,
+        BundleWithMiscNotes,
+        fhirIndexBundleWithMiscNotes
       );
       expect(actual.treatmentData.availableData).toBeEmpty();
     });
     it("Should return Plan of Treatment when only pending results", () => {
+      const fhirIndexBundleWithPendingResultsOnly = getFhirIndex(
+        BundleWithPendingResultsOnly
+      );
       const actual = evaluateClinicalData(
-        BundleWithPendingResultsOnly as unknown as Bundle,
+        BundleWithPendingResultsOnly,
+        fhirIndexBundleWithPendingResultsOnly
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",
@@ -103,8 +115,12 @@ describe("Snapshot test for eCR Document", () => {
       expect(container).toMatchSnapshot();
     });
     it("Should return Plan of Treatment when only scheduled appointments", () => {
+      const fhirIndexBundleWithScheduledApptsOnly = getFhirIndex(
+        BundleWithScheduledApptsOnly
+      );
       const actual = evaluateClinicalData(
-        BundleWithScheduledApptsOnly as unknown as Bundle,
+        BundleWithScheduledApptsOnly,
+        fhirIndexBundleWithScheduledApptsOnly
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",
@@ -115,8 +131,12 @@ describe("Snapshot test for eCR Document", () => {
       expect(container).toMatchSnapshot();
     });
     it("Should return Plan of Treatment when only ordered meds", () => {
+      const fhirIndexBundleWithPlannedMedsOnly = getFhirIndex(
+        BundleWithPlannedMedsOnly
+      );
       const actual = evaluateClinicalData(
-        BundleWithPlannedMedsOnly as unknown as Bundle,
+        BundleWithPlannedMedsOnly,
+        fhirIndexBundleWithPlannedMedsOnly
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -26,7 +26,6 @@ const BundleWithPendingResultsOnly = _BundleWithPendingResultsOnly as Bundle;
 const BundleWithPlannedMedsOnly = _BundleWithPlannedMedsOnly as Bundle;
 const BundleWithScheduledApptsOnly = _BundleWithScheduledApptsOnly as Bundle;
 
-
 describe("Snapshot test for eCR Document", () => {
   it("Given no data, info message for empty sections should appear", async () => {
     const bundleEmpty: Bundle = {
@@ -82,7 +81,7 @@ describe("Snapshot test for eCR Document", () => {
     it("Should return notes", () => {
       const actual = evaluateClinicalData(
         BundleWithMiscNotes,
-        fhirIndexBundleWithMiscNotes
+        fhirIndexBundleWithMiscNotes,
       );
       render(actual.clinicalNotes.availableData[0].value as React.JSX.Element);
       expect(actual.clinicalNotes.availableData[0].title).toEqual(
@@ -94,17 +93,17 @@ describe("Snapshot test for eCR Document", () => {
     it("Should not include Treatment details if medications is not available", () => {
       const actual = evaluateClinicalData(
         BundleWithMiscNotes,
-        fhirIndexBundleWithMiscNotes
+        fhirIndexBundleWithMiscNotes,
       );
       expect(actual.treatmentData.availableData).toBeEmpty();
     });
     it("Should return Plan of Treatment when only pending results", () => {
       const fhirIndexBundleWithPendingResultsOnly = getFhirIndex(
-        BundleWithPendingResultsOnly
+        BundleWithPendingResultsOnly,
       );
       const actual = evaluateClinicalData(
         BundleWithPendingResultsOnly,
-        fhirIndexBundleWithPendingResultsOnly
+        fhirIndexBundleWithPendingResultsOnly,
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",
@@ -116,11 +115,11 @@ describe("Snapshot test for eCR Document", () => {
     });
     it("Should return Plan of Treatment when only scheduled appointments", () => {
       const fhirIndexBundleWithScheduledApptsOnly = getFhirIndex(
-        BundleWithScheduledApptsOnly
+        BundleWithScheduledApptsOnly,
       );
       const actual = evaluateClinicalData(
         BundleWithScheduledApptsOnly,
-        fhirIndexBundleWithScheduledApptsOnly
+        fhirIndexBundleWithScheduledApptsOnly,
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",
@@ -132,11 +131,11 @@ describe("Snapshot test for eCR Document", () => {
     });
     it("Should return Plan of Treatment when only ordered meds", () => {
       const fhirIndexBundleWithPlannedMedsOnly = getFhirIndex(
-        BundleWithPlannedMedsOnly
+        BundleWithPlannedMedsOnly,
       );
       const actual = evaluateClinicalData(
         BundleWithPlannedMedsOnly,
-        fhirIndexBundleWithPlannedMedsOnly
+        fhirIndexBundleWithPlannedMedsOnly,
       );
       expect(actual.treatmentData.availableData[0].title).toEqual(
         "Plan of Treatment",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { Bundle } from "fhir/r4";
 import { axe } from "jest-axe";
 
-import BundleAdmissionMedications from "@/../../../test-data/fhir/BundleAdmissionMedications.json";
+import * as _BundleAdmissionMedications from "@/../../../test-data/fhir/BundleAdmissionMedications.json";
 import BundleCareTeam from "@/../../../test-data/fhir/BundleCareTeam.json";
 import * as _BundleWithMiscNotes from "@/../../../test-data/fhir/BundleMiscNotes.json";
 import * as _BundleWithPatient from "@/../../../test-data/fhir/BundlePatient.json";
@@ -20,6 +20,8 @@ import {
 } from "@/app/view-data/components/EcrDocument/clinical-data";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
+const BundleAdmissionMedications = _BundleAdmissionMedications as Bundle;
+const fhirIndexBundleAdmissionMedications = getFhirIndex(BundleAdmissionMedications);
 const BundleWithPatient = _BundleWithPatient as Bundle;
 const BundleWithMiscNotes = _BundleWithMiscNotes as Bundle;
 const fhirIndexBundleWithMiscNotes = getFhirIndex(BundleWithMiscNotes);
@@ -151,7 +153,8 @@ describe("Snapshot test for eCR Document", () => {
   describe("Evaluate Administered Medications", () => {
     it("should include dosage text when present", () => {
       const actual = evaluateClinicalData(
-        BundleAdmissionMedications as unknown as Bundle,
+        BundleAdmissionMedications,
+        fhirIndexBundleAdmissionMedications
       );
       const adminMedsItem = actual.treatmentData.availableData.find(
         (d) => d.title === "Administered Medications",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/utils.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/utils.test.tsx
@@ -20,7 +20,9 @@ import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService
 describe("Utils", () => {
   describe("Render Active Problem table", () => {
     it("should return empty if active problem name is undefined", () => {
-      const fhirIndex = getFhirIndex(BundleNoActiveProblems as unknown as Bundle);
+      const fhirIndex = getFhirIndex(
+        BundleNoActiveProblems as unknown as Bundle,
+      );
       const actual = returnProblemsTable(
         BundleNoActiveProblems as unknown as Bundle,
         fhirIndex,

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/utils.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/utils.test.tsx
@@ -15,12 +15,15 @@ import {
   ToolTipElement,
 } from "@/app/view-data/components/ToolTipElement";
 import { returnProblemsTable } from "@/app/view-data/components/common";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 describe("Utils", () => {
   describe("Render Active Problem table", () => {
     it("should return empty if active problem name is undefined", () => {
+      const fhirIndex = getFhirIndex(BundleNoActiveProblems as unknown as Bundle);
       const actual = returnProblemsTable(
         BundleNoActiveProblems as unknown as Bundle,
+        fhirIndex,
         evaluateAll(
           BundleNoActiveProblems as unknown as Bundle,
           fhirPathMappings.activeProblems,

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { Bundle } from "fhir/r4";
 
-import BundleWithClinicalInfo from "../../../../../../../test-data/fhir/BundleClinicalInfo.json";
+import _BundleWithClinicalInfo from "../../../../../../../test-data/fhir/BundleClinicalInfo.json";
 import _BundleEcrSummary from "../../../../../../../test-data/fhir/BundleEcrSummary.json";
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
-import BundlePatient from "../../../../../../../test-data/fhir/BundlePatient.json";
+import _BundlePatient from "../../../../../../../test-data/fhir/BundlePatient.json";
 import _BundleRRConditionValueString from "../../../../../../../test-data/fhir/BundleRRConditionValueString.json";
 import {
   evaluateEcrSummaryConditionSummary,
@@ -31,11 +31,18 @@ const fhirIndexBundleRRConditionValueString = getFhirIndex(
   BundleRRConditionValueString,
 );
 
+const BundlePatient = _BundlePatient as unknown as Bundle;
+const fhirIndexBundlePatient = getFhirIndex(BundlePatient);
+
+const BundleWithClinicalInfo = _BundleWithClinicalInfo as unknown as Bundle;
+const fhirIndexBundleWithClinicalInfo = getFhirIndex(BundleWithClinicalInfo);
+
 describe("ecrSummaryService Tests", () => {
   describe("Evaluate eCR Summary Relevant Clinical Details", () => {
     it("should return an empty list when no SNOMED code is provided", () => {
       const actual = evaluateEcrSummaryRelevantClinicalDetails(
-        BundleWithClinicalInfo as unknown as Bundle,
+        BundleWithClinicalInfo,
+        fhirIndexBundleWithClinicalInfo,
         "",
       );
 
@@ -44,7 +51,8 @@ describe("ecrSummaryService Tests", () => {
 
     it("should return an empty list when the provided SNOMED code has no matches", () => {
       const actual = evaluateEcrSummaryRelevantClinicalDetails(
-        BundleWithClinicalInfo as unknown as Bundle,
+        BundleWithClinicalInfo,
+        fhirIndexBundleWithClinicalInfo,
         "invalid-snomed-code",
       );
 
@@ -53,7 +61,8 @@ describe("ecrSummaryService Tests", () => {
 
     it("should return the correct active problem when the provided SNOMED code matches", () => {
       const result = evaluateEcrSummaryRelevantClinicalDetails(
-        BundleWithClinicalInfo as unknown as Bundle,
+        BundleWithClinicalInfo,
+        fhirIndexBundleWithClinicalInfo,
         "263133002",
       );
       expect(result).toHaveLength(1);
@@ -294,7 +303,8 @@ describe("ecrSummaryService Tests", () => {
   describe("Evaluate eCR Summary Patient Details", () => {
     it("should get all relevant patient details", () => {
       const actual = evaluateEcrSummaryPatientDetails(
-        BundlePatient as unknown as Bundle,
+        BundlePatient,
+        fhirIndexBundlePatient
       );
 
       expect(actual.unavailableData).toBeEmpty();
@@ -302,7 +312,8 @@ describe("ecrSummaryService Tests", () => {
 
     it("should not show parent/guardian info if adult", () => {
       const actual = evaluateEcrSummaryPatientDetails(
-        BundlePatient as unknown as Bundle,
+        BundlePatient,
+        fhirIndexBundlePatient
       );
 
       const guardian = actual.availableData.find(
@@ -320,15 +331,17 @@ describe("ecrSummaryService Tests", () => {
           {
             fullUrl: "urn:uuid:99999999-4p89-4b96-b6ab-c46406839cea",
             resource: {
-              ...BundlePatient.entry.at(0)?.resource,
+              ...BundlePatient.entry!.at(0)?.resource,
               birthDate: "2025-01-01",
             },
           },
-          ...BundlePatient.entry.slice(1),
+          ...BundlePatient.entry!.slice(1),
         ],
-      };
+      } as unknown as Bundle;
+      const fhirIndexBundle = getFhirIndex(bundle);
       const actual = evaluateEcrSummaryPatientDetails(
-        bundle as unknown as Bundle,
+        bundle,
+        fhirIndexBundle
       );
 
       const guardian = actual.availableData.find(

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -304,7 +304,7 @@ describe("ecrSummaryService Tests", () => {
     it("should get all relevant patient details", () => {
       const actual = evaluateEcrSummaryPatientDetails(
         BundlePatient,
-        fhirIndexBundlePatient
+        fhirIndexBundlePatient,
       );
 
       expect(actual.unavailableData).toBeEmpty();
@@ -313,7 +313,7 @@ describe("ecrSummaryService Tests", () => {
     it("should not show parent/guardian info if adult", () => {
       const actual = evaluateEcrSummaryPatientDetails(
         BundlePatient,
-        fhirIndexBundlePatient
+        fhirIndexBundlePatient,
       );
 
       const guardian = actual.availableData.find(
@@ -339,10 +339,7 @@ describe("ecrSummaryService Tests", () => {
         ],
       } as unknown as Bundle;
       const fhirIndexBundle = getFhirIndex(bundle);
-      const actual = evaluateEcrSummaryPatientDetails(
-        bundle,
-        fhirIndexBundle
-      );
+      const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
 
       const guardian = actual.availableData.find(
         (d) => d.title === "Parent/Guardian",

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -78,6 +78,36 @@ describe("evaluateFhirDataService tests", () => {
     const patientMultiple = getPatient(fhirIndexBundleWithPatientMultiple);
     const patientDeceased = getPatient(fhirIndexBundleWithDeceasedPatient);
 
+    describe("getPatient", () => {
+      it("should return the correct Patient resource", () => {
+        const resource1 = {
+          fullUrl: "urn:uuid:1",
+          resource: {
+            resourceType: "Patient",
+            id: "1",
+          },
+        };
+        const fhirIndexPatient = {
+          fhirIndexByType: {
+            Patient: [resource1.resource],
+          },
+          fhirIndexByTypeAndId: {
+            Patient: {
+              "1": resource1.resource,
+            },
+          },
+        };
+        const actual = getPatient(fhirIndexPatient);
+        expect(actual).toEqual(resource1.resource);
+      });
+
+      it("should return undefined of no Patient resource exists", () => {
+        const fhirIndexEmpty = {fhirIndexByType: {}, fhirIndexByTypeAndId: {}}
+        const actual = getPatient(fhirIndexEmpty);
+        expect(actual).toEqual(undefined);
+      });
+    });
+
     describe("Evaluate Patient Name", () => {
 
       it("should return the 1 name", () => {

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -61,15 +61,16 @@ const BundlePatientWithCovid = _BundlePatientWithCovid as Bundle;
 
 const BundleWithDeceasedPatient = _BundleWithDeceasedPatient as Bundle;
 const fhirIndexBundleWithDeceasedPatient = getFhirIndex(
-  BundleWithDeceasedPatient
+  BundleWithDeceasedPatient,
 );
 
 const BundleWithTravelHistory = _BundleWithTravelHistory as unknown as Bundle;
 const fhirIndexBundleWithTravelHistory = getFhirIndex(BundleWithTravelHistory);
 
-const BundleWithSexualOrientation = _BundleWithSexualOrientation as unknown as Bundle;
+const BundleWithSexualOrientation =
+  _BundleWithSexualOrientation as unknown as Bundle;
 const fhirIndexBundleWithSexualOrientation = getFhirIndex(
-  BundleWithSexualOrientation
+  BundleWithSexualOrientation,
 );
 
 describe("evaluateFhirDataService tests", () => {
@@ -102,16 +103,17 @@ describe("evaluateFhirDataService tests", () => {
       });
 
       it("should return undefined of no Patient resource exists", () => {
-        const fhirIndexEmpty = {fhirIndexByType: {}, fhirIndexByTypeAndId: {}}
+        const fhirIndexEmpty = {
+          fhirIndexByType: {},
+          fhirIndexByTypeAndId: {},
+        };
         const actual = getPatient(fhirIndexEmpty);
         expect(actual).toEqual(undefined);
       });
     });
 
     describe("Evaluate Patient Name", () => {
-
       it("should return the 1 name", () => {
-        
         const actual = evaluatePatientName(patient, false);
         expect(actual).toEqual("Han Solo");
       });
@@ -223,7 +225,7 @@ describe("evaluateFhirDataService tests", () => {
       it("should return Age at Death if there is a date of death", () => {
         const patientAgeProp = createPatientAgeDataProp(
           BundleWithDeceasedPatient,
-          patientDeceased
+          patientDeceased,
         );
         expect(patientAgeProp).toEqual({
           title: "Age at Death",
@@ -268,12 +270,14 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         };
-        const fhirIndexPatientBundleWithEncounter = getFhirIndex(patientBundleWithEncounter);
+        const fhirIndexPatientBundleWithEncounter = getFhirIndex(
+          patientBundleWithEncounter,
+        );
         const patientResource = getPatient(fhirIndexPatientBundleWithEncounter);
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
-          patientResource
+          patientResource,
         );
 
         expect(patientAgeProp).toEqual({
@@ -317,15 +321,13 @@ describe("evaluateFhirDataService tests", () => {
           ],
         };
         const fhirIndexPatientBundleWithEncounter = getFhirIndex(
-          patientBundleWithEncounter
+          patientBundleWithEncounter,
         );
-        const patientResource = getPatient(
-          fhirIndexPatientBundleWithEncounter
-        );
+        const patientResource = getPatient(fhirIndexPatientBundleWithEncounter);
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
-          patientResource
+          patientResource,
         );
 
         expect(patientAgeProp).toEqual({
@@ -373,15 +375,13 @@ describe("evaluateFhirDataService tests", () => {
           ],
         };
         const fhirIndexPatientBundleWithEncounter = getFhirIndex(
-          patientBundleWithEncounter
+          patientBundleWithEncounter,
         );
-        const patientResource = getPatient(
-          fhirIndexPatientBundleWithEncounter
-        );
+        const patientResource = getPatient(fhirIndexPatientBundleWithEncounter);
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
-          patientResource
+          patientResource,
         );
 
         expect(patientAgeProp).toEqual({
@@ -413,16 +413,15 @@ describe("evaluateFhirDataService tests", () => {
           ],
         };
         const fhirIndexPatientBundleWithCreatedDate = getFhirIndex(
-          patientBundleWithCreatedDate
+          patientBundleWithCreatedDate,
         );
         const patientResource = getPatient(
-          fhirIndexPatientBundleWithCreatedDate
+          fhirIndexPatientBundleWithCreatedDate,
         );
-
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithCreatedDate,
-          patientResource
+          patientResource,
         );
 
         expect(patientAgeProp).toEqual({
@@ -445,7 +444,10 @@ describe("evaluateFhirDataService tests", () => {
     });
 
     it("should return Tribal Affiliation if available", () => {
-      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
+      const actual = evaluateDemographicsData(
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
+      );
       const ext = actual.availableData.filter(
         (d) => d.title === "Tribal Affiliation",
       );
@@ -511,7 +513,9 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         } as unknown as Bundle;
-        const fhirIndexBundlePatientLanguage = getFhirIndex(bundlePatientLanguage);
+        const fhirIndexBundlePatientLanguage = getFhirIndex(
+          bundlePatientLanguage,
+        );
         const patientLanguage = getPatient(fhirIndexBundlePatientLanguage);
 
         const actual = evaluatePatientLanguage(patientLanguage);
@@ -555,7 +559,7 @@ describe("evaluateFhirDataService tests", () => {
           ],
         } as unknown as Bundle;
         const fhirIndexBundlePatientNoLanguage = getFhirIndex(
-          bundlePatientNoLanguage
+          bundlePatientNoLanguage,
         );
         const patientNoLanguage = getPatient(fhirIndexBundlePatientNoLanguage);
 
@@ -597,7 +601,10 @@ describe("evaluateFhirDataService tests", () => {
     });
 
     it("should return Parent/Guardian if available", () => {
-      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
+      const actual = evaluateDemographicsData(
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
+      );
       const ext = actual.availableData.filter(
         (d) => d.title === "Parent/Guardian",
       );
@@ -625,18 +632,31 @@ Home: 123-456-6909`,
     });
 
     it("should return all correct demographic info not covered by other tests", () => {
-      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
-      const expectedContact = [{"title": "Contact", "value": "Home: 555-555-5555\nfakefakenotreal@example.com"}];
+      const actual = evaluateDemographicsData(
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
+      );
+      const expectedContact = [
+        {
+          title: "Contact",
+          value: "Home: 555-555-5555\nfakefakenotreal@example.com",
+        },
+      ];
 
-      expect(actual.availableData.filter((d) => d.title === "Contact")).toEqual(expectedContact);
-      
+      expect(actual.availableData.filter((d) => d.title === "Contact")).toEqual(
+        expectedContact,
+      );
+
       console.log(actual);
     });
   });
 
   describe("Evaluate Patient Info: Social History", () => {
     it("should have no available data when there is no data", () => {
-      const actual = evaluateSocialData(undefined as any, {fhirIndexByType: {}, fhirIndexByTypeAndId: {}});
+      const actual = evaluateSocialData(undefined as any, {
+        fhirIndexByType: {},
+        fhirIndexByTypeAndId: {},
+      });
 
       expect(actual.availableData).toBeEmpty();
       expect(actual.unavailableData).not.toBeEmpty();
@@ -645,7 +665,7 @@ Home: 123-456-6909`,
     it("should have exposure contact when there is a exposure contact observation present", () => {
       const actual = evaluateSocialData(
         BundleWithTravelHistory,
-        fhirIndexBundleWithTravelHistory
+        fhirIndexBundleWithTravelHistory,
       );
 
       render(actual.availableData[0].value);
@@ -656,7 +676,7 @@ Home: 123-456-6909`,
     it("should have travel history when there is a travel history observation present", () => {
       const actual = evaluateSocialData(
         BundleWithTravelHistory,
-        fhirIndexBundleWithTravelHistory
+        fhirIndexBundleWithTravelHistory,
       );
 
       render(actual.availableData[1].value);
@@ -684,7 +704,7 @@ Home: 123-456-6909`,
     it("should have patient sexual orientation when available", () => {
       const actual = evaluateSocialData(
         BundleWithSexualOrientation,
-        fhirIndexBundleWithSexualOrientation
+        fhirIndexBundleWithSexualOrientation,
       );
 
       expect(actual.availableData[0].value).toEqual("Other");
@@ -1511,7 +1531,10 @@ Home: 123-456-6909`,
     });
 
     it("should return religion if available", () => {
-      const actual = evaluateSocialData(BundleWithPatient, fhirIndexBundleWithPatient);
+      const actual = evaluateSocialData(
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
+      );
       const ext = actual.availableData.filter(
         (d) => d.title === "Religious Affiliation",
       );
@@ -1520,7 +1543,10 @@ Home: 123-456-6909`,
     });
 
     it("should return marital status if available", () => {
-      const actual = evaluateSocialData(BundleWithPatient, fhirIndexBundleWithPatient);
+      const actual = evaluateSocialData(
+        BundleWithPatient,
+        fhirIndexBundleWithPatient,
+      );
       const ext = actual.availableData.filter(
         (d) => d.title === "Marital Status",
       );

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -394,12 +394,12 @@ describe("evaluateFhirDataService tests", () => {
     });
 
     it("should return race category and extension if available", () => {
-      const actual = evaluatePatientRace(BundleWithPatient);
+      const actual = evaluatePatientRace(patient);
       expect(actual).toEqual("Black or African American\nAfrican");
     });
 
     it("should return ethnicity category and extension if available", () => {
-      const actual = evaluatePatientEthnicity(BundleWithPatient);
+      const actual = evaluatePatientEthnicity(patient);
       expect(actual).toEqual("Hispanic or Latino\nWhite");
     });
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -133,30 +133,33 @@ describe("evaluateFhirDataService tests", () => {
           entry: [
             {
               resource: {
+                id: "1",
                 resourceType: "Patient",
                 deceasedBoolean: deceased,
               },
             },
           ],
-        };
+        } as unknown as Bundle;
       }
 
       it("should return an empty string when no `deceasedBoolean` value is present", () => {
-        const actual = evaluatePatientVitalStatus(BundleWithPatient);
+        const actual = evaluatePatientVitalStatus(patient);
         expect(actual).toEqual("");
       });
 
       it("should return `Alive` when `deceasedBoolean` is `false`", () => {
-        const actual = evaluatePatientVitalStatus(
-          getPatientBundle(false) as unknown as Bundle,
-        );
+        const bundleDeceasedFalse = getPatientBundle(false);
+        const fhirIndexDeceasedFalse = getFhirIndex(bundleDeceasedFalse);
+        const patientDeceasedFalse = getPatient(fhirIndexDeceasedFalse);
+        const actual = evaluatePatientVitalStatus(patientDeceasedFalse);
         expect(actual).toEqual("Alive");
       });
 
       it("should return `Deceased` when `deceasedBoolean` is `true`", () => {
-        const actual = evaluatePatientVitalStatus(
-          getPatientBundle(true) as unknown as Bundle,
-        );
+        const bundleDeceasedTrue = getPatientBundle(true);
+        const fhirIndexDeceasedTrue = getFhirIndex(bundleDeceasedTrue);
+        const patientDeceasedTrue = getPatient(fhirIndexDeceasedTrue);
+        const actual = evaluatePatientVitalStatus(patientDeceasedTrue);
         expect(actual).toEqual("Deceased");
       });
     });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -17,8 +17,8 @@ import * as _BundleWithDeceasedPatient from "@/../../../test-data/fhir/BundlePat
 import * as _BundlePatientMultiple from "@/../../../test-data/fhir/BundlePatientMultiple.json";
 import * as _BundlePatientWithCovid from "@/../../../test-data/fhir/BundlePatientWithCovid.json";
 import BundlePractitionerRole from "@/../../../test-data/fhir/BundlePractitionerRole.json";
-import BundleWithSexualOrientation from "@/../../../test-data/fhir/BundleSexualOrientation.json";
-import BundleWithTravelHistory from "@/../../../test-data/fhir/BundleTravelHistory.json";
+import * as _BundleWithSexualOrientation from "@/../../../test-data/fhir/BundleSexualOrientation.json";
+import * as _BundleWithTravelHistory from "@/../../../test-data/fhir/BundleTravelHistory.json";
 import { formatAge } from "@/app/services/formatService";
 import { evaluateValue } from "@/app/utils/evaluate";
 import mappings from "@/app/utils/evaluate/fhir-paths";
@@ -52,14 +52,25 @@ import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
 const fhirIndexBundleWithPatient = getFhirIndex(BundleWithPatient);
+
 const BundlePatientMultiple = _BundlePatientMultiple as unknown as Bundle;
 const fhirIndexBundleWithPatientMultiple = getFhirIndex(BundlePatientMultiple);
+
 const BundleWithAdmissionMedications = _BundleAdmissionMedications as Bundle;
+const BundlePatientWithCovid = _BundlePatientWithCovid as Bundle;
+
 const BundleWithDeceasedPatient = _BundleWithDeceasedPatient as Bundle;
 const fhirIndexBundleWithDeceasedPatient = getFhirIndex(
   BundleWithDeceasedPatient
 );
-const BundlePatientWithCovid = _BundlePatientWithCovid as Bundle;
+
+const BundleWithTravelHistory = _BundleWithTravelHistory as unknown as Bundle;
+const fhirIndexBundleWithTravelHistory = getFhirIndex(BundleWithTravelHistory);
+
+const BundleWithSexualOrientation = _BundleWithSexualOrientation as unknown as Bundle;
+const fhirIndexBundleWithSexualOrientation = getFhirIndex(
+  BundleWithSexualOrientation
+);
 
 describe("evaluateFhirDataService tests", () => {
   describe("Evaluate Patient Info: Demographics", () => {
@@ -595,7 +606,7 @@ Home: 123-456-6909`,
 
   describe("Evaluate Patient Info: Social History", () => {
     it("should have no available data when there is no data", () => {
-      const actual = evaluateSocialData(undefined as any);
+      const actual = evaluateSocialData(undefined as any, {fhirIndexByType: {}, fhirIndexByTypeAndId: {}});
 
       expect(actual.availableData).toBeEmpty();
       expect(actual.unavailableData).not.toBeEmpty();
@@ -603,7 +614,8 @@ Home: 123-456-6909`,
 
     it("should have exposure contact when there is a exposure contact observation present", () => {
       const actual = evaluateSocialData(
-        BundleWithTravelHistory as unknown as Bundle,
+        BundleWithTravelHistory,
+        fhirIndexBundleWithTravelHistory
       );
 
       render(actual.availableData[0].value);
@@ -613,7 +625,8 @@ Home: 123-456-6909`,
 
     it("should have travel history when there is a travel history observation present", () => {
       const actual = evaluateSocialData(
-        BundleWithTravelHistory as unknown as Bundle,
+        BundleWithTravelHistory,
+        fhirIndexBundleWithTravelHistory
       );
 
       render(actual.availableData[1].value);
@@ -640,7 +653,8 @@ Home: 123-456-6909`,
 
     it("should have patient sexual orientation when available", () => {
       const actual = evaluateSocialData(
-        BundleWithSexualOrientation as unknown as Bundle,
+        BundleWithSexualOrientation,
+        fhirIndexBundleWithSexualOrientation
       );
 
       expect(actual.availableData[0].value).toEqual("Other");
@@ -1467,7 +1481,7 @@ Home: 123-456-6909`,
     });
 
     it("should return religion if available", () => {
-      const actual = evaluateSocialData(BundleWithPatient as unknown as Bundle);
+      const actual = evaluateSocialData(BundleWithPatient, fhirIndexBundleWithPatient);
       const ext = actual.availableData.filter(
         (d) => d.title === "Religious Affiliation",
       );
@@ -1476,7 +1490,7 @@ Home: 123-456-6909`,
     });
 
     it("should return marital status if available", () => {
-      const actual = evaluateSocialData(BundleWithPatient as unknown as Bundle);
+      const actual = evaluateSocialData(BundleWithPatient, fhirIndexBundleWithPatient);
       const ext = actual.availableData.filter(
         (d) => d.title === "Marital Status",
       );

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -14,7 +14,7 @@ import * as _BundleAdmissionMedications from "@/../../../test-data/fhir/BundleAd
 import BundleEcrMetadata from "@/../../../test-data/fhir/BundleEcrMetadata.json";
 import * as _BundleWithPatient from "@/../../../test-data/fhir/BundlePatient.json";
 import * as _BundleWithDeceasedPatient from "@/../../../test-data/fhir/BundlePatientDeceased.json";
-import BundlePatientMultiple from "@/../../../test-data/fhir/BundlePatientMultiple.json";
+import * as _BundlePatientMultiple from "@/../../../test-data/fhir/BundlePatientMultiple.json";
 import * as _BundlePatientWithCovid from "@/../../../test-data/fhir/BundlePatientWithCovid.json";
 import BundlePractitionerRole from "@/../../../test-data/fhir/BundlePractitionerRole.json";
 import BundleWithSexualOrientation from "@/../../../test-data/fhir/BundleSexualOrientation.json";
@@ -46,38 +46,46 @@ import {
   getLocationName,
   evaluateEncounterDiagnosis,
   evaluateFacilityData,
+  getPatient,
 } from "@/app/view-data/services/evaluateFhirDataService";
+import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
+const fhirIndexBundleWithPatient = getFhirIndex(BundleWithPatient);
+const BundlePatientMultiple = _BundlePatientMultiple as unknown as Bundle;
+const fhirIndexBundleWithPatientMultiple = getFhirIndex(BundlePatientMultiple);
 const BundleWithAdmissionMedications = _BundleAdmissionMedications as Bundle;
 const BundleWithDeceasedPatient = _BundleWithDeceasedPatient as Bundle;
+const fhirIndexBundleWithDeceasedPatient = getFhirIndex(
+  BundleWithDeceasedPatient
+);
 const BundlePatientWithCovid = _BundlePatientWithCovid as Bundle;
 
 describe("evaluateFhirDataService tests", () => {
   describe("Evaluate Patient Info: Demographics", () => {
+    const patient = getPatient(fhirIndexBundleWithPatient);
+    const patientMultiple = getPatient(fhirIndexBundleWithPatientMultiple);
+    const patientDeceased = getPatient(fhirIndexBundleWithDeceasedPatient);
+
     describe("Evaluate Patient Name", () => {
+
       it("should return the 1 name", () => {
-        const actual = evaluatePatientName(BundleWithPatient, false);
+        
+        const actual = evaluatePatientName(patient, false);
         expect(actual).toEqual("Han Solo");
       });
       it("should return all 2 of the names", () => {
-        const actual = evaluatePatientName(
-          BundlePatientMultiple as unknown as Bundle,
-          false,
-        );
+        const actual = evaluatePatientName(patientMultiple, false);
         expect(actual).toEqual(
           "Official: Anakin Skywalker\n" + "Nickname: Darth Vader",
         );
       });
       it("should only return the official name for the banner", () => {
-        const actual = evaluatePatientName(
-          BundlePatientMultiple as unknown as Bundle,
-          true,
-        );
+        const actual = evaluatePatientName(patientMultiple, true);
         expect(actual).toEqual("Anakin Skywalker");
       });
       it("should only return the official name for the banner", () => {
-        const actual = evaluatePatientName(BundleWithPatient, true);
+        const actual = evaluatePatientName(patient, true);
         expect(actual).toEqual("Han Solo");
       });
     });
@@ -87,7 +95,7 @@ describe("evaluateFhirDataService tests", () => {
         // Fixed "today" for testing purposes
         jest.useFakeTimers().setSystemTime(new Date("2024-03-12"));
 
-        const patientAge = calculatePatientAge(BundleWithPatient);
+        const patientAge = calculatePatientAge(patient);
 
         expect(patientAge).toEqual({ years: 146, months: 9, days: 16 });
 
@@ -104,13 +112,13 @@ describe("evaluateFhirDataService tests", () => {
       it("when date is given, should return age at given date", () => {
         const givenDate = "2020-01-01";
 
-        const patientAge = calculatePatientAge(BundleWithPatient, givenDate);
+        const patientAge = calculatePatientAge(patient, givenDate);
 
         expect(patientAge).toEqual({ years: 142, months: 7, days: 7 });
       });
 
       it("should return a value that can display only in days", () => {
-        const patientAge = calculatePatientAge(BundleWithPatient, "1877-05-30");
+        const patientAge = calculatePatientAge(patient, "1877-05-30");
 
         const formattedPatientAge = formatAge(patientAge);
 
@@ -171,6 +179,7 @@ describe("evaluateFhirDataService tests", () => {
       it("should return Age at Death if there is a date of death", () => {
         const patientAgeProp = createPatientAgeDataProp(
           BundleWithDeceasedPatient,
+          patientDeceased
         );
         expect(patientAgeProp).toEqual({
           title: "Age at Death",
@@ -215,9 +224,12 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         };
+        const fhirIndexPatientBundleWithEncounter = getFhirIndex(patientBundleWithEncounter);
+        const patientResource = getPatient(fhirIndexPatientBundleWithEncounter);
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
+          patientResource
         );
 
         expect(patientAgeProp).toEqual({
@@ -260,9 +272,16 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         };
+        const fhirIndexPatientBundleWithEncounter = getFhirIndex(
+          patientBundleWithEncounter
+        );
+        const patientResource = getPatient(
+          fhirIndexPatientBundleWithEncounter
+        );
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
+          patientResource
         );
 
         expect(patientAgeProp).toEqual({
@@ -309,9 +328,16 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         };
+        const fhirIndexPatientBundleWithEncounter = getFhirIndex(
+          patientBundleWithEncounter
+        );
+        const patientResource = getPatient(
+          fhirIndexPatientBundleWithEncounter
+        );
 
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithEncounter,
+          patientResource
         );
 
         expect(patientAgeProp).toEqual({
@@ -342,8 +368,17 @@ describe("evaluateFhirDataService tests", () => {
             },
           ],
         };
+        const fhirIndexPatientBundleWithCreatedDate = getFhirIndex(
+          patientBundleWithCreatedDate
+        );
+        const patientResource = getPatient(
+          fhirIndexPatientBundleWithCreatedDate
+        );
+
+
         const patientAgeProp = createPatientAgeDataProp(
           patientBundleWithCreatedDate,
+          patientResource
         );
 
         expect(patientAgeProp).toEqual({
@@ -366,7 +401,7 @@ describe("evaluateFhirDataService tests", () => {
     });
 
     it("should return Tribal Affiliation if available", () => {
-      const actual = evaluateDemographicsData(BundleWithPatient);
+      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
       const ext = actual.availableData.filter(
         (d) => d.title === "Tribal Affiliation",
       );
@@ -512,7 +547,7 @@ describe("evaluateFhirDataService tests", () => {
     });
 
     it("should return Parent/Guardian if available", () => {
-      const actual = evaluateDemographicsData(BundleWithPatient);
+      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
       const ext = actual.availableData.filter(
         (d) => d.title === "Parent/Guardian",
       );

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -416,17 +416,18 @@ describe("evaluateFhirDataService tests", () => {
 
     describe("Evaluate Patient Language", () => {
       it("Should display language, proficiency, and mode", () => {
-        const actual = evaluatePatientLanguage(BundleWithPatient);
+        const actual = evaluatePatientLanguage(patient);
 
         expect(actual).toEqual("English\nGood\nExpressed spoken");
       });
 
       it("Should only display preferred languages", () => {
-        const patient = {
+        const bundlePatientLanguage = {
           resourceType: "Bundle",
           entry: [
             {
               resource: {
+                id: "1",
                 resourceType: "Patient",
                 communication: [
                   {
@@ -468,18 +469,21 @@ describe("evaluateFhirDataService tests", () => {
               },
             },
           ],
-        };
+        } as unknown as Bundle;
+        const fhirIndexBundlePatientLanguage = getFhirIndex(bundlePatientLanguage);
+        const patientLanguage = getPatient(fhirIndexBundlePatientLanguage);
 
-        const actual = evaluatePatientLanguage(patient as unknown as Bundle);
+        const actual = evaluatePatientLanguage(patientLanguage);
 
         expect(actual).toEqual("English\n\nHindi");
       });
       it("Should display language when there are no preferred languages", () => {
-        const patient = {
+        const bundlePatientNoLanguage = {
           resourceType: "Bundle",
           entry: [
             {
               resource: {
+                id: "1",
                 resourceType: "Patient",
                 communication: [
                   {
@@ -508,9 +512,13 @@ describe("evaluateFhirDataService tests", () => {
               },
             },
           ],
-        };
+        } as unknown as Bundle;
+        const fhirIndexBundlePatientNoLanguage = getFhirIndex(
+          bundlePatientNoLanguage
+        );
+        const patientNoLanguage = getPatient(fhirIndexBundlePatientNoLanguage);
 
-        const actual = evaluatePatientLanguage(patient as unknown as Bundle);
+        const actual = evaluatePatientLanguage(patientNoLanguage);
 
         expect(actual).toEqual("Spanish\n\nEnglish");
       });
@@ -523,13 +531,11 @@ describe("evaluateFhirDataService tests", () => {
         expect(actual).toBeEmpty();
       });
       it("should return the 1 address", () => {
-        const actual = evaluatePatientAddress(BundleWithPatient);
+        const actual = evaluatePatientAddress(patient);
         expect(actual).toEqual("1 Main St\nCloud City, CA 00000\nUS");
       });
       it("should return all 3 of the addresses", () => {
-        const actual = evaluatePatientAddress(
-          BundlePatientMultiple as unknown as Bundle,
-        );
+        const actual = evaluatePatientAddress(patientMultiple);
         expect(actual).toEqual(
           "Home:\n" +
             "1 Mos Espa\n" +
@@ -572,9 +578,18 @@ Home: 123-456-6909`,
     });
 
     it("should return the Patient Identifier value", () => {
-      const actual = evaluateValue(BundleWithPatient, mappings.patientIds);
+      const actual = evaluateValue(patient, mappings.patientIds);
 
       expect(actual).toEqual("1234567890");
+    });
+
+    it("should return all correct demographic info not covered by other tests", () => {
+      const actual = evaluateDemographicsData(BundleWithPatient, fhirIndexBundleWithPatient);
+      const expectedContact = [{"title": "Contact", "value": "Home: 555-555-5555\nfakefakenotreal@example.com"}];
+
+      expect(actual.availableData.filter((d) => d.title === "Contact")).toEqual(expectedContact);
+      
+      console.log(actual);
     });
   });
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -128,20 +128,21 @@ describe("fhirResourcesIndexService Tests", () => {
     it("Returns a single resource of a specified type", () => {
       const actual = getOneResourceByType<Composition>(
         fhirIndexBundleSample,
-        "Composition"
+        "Composition",
       );
       expect(actual).toEqual(resource1.resource);
     });
     it("Returns undefined when no resources exist of specified type", () => {
       const actual = getOneResourceByType<Patient>(
         fhirIndexBundleSample,
-        "Patient"
+        "Patient",
       );
       expect(actual).toEqual(undefined);
     });
     it("Errors when there is more than one resource of a specific type", () => {
       expect(() =>
-        getOneResourceByType<Observation>(fhirIndexBundleSample, "Observation")).toThrow(Error)
+        getOneResourceByType<Observation>(fhirIndexBundleSample, "Observation"),
+      ).toThrow(Error);
     });
   });
   describe("getResourceById Tests", () => {

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/fhirResourcesIndexService.test.tsx
@@ -2,6 +2,7 @@ import { Bundle, Composition, Observation, Patient } from "fhir/r4";
 import {
   FhirIndex,
   getFhirIndex,
+  getOneResourceByType,
   getResourceById,
   getResourcesByType,
 } from "@/app/view-data/services/fhirResourcesIndexService";
@@ -121,6 +122,26 @@ describe("fhirResourcesIndexService Tests", () => {
       };
       const actual = getResourcesByType<Patient>(fhirIndexEmpty, "Patient");
       expect(actual).toEqual([]);
+    });
+  });
+  describe("getOneResourceByType Tests", () => {
+    it("Returns a single resource of a specified type", () => {
+      const actual = getOneResourceByType<Composition>(
+        fhirIndexBundleSample,
+        "Composition"
+      );
+      expect(actual).toEqual(resource1.resource);
+    });
+    it("Returns undefined when no resources exist of specified type", () => {
+      const actual = getOneResourceByType<Patient>(
+        fhirIndexBundleSample,
+        "Patient"
+      );
+      expect(actual).toEqual(undefined);
+    });
+    it("Errors when there is more than one resource of a specific type", () => {
+      expect(() =>
+        getOneResourceByType<Observation>(fhirIndexBundleSample, "Observation")).toThrow(Error)
     });
   });
   describe("getResourceById Tests", () => {


### PR DESCRIPTION
# PULL REQUEST

## Summary

Pt. 2 of using the FHIR Index to improve performance of viewing Large eCRs
- focused on replacing areas where we're looking for the `Patient` resource to evaluate data
- Add helper function `getOneResourceByType` -- expects only one resource to be returned of a specific type (i.e. Patient, Composition) -- throws Error if multiple are returned, or returns undefined if nothing was found.
- Also add & update relevant tests

## Related Issue

Fixes #1396 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
