### PR TITLE
feat: add complete deployment infrastructure for eCR Viewer

### DIFF
--- a/deployment/docker-compose.env.example
+++ b/deployment/docker-compose.env.example
@@ -1,0 +1,57 @@
+# eCR Viewer Stack - Environment Variables Template
+# Copy this file to .env and fill in the required values
+
+# =============================================================================
+# Required Variables
+# =============================================================================
+
+# Database connection string (external database - not included in deployment)
+# Format: postgresql://user:password@host:port/database
+DATABASE_URL=postgresql://user:password@localhost:5432/ecr_viewer_db
+
+# =============================================================================
+# Authentication (for ecr-viewer)
+# =============================================================================
+
+# OAuth/OpenID Connect provider configuration
+# Leave empty if not using external auth provider
+AUTH_PROVIDER=
+AUTH_CLIENT_ID=
+AUTH_CLIENT_SECRET=
+AUTH_ISSUER=
+
+# =============================================================================
+# Service URLs (for orchestration)
+# =============================================================================
+
+# Internal service endpoints (Docker DNS names)
+# These use the internal container ports (8080 for most services)
+FHIR_CONVERTER_URL=http://fhir-converter:8080
+MESSAGE_PARSER_URL=http://message-parser:8080
+INGESTION_URL=http://ingestion:8080
+TRIGGER_CODE_REFERENCE_URL=http://trigger-code-reference:8080
+ECR_VIEWER_URL=http://ecr-viewer:3000
+
+# =============================================================================
+# Optional Variables
+# =============================================================================
+
+# Smarty API credentials for address standardization (ingestion service)
+# Get these from https://www.smarty.com/
+SMARTY_AUTH_ID=
+SMARTY_AUTH_TOKEN=
+
+# =============================================================================
+# AWS Credentials (for ecr-viewer - if using S3 storage)
+# =============================================================================
+
+# Leave empty if not using AWS services
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+
+# =============================================================================
+# Application Version
+# =============================================================================
+
+APP_VERSION=1.0.0

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,137 @@
+# Docker Compose configuration for eCR Viewer stack
+# This file defines all 6 services for local Docker deployment
+
+services:
+  # eCR Viewer - Next.js frontend application
+  # Exposed on port 3000, internal port 3000
+  ecr-viewer:
+    build:
+      context: ../containers/ecr-viewer/
+    ports:
+      - "3000:3000"
+    environment:
+      - APP_VERSION=${APP_VERSION:-1.0.0}
+    networks:
+      - ecr-viewer-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Orchestration - FastAPI backend service
+  # Exposed on port 8080, internal port 8080
+  # Depends on all backend services for startup
+  orchestration:
+    build:
+      context: ../containers/orchestration/
+    ports:
+      - "8080:8080"
+    environment:
+      - FHIR_CONVERTER_URL=http://fhir-converter:8080
+      - MESSAGE_PARSER_URL=http://message-parser:8080
+      - INGESTION_URL=http://ingestion:8080
+      - TRIGGER_CODE_REFERENCE_URL=http://trigger-code-reference:8080
+      - ECR_VIEWER_URL=http://ecr-viewer:3000
+      - DATABASE_URL=${DATABASE_URL}
+      - AUTH_PROVIDER=${AUTH_PROVIDER:-}
+      - AUTH_CLIENT_ID=${AUTH_CLIENT_ID:-}
+      - AUTH_CLIENT_SECRET=${AUTH_CLIENT_SECRET:-}
+      - AUTH_ISSUER=${AUTH_ISSUER:-}
+    networks:
+      - ecr-viewer-network
+    depends_on:
+      fhir-converter:
+        condition: service_healthy
+      ingestion:
+        condition: service_healthy
+      trigger-code-reference:
+        condition: service_healthy
+      message-parser:
+        condition: service_healthy
+      ecr-viewer:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # FHIR Converter - .NET service for FHIR conversion
+  # Exposed on port 8082, internal port 8080
+  fhir-converter:
+    build:
+      context: ../containers/fhir-converter/
+    ports:
+      - "8082:8080"
+    networks:
+      - ecr-viewer-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Ingestion - Python service for data ingestion
+  # Exposed on port 8083, internal port 8080
+  ingestion:
+    build:
+      context: ../containers/ingestion/
+    ports:
+      - "8083:8080"
+    environment:
+      - SMARTY_AUTH_ID=${SMARTY_AUTH_ID:-}
+      - SMARTY_AUTH_TOKEN=${SMARTY_AUTH_TOKEN:-}
+    networks:
+      - ecr-viewer-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Message Parser - Python service for message parsing
+  # Exposed on port 8085, internal port 8080
+  # Depends on fhir-converter for initial setup
+  message-parser:
+    build:
+      context: ../containers/message-parser/
+    ports:
+      - "8085:8080"
+    environment:
+      - FHIR_CONVERTER_URL=http://fhir-converter:8080
+    networks:
+      - ecr-viewer-network
+    depends_on:
+      fhir-converter:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Trigger Code Reference - Python service for trigger codes
+  # Exposed on port 8086, internal port 8080
+  trigger-code-reference:
+    build:
+      context: ../containers/trigger-code-reference/
+    ports:
+      - "8086:8080"
+    networks:
+      - ecr-viewer-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+networks:
+  ecr-viewer-network:
+    driver: bridge

--- a/deployment/ecs/ecs-task-definition.json
+++ b/deployment/ecs/ecs-task-definition.json
@@ -45,23 +45,26 @@
         }
       ],
       "environment": [
-        {"name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080"},
-        {"name": "MESSAGE_PARSER_URL", "value": "http://message-parser:8080"},
-        {"name": "INGESTION_URL", "value": "http://ingestion:8080"},
-        {"name": "TRIGGER_CODE_REFERENCE_URL", "value": "http://trigger-code-reference:8080"},
-        {"name": "ECR_VIEWER_URL", "value": "http://ecr-viewer:3000"},
-        {"name": "DATABASE_URL", "value": ""},
-        {"name": "AUTH_PROVIDER", "value": ""},
-        {"name": "AUTH_CLIENT_ID", "value": ""},
-        {"name": "AUTH_CLIENT_SECRET", "value": ""},
-        {"name": "AUTH_ISSUER", "value": ""}
+        { "name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080" },
+        { "name": "MESSAGE_PARSER_URL", "value": "http://message-parser:8080" },
+        { "name": "INGESTION_URL", "value": "http://ingestion:8080" },
+        {
+          "name": "TRIGGER_CODE_REFERENCE_URL",
+          "value": "http://trigger-code-reference:8080"
+        },
+        { "name": "ECR_VIEWER_URL", "value": "http://ecr-viewer:3000" },
+        { "name": "DATABASE_URL", "value": "" },
+        { "name": "AUTH_PROVIDER", "value": "" },
+        { "name": "AUTH_CLIENT_ID", "value": "" },
+        { "name": "AUTH_CLIENT_SECRET", "value": "" },
+        { "name": "AUTH_ISSUER", "value": "" }
       ],
       "dependsOn": [
-        {"containerName": "fhir-converter", "condition": "HEALTHY"},
-        {"containerName": "ingestion", "condition": "HEALTHY"},
-        {"containerName": "trigger-code-reference", "condition": "HEALTHY"},
-        {"containerName": "message-parser", "condition": "HEALTHY"},
-        {"containerName": "ecr-viewer", "condition": "HEALTHY"}
+        { "containerName": "fhir-converter", "condition": "HEALTHY" },
+        { "containerName": "ingestion", "condition": "HEALTHY" },
+        { "containerName": "trigger-code-reference", "condition": "HEALTHY" },
+        { "containerName": "message-parser", "condition": "HEALTHY" },
+        { "containerName": "ecr-viewer", "condition": "HEALTHY" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
@@ -102,8 +105,8 @@
         }
       ],
       "environment": [
-        {"name": "SMARTY_AUTH_ID", "value": ""},
-        {"name": "SMARTY_AUTH_TOKEN", "value": ""}
+        { "name": "SMARTY_AUTH_ID", "value": "" },
+        { "name": "SMARTY_AUTH_TOKEN", "value": "" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
@@ -125,10 +128,10 @@
         }
       ],
       "environment": [
-        {"name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080"}
+        { "name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080" }
       ],
       "dependsOn": [
-        {"containerName": "fhir-converter", "condition": "HEALTHY"}
+        { "containerName": "fhir-converter", "condition": "HEALTHY" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],

--- a/deployment/ecs/ecs-task-definition.json
+++ b/deployment/ecs/ecs-task-definition.json
@@ -1,0 +1,161 @@
+{
+  "family": "ecr-viewer-stack",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "2048",
+  "memory": "4096",
+  "executionRoleArn": "arn:aws:iam::ACCOUNT_ID:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT_ID:role/ecsTaskRole",
+  "platformVersion": "LATEST",
+  "containerDefinitions": [
+    {
+      "name": "ecr-viewer",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/ecr-viewer:latest",
+      "cpu": 256,
+      "memory": 512,
+      "portMappings": [
+        {
+          "containerPort": 3000,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {
+          "name": "APP_VERSION",
+          "value": "1.0.0"
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:3000/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    },
+    {
+      "name": "orchestration",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/orchestration:latest",
+      "cpu": 512,
+      "memory": 1024,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {"name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080"},
+        {"name": "MESSAGE_PARSER_URL", "value": "http://message-parser:8080"},
+        {"name": "INGESTION_URL", "value": "http://ingestion:8080"},
+        {"name": "TRIGGER_CODE_REFERENCE_URL", "value": "http://trigger-code-reference:8080"},
+        {"name": "ECR_VIEWER_URL", "value": "http://ecr-viewer:3000"},
+        {"name": "DATABASE_URL", "value": ""},
+        {"name": "AUTH_PROVIDER", "value": ""},
+        {"name": "AUTH_CLIENT_ID", "value": ""},
+        {"name": "AUTH_CLIENT_SECRET", "value": ""},
+        {"name": "AUTH_ISSUER", "value": ""}
+      ],
+      "dependsOn": [
+        {"containerName": "fhir-converter", "condition": "HEALTHY"},
+        {"containerName": "ingestion", "condition": "HEALTHY"},
+        {"containerName": "trigger-code-reference", "condition": "HEALTHY"},
+        {"containerName": "message-parser", "condition": "HEALTHY"},
+        {"containerName": "ecr-viewer", "condition": "HEALTHY"}
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    },
+    {
+      "name": "fhir-converter",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/fhir-converter:latest",
+      "cpu": 512,
+      "memory": 1024,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    },
+    {
+      "name": "ingestion",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/ingestion:latest",
+      "cpu": 256,
+      "memory": 512,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {"name": "SMARTY_AUTH_ID", "value": ""},
+        {"name": "SMARTY_AUTH_TOKEN", "value": ""}
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    },
+    {
+      "name": "message-parser",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/message-parser:latest",
+      "cpu": 256,
+      "memory": 512,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {"name": "FHIR_CONVERTER_URL", "value": "http://fhir-converter:8080"}
+      ],
+      "dependsOn": [
+        {"containerName": "fhir-converter", "condition": "HEALTHY"}
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    },
+    {
+      "name": "trigger-code-reference",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/trigger-code-reference:latest",
+      "cpu": 256,
+      "memory": 512,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}

--- a/deployment/helm/ecr-viewer/Chart.yaml
+++ b/deployment/helm/ecr-viewer/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: ecr-viewer
+description: A Helm chart for deploying the eCR Viewer application to Kubernetes
+
+type: application
+
+version: 1.0.0
+appVersion: "1.0.0"
+
+maintainers:
+  - name: dibbs-team
+    url: https://github.com/CDCgov/dibbs-ecr-viewer

--- a/deployment/helm/ecr-viewer/NOTES.txt
+++ b/deployment/helm/ecr-viewer/NOTES.txt
@@ -1,0 +1,52 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your eCR Viewer application is now deployed to your Kubernetes cluster.
+
+## Next Steps:
+
+1. **Access the application:**
+   {{- if .Values.ingress.enabled }}
+   The application is exposed via Ingress. You can access it at:
+   {{- range .Values.ingress.hosts }}
+   {{- range .paths }}
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ .path }}
+   {{- end }}
+   {{- end }}
+   {{- else }}
+   The application is deployed but not exposed externally. To access it:
+   - Use `kubectl port-forward svc/{{ include "ecr-viewer.fullname" . }}-ecr-viewer 3000:3000`
+   - Then visit: http://localhost:3000
+   {{- end }}
+
+2. **Check deployment status:**
+   kubectl get deployments -l app.kubernetes.io/name={{ .Chart.Name }}
+   kubectl get services -l app.kubernetes.io/name={{ .Chart.Name }}
+
+3. **View logs:**
+   kubectl logs -l app.kubernetes.io/component=ecr-viewer -f
+
+4. **Verify database connection:**
+   Ensure you have set the DATABASE_URL environment variable in your values file or via secret.
+
+## Configuration:
+
+Review the following files for customization:
+- {{ .Chart.Name }}/values.yaml - Default configuration
+- {{ .Chart.Name }}/values-dev.yaml - Development environment settings
+- {{ .Chart.Name }}/values-prod.yaml - Production environment settings
+
+## Database Setup:
+
+This chart requires an external database. Set the DATABASE_URL in your values file:
+
+values-dev.yaml:
+  database:
+    url: "postgresql://user:password@localhost:5432/ecr_dev"
+
+values-prod.yaml:
+  database:
+    url: "postgresql://user:password@prod-db:5432/ecr_prod"
+
+## Support:
+
+For issues and documentation, visit: https://github.com/CDCgov/dibbs-ecr-viewer

--- a/deployment/helm/ecr-viewer/README.md
+++ b/deployment/helm/ecr-viewer/README.md
@@ -36,13 +36,13 @@ deployment/helm/ecr-viewer/
 
 This chart deploys the following services:
 
-| Service | Port | Description |
-|---------|------|-------------|
-| ecr-viewer | 3000 | Next.js application frontend |
-| orchestration | 8080 | FastAPI backend orchestration |
-| fhir-converter | 8082 (internal: 8080) | FHIR data conversion |
-| ingestion | 8083 (internal: 8080) | Data ingestion service |
-| message-parser | 8085 (internal: 8080) | Message parsing service |
+| Service                | Port                  | Description                    |
+| ---------------------- | --------------------- | ------------------------------ |
+| ecr-viewer             | 3000                  | Next.js application frontend   |
+| orchestration          | 8080                  | FastAPI backend orchestration  |
+| fhir-converter         | 8082 (internal: 8080) | FHIR data conversion           |
+| ingestion              | 8083 (internal: 8080) | Data ingestion service         |
+| message-parser         | 8085 (internal: 8080) | Message parsing service        |
 | trigger-code-reference | 8086 (internal: 8080) | Trigger code reference service |
 
 ## Installation
@@ -76,12 +76,12 @@ helm install my-ecr-viewer ./deployment/helm/ecr-viewer/ \
 
 ### Global Settings
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `image.registry` | Container image registry | `ghcr.io` |
-| `image.repository` | Container image repository | `cdcgov` |
-| `image.tag` | Container image tag | `latest` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| Parameter          | Description                | Default        |
+| ------------------ | -------------------------- | -------------- |
+| `image.registry`   | Container image registry   | `ghcr.io`      |
+| `image.repository` | Container image repository | `cdcgov`       |
+| `image.tag`        | Container image tag        | `latest`       |
+| `image.pullPolicy` | Image pull policy          | `IfNotPresent` |
 
 ### Service Configuration
 
@@ -89,40 +89,40 @@ Each service supports the following configuration options:
 
 ```yaml
 ecr-viewer:
-  replicas: 1                    # Number of pod replicas
-  resources:                     # CPU and memory limits/requests
+  replicas: 1 # Number of pod replicas
+  resources: # CPU and memory limits/requests
     limits:
       cpu: 256m
       memory: 512Mi
     requests:
       cpu: 128m
       memory: 256Mi
-  containerPort: 3000            # Port inside the container
-  servicePort: 3000              # Port exposed by the service
-  healthCheckPath: /             # Health check endpoint
-  environment: []                # Additional environment variables
+  containerPort: 3000 # Port inside the container
+  servicePort: 3000 # Port exposed by the service
+  healthCheckPath: / # Health check endpoint
+  environment: [] # Additional environment variables
 ```
 
 ### Ingress Configuration
 
 ```yaml
 ingress:
-  enabled: true                  # Enable ingress
-  className: ""                  # Ingress class name
-  annotations: {}                # Ingress annotations
-  hosts:                         # Host configuration
+  enabled: true # Enable ingress
+  className: "" # Ingress class name
+  annotations: {} # Ingress annotations
+  hosts: # Host configuration
     - host: ecr-viewer.local
       paths:
         - path: /
           pathType: Prefix
-  tls: []                        # TLS configuration
+  tls: [] # TLS configuration
 ```
 
 ### Database Configuration
 
 ```yaml
 database:
-  url: "postgresql://user:password@host:5432/database"  # Required
+  url: "postgresql://user:password@host:5432/database" # Required
 ```
 
 ## Environment-Specific Settings

--- a/deployment/helm/ecr-viewer/README.md
+++ b/deployment/helm/ecr-viewer/README.md
@@ -1,0 +1,244 @@
+# eCR Viewer Kubernetes Helm Chart
+
+A Helm chart for deploying the eCR Viewer application to Kubernetes. This chart deploys all 6 services that make up the eCR Viewer application.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3+
+- An external PostgreSQL database
+- Access to a container registry (for custom images)
+
+## Chart Structure
+
+```
+deployment/helm/ecr-viewer/
+├── Chart.yaml              # Chart metadata
+├── values.yaml             # Default values for all services
+├── values-dev.yaml         # Development environment overrides
+├── values-prod.yaml        # Production environment overrides
+├── templates/              # Kubernetes resource templates
+│   ├── _helpers.tpl        # Template helpers
+│   ├── configmap.yaml      # Shared configuration
+│   ├── secret.yaml         # Sensitive data
+│   ├── ingress.yaml        # Ingress resource
+│   ├── NOTES.txt           # Post-install notes
+│   ├── ecr-viewer-*
+│   ├── orchestration-*
+│   ├── fhir-converter-*
+│   ├── ingestion-*
+│   ├── message-parser-*
+│   └── trigger-code-reference-*
+└── README.md               # This file
+```
+
+## Services
+
+This chart deploys the following services:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| ecr-viewer | 3000 | Next.js application frontend |
+| orchestration | 8080 | FastAPI backend orchestration |
+| fhir-converter | 8082 (internal: 8080) | FHIR data conversion |
+| ingestion | 8083 (internal: 8080) | Data ingestion service |
+| message-parser | 8085 (internal: 8080) | Message parsing service |
+| trigger-code-reference | 8086 (internal: 8080) | Trigger code reference service |
+
+## Installation
+
+### Using default values:
+
+```bash
+helm install my-ecr-viewer ./deployment/helm/ecr-viewer/
+```
+
+### Using development values:
+
+```bash
+helm install my-ecr-viewer ./deployment/helm/ecr-viewer/ -f ./deployment/helm/ecr-viewer/values-dev.yaml
+```
+
+### Using production values:
+
+```bash
+helm install my-ecr-viewer ./deployment/helm/ecr-viewer/ -f ./deployment/helm/ecr-viewer/values-prod.yaml
+```
+
+### With custom database URL:
+
+```bash
+helm install my-ecr-viewer ./deployment/helm/ecr-viewer/ \
+  --set database.url="postgresql://user:password@host:5432/database"
+```
+
+## Configuration
+
+### Global Settings
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.registry` | Container image registry | `ghcr.io` |
+| `image.repository` | Container image repository | `cdcgov` |
+| `image.tag` | Container image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+
+### Service Configuration
+
+Each service supports the following configuration options:
+
+```yaml
+ecr-viewer:
+  replicas: 1                    # Number of pod replicas
+  resources:                     # CPU and memory limits/requests
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+  containerPort: 3000            # Port inside the container
+  servicePort: 3000              # Port exposed by the service
+  healthCheckPath: /             # Health check endpoint
+  environment: []                # Additional environment variables
+```
+
+### Ingress Configuration
+
+```yaml
+ingress:
+  enabled: true                  # Enable ingress
+  className: ""                  # Ingress class name
+  annotations: {}                # Ingress annotations
+  hosts:                         # Host configuration
+    - host: ecr-viewer.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []                        # TLS configuration
+```
+
+### Database Configuration
+
+```yaml
+database:
+  url: "postgresql://user:password@host:5432/database"  # Required
+```
+
+## Environment-Specific Settings
+
+### Development (`values-dev.yaml`)
+
+- Single replica for each service
+- Reduced resource limits
+- Development image tag
+- Ideal for local testing
+
+### Production (`values-prod.yaml`)
+
+- 2 replicas for high availability
+- Full resource allocation
+- Production image tag
+- Pod disruption budget enabled
+- TLS support configured
+
+## Running the Chart
+
+### Build and Push Images
+
+```bash
+# Build each service image
+docker build -t myregistry/ecr-viewer:latest ./containers/ecr-viewer/
+docker build -t myregistry/orchestration:latest ./containers/orchestration/
+docker build -t myregistry/fhir-converter:latest ./containers/fhir-converter/
+docker build -t myregistry/ingestion:latest ./containers/ingestion/
+docker build -t myregistry/message-parser:latest ./containers/message-parser/
+docker build -t myregistry/trigger-code-reference:latest ./containers/trigger-code-reference/
+
+# Push to registry
+docker push myregistry/ecr-viewer:latest
+docker push myregistry/orchestration:latest
+docker push myregistry/fhir-converter:latest
+docker push myregistry/ingestion:latest
+docker push myregistry/message-parser:latest
+docker push myregistry/trigger-code-reference:latest/
+```
+
+### Install with Custom Registry
+
+```bash
+helm install my-ecr-viewer ./deployment/helm/ecr-viewer/ \
+  --set image.registry=myregistry \
+  --set image.tag=latest \
+  --set database.url="postgresql://user:password@host:5432/database"
+```
+
+## Verification
+
+### Check Deployments
+
+```bash
+kubectl get deployments -l app.kubernetes.io/name=ecr-viewer
+```
+
+### Check Services
+
+```bash
+kubectl get services -l app.kubernetes.io/name=ecr-viewer
+```
+
+### Check Pod Status
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=ecr-viewer
+```
+
+### View Logs
+
+```bash
+kubectl logs -l app.kubernetes.io/component=ecr-viewer -f
+```
+
+## Uninstallation
+
+```bash
+helm uninstall my-ecr-viewer
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+# Check pod events
+kubectl describe pod <pod-name>
+
+# Check pod logs
+kubectl logs <pod-name>
+```
+
+### Service not responding
+
+```bash
+# Check service endpoints
+kubectl get endpoints <service-name>
+
+# Test service connectivity
+kubectl run -it --rm debug --image=busybox --restart=Never -- sh
+# Inside the pod:
+nslookup <service-name>
+```
+
+### Ingress not working
+
+```bash
+# Check ingress controller logs
+kubectl logs -n ingress-nginx controller-nginx-<id>
+
+# Verify ingress resource
+kubectl get ingress <ingress-name> -o yaml
+```
+
+## License
+
+Copyright © 2025 CDC. Licensed under the MIT License.

--- a/deployment/helm/ecr-viewer/templates/_helpers.tpl
+++ b/deployment/helm/ecr-viewer/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ecr-viewer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ecr-viewer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ecr-viewer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create service account name.
+*/}}
+{{- define "ecr-viewer.serviceAccountName" -}}
+{{- if .Values.serviceAccount }}
+{{- default (include "ecr-viewer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default (include "ecr-viewer.fullname" .) .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create image pull secrets from global settings.
+*/}}
+{{- define "ecr-viewer.imagePullSecret" -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.image.registry .Values.image.registry .Values.image.registry (printf "%s:%s" .Values.image.registry .Values.image.registry | b64enc) | b64enc }}
+{{- end }}
+
+{{/*
+Create the image path for a service.
+Usage: {{ include "ecr-viewer.imagePath" (dict "service" "ecr-viewer" "Values" .Values) }}
+*/}}
+{{- define "ecr-viewer.imagePath" -}}
+{{- $service := default "ecr-viewer" .service }}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository $service .Values.image.tag }}
+{{- end }}
+
+{{/*
+Create common labels.
+*/}}
+{{- define "ecr-viewer.commonLabels" -}}
+app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "ecr-viewer.chart" . }}
+{{- end }}
+
+{{/*
+Create pod labels.
+*/}}
+{{- define "ecr-viewer.podLabels" -}}
+{{- include "ecr-viewer.commonLabels" . }}
+{{- end }}
+
+{{/*
+Create service labels.
+*/}}
+{{- define "ecr-viewer.serviceLabels" -}}
+{{- include "ecr-viewer.commonLabels" . }}
+{{- end }}
+
+{{/*
+Create deployment labels.
+*/}}
+{{- define "ecr-viewer.deploymentLabels" -}}
+{{- include "ecr-viewer.commonLabels" . }}
+{{- end }}

--- a/deployment/helm/ecr-viewer/templates/configmap.yaml
+++ b/deployment/helm/ecr-viewer/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-shared-config
+  labels:
+    {{- include "ecr-viewer.commonLabels" . | nindent 4 }}
+data:
+  # Shared configuration across services
+  APP_ENV: {{ .Values.appEnvironment | default "development" | quote }}
+  LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}
+  # Shared timeout settings
+  DEFAULT_TIMEOUT_MS: {{ .Values.defaultTimeoutMs | default "30000" | quote }}
+  # Shared retry settings
+  MAX_RETRIES: {{ .Values.maxRetries | default "3" | quote }}
+  RETRY_DELAY_MS: {{ .Values.retryDelayMs | default "1000" | quote }}

--- a/deployment/helm/ecr-viewer/templates/ecr-viewer-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/ecr-viewer-deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-ecr-viewer
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ecr-viewer
+spec:
+  replicas: {{ .Values.ecr-viewer.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: ecr-viewer
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ecr-viewer
+    spec:
+      containers:
+        - name: ecr-viewer
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "ecr-viewer" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ecr-viewer.containerPort }}
+              protocol: TCP
+          env:
+            - name: APP_VERSION
+              value: {{ .Chart.AppVersion | quote }}
+            - name: PORT
+              value: {{ .Values.ecr-viewer.containerPort | quote }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: DATABASE_URL
+                  optional: true
+            - name: AUTH_PROVIDER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AUTH_PROVIDER
+                  optional: true
+            - name: AUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AUTH_CLIENT_ID
+                  optional: true
+            - name: AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AUTH_CLIENT_SECRET
+                  optional: true
+            - name: AUTH_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AUTH_ISSUER
+                  optional: true
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AWS_ACCESS_KEY_ID
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: AWS_SECRET_ACCESS_KEY
+                  optional: true
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.ecr-viewer.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.ecr-viewer.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.ecr-viewer.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/ecr-viewer-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/ecr-viewer-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-ecr-viewer
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ecr-viewer
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ecr-viewer.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: ecr-viewer

--- a/deployment/helm/ecr-viewer/templates/fhir-converter-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/fhir-converter-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-fhir-converter
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fhir-converter
+spec:
+  replicas: {{ .Values.fhir-converter.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: fhir-converter
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: fhir-converter
+    spec:
+      containers:
+        - name: fhir-converter
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "fhir-converter" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.fhir-converter.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.fhir-converter.containerPort | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.fhir-converter.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.fhir-converter.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.fhir-converter.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/fhir-converter-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/fhir-converter-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-fhir-converter
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fhir-converter
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.fhir-converter.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: fhir-converter

--- a/deployment/helm/ecr-viewer/templates/ingestion-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/ingestion-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-ingestion
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ingestion
+spec:
+  replicas: {{ .Values.ingestion.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: ingestion
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ingestion
+    spec:
+      containers:
+        - name: ingestion
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "ingestion" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ingestion.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.ingestion.containerPort | quote }}
+            {{- range .Values.ingestion.environment }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ecr-viewer.fullname" . }}-secrets
+                  key: {{ .name }}
+                  optional: true
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.ingestion.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.ingestion.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.ingestion.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/ingestion-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/ingestion-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-ingestion
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ingestion
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ingestion.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: ingestion

--- a/deployment/helm/ecr-viewer/templates/ingress.yaml
+++ b/deployment/helm/ecr-viewer/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-ingress
+  labels:
+    {{- include "ecr-viewer.commonLabels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ecr-viewer.fullname" $ }}-ecr-viewer
+                port:
+                  number: {{ $.Values.ecr-viewer.servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/ecr-viewer/templates/message-parser-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/message-parser-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-message-parser
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: message-parser
+spec:
+  replicas: {{ .Values.message-parser.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: message-parser
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: message-parser
+    spec:
+      containers:
+        - name: message-parser
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "message-parser" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.message-parser.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.message-parser.containerPort | quote }}
+            {{- range .Values.message-parser.environment }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.message-parser.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.message-parser.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.message-parser.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/message-parser-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/message-parser-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-message-parser
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: message-parser
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.message-parser.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: message-parser

--- a/deployment/helm/ecr-viewer/templates/orchestration-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/orchestration-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-orchestration
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestration
+spec:
+  replicas: {{ .Values.orchestration.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: orchestration
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: orchestration
+    spec:
+      containers:
+        - name: orchestration
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "orchestration" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.orchestration.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.orchestration.containerPort | quote }}
+            {{- range .Values.orchestration.environment }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- if .Values.database.url }}
+            - name: DATABASE_URL
+              value: {{ .Values.database.url }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.orchestration.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: {{ .Values.orchestration.healthCheckPath }}
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.orchestration.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.orchestration.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/orchestration-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/orchestration-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-orchestration
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestration
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.orchestration.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: orchestration

--- a/deployment/helm/ecr-viewer/templates/secret.yaml
+++ b/deployment/helm/ecr-viewer/templates/secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-secrets
+  labels:
+    {{- include "ecr-viewer.commonLabels" . | nindent 4 }}
+type: Opaque
+data:
+  # Database credentials (base64 encoded values)
+  # Generate with: echo -n 'your-password' | base64
+  {{- if .Values.database.password }}
+  DATABASE_PASSWORD: {{ .Values.database.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.database.username }}
+  DATABASE_USERNAME: {{ .Values.database.username | b64enc | quote }}
+  {{- end }}
+  # Auth credentials (base64 encoded values)
+  {{- if .Values.auth.clientSecret }}
+  AUTH_CLIENT_SECRET: {{ .Values.auth.clientSecret | b64enc | quote }}
+  {{- end }}
+  # Additional secrets can be added here
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}

--- a/deployment/helm/ecr-viewer/templates/trigger-code-reference-deployment.yaml
+++ b/deployment/helm/ecr-viewer/templates/trigger-code-reference-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-trigger-code-reference
+  labels:
+    {{- include "ecr-viewer.deploymentLabels" . | nindent 4 }}
+    app.kubernetes.io/component: trigger-code-reference
+spec:
+  replicas: {{ .Values.trigger-code-reference.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+      app.kubernetes.io/component: trigger-code-reference
+  template:
+    metadata:
+      labels:
+        {{- include "ecr-viewer.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: trigger-code-reference
+    spec:
+      containers:
+        - name: trigger-code-reference
+          image: {{ include "ecr-viewer.imagePath" (dict "service" "trigger-code-reference" "Values" .Values) | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.trigger-code-reference.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.trigger-code-reference.containerPort | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ecr-viewer.fullname" . }}-shared-config
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.trigger-code-reference.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.trigger-code-reference.healthCheckPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.trigger-code-reference.resources | nindent 12 }}

--- a/deployment/helm/ecr-viewer/templates/trigger-code-reference-service.yaml
+++ b/deployment/helm/ecr-viewer/templates/trigger-code-reference-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ecr-viewer.fullname" . }}-trigger-code-reference
+  labels:
+    {{- include "ecr-viewer.serviceLabels" . | nindent 4 }}
+    app.kubernetes.io/component: trigger-code-reference
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.trigger-code-reference.servicePort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "ecr-viewer.name" . }}
+    app.kubernetes.io/component: trigger-code-reference

--- a/deployment/helm/ecr-viewer/values-dev.yaml
+++ b/deployment/helm/ecr-viewer/values-dev.yaml
@@ -1,0 +1,81 @@
+# Development environment overrides for ecr-viewer Helm chart
+# Use with: helm template dev deployment/helm/ecr-viewer/ -f values-dev.yaml
+
+# Development image settings
+image:
+  tag: "dev"
+  pullPolicy: Always
+
+# Development resources (reduced for local development)
+ecr-viewer:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 128m
+      memory: 256Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+
+orchestration:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+
+fhir-converter:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+
+ingestion:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 128m
+      memory: 256Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+
+message-parser:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 128m
+      memory: 256Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+
+trigger-code-reference:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 128m
+      memory: 256Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+
+# Enable ingress for local development
+ingress:
+  enabled: true
+  className: ""
+  hosts:
+    - host: ecr-viewer.local
+      paths:
+        - path: /
+          pathType: Prefix
+
+# Database URL for development (override with your actual development database)
+# DATABASE_URL: postgresql://user:password@localhost:5432/ecr_dev

--- a/deployment/helm/ecr-viewer/values-dev.yaml
+++ b/deployment/helm/ecr-viewer/values-dev.yaml
@@ -76,6 +76,5 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
-
 # Database URL for development (override with your actual development database)
 # DATABASE_URL: postgresql://user:password@localhost:5432/ecr_dev

--- a/deployment/helm/ecr-viewer/values-prod.yaml
+++ b/deployment/helm/ecr-viewer/values-prod.yaml
@@ -90,6 +90,5 @@ ingress:
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
-
 # Production database URL (must be provided - example format)
 # DATABASE_URL: postgresql://user:password@prod-db.example.com:5432/ecr_prod

--- a/deployment/helm/ecr-viewer/values-prod.yaml
+++ b/deployment/helm/ecr-viewer/values-prod.yaml
@@ -1,0 +1,95 @@
+# Production environment overrides for ecr-viewer Helm chart
+# Use with: helm template prod deployment/helm/ecr-viewer/ -f values-prod.yaml
+
+# Production image settings
+image:
+  tag: "prod"
+  pullPolicy: Always
+
+# Production resources (full capacity)
+ecr-viewer:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+
+orchestration:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 1024m
+      memory: 2048Mi
+    requests:
+      cpu: 512m
+      memory: 1024Mi
+
+fhir-converter:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 1024m
+      memory: 2048Mi
+    requests:
+      cpu: 512m
+      memory: 1024Mi
+
+ingestion:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+
+message-parser:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+
+trigger-code-reference:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+
+# Enable ingress for production (configure for your ingress controller)
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    # Example for nginx ingress controller
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  hosts:
+    - host: ecr-viewer.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # TLS configuration (update with your certificate)
+  tls:
+    - secretName: ecr-viewer-tls
+      hosts:
+        - ecr-viewer.example.com
+
+# Pod disruption budget for high availability
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Production database URL (must be provided - example format)
+# DATABASE_URL: postgresql://user:password@prod-db.example.com:5432/ecr_prod

--- a/deployment/helm/ecr-viewer/values.yaml
+++ b/deployment/helm/ecr-viewer/values.yaml
@@ -1,0 +1,163 @@
+# Default values for ecr-viewer Helm chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global settings
+image:
+  registry: ghcr.io
+  repository: cdcgov
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Service configurations
+# Each service has: replicas, resources (cpu/memory), ports, and environment variables
+
+ecr-viewer:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+  containerPort: 3000
+  servicePort: 3000
+  # Health check at the root endpoint
+  healthCheckPath: /
+  environment: []
+
+orchestration:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+  containerPort: 8080
+  servicePort: 8080
+  healthCheckPath: /
+  environment:
+    - name: FHIR_CONVERTER_URL
+      value: http://fhir-converter:8080
+    - name: MESSAGE_PARSER_URL
+      value: http://message-parser:8080
+    - name: INGESTION_URL
+      value: http://ingestion:8080
+    - name: TRIGGER_CODE_REFERENCE_URL
+      value: http://trigger-code-reference:8080
+    - name: ECR_VIEWER_URL
+      value: http://ecr-viewer:3000
+    # DATABASE_URL must be provided externally
+    - name: DATABASE_URL
+      value: ""
+    - name: AUTH_PROVIDER
+      value: ""
+    - name: AUTH_CLIENT_ID
+      value: ""
+    - name: AUTH_CLIENT_SECRET
+      value: ""
+    - name: AUTH_ISSUER
+      value: ""
+
+fhir-converter:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 512m
+      memory: 1024Mi
+    requests:
+      cpu: 256m
+      memory: 512Mi
+  containerPort: 8080
+  servicePort: 8082  # Exposed on 8082 but container listens on 8080
+  healthCheckPath: /
+  environment: []
+
+ingestion:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+  containerPort: 8080
+  servicePort: 8083  # Exposed on 8083 but container listens on 8080
+  healthCheckPath: /
+  environment:
+    - name: SMARTY_AUTH_ID
+      value: ""
+    - name: SMARTY_AUTH_TOKEN
+      value: ""
+
+message-parser:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+  containerPort: 8080
+  servicePort: 8085  # Exposed on 8085 but container listens on 8080
+  healthCheckPath: /
+  environment:
+    - name: FHIR_CONVERTER_URL
+      value: http://fhir-converter:8080
+  dependsOn:
+    - fhir-converter
+
+trigger-code-reference:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 256m
+      memory: 512Mi
+    requests:
+      cpu: 128m
+      memory: 256Mi
+  containerPort: 8080
+  servicePort: 8086  # Exposed on 8086 but container listens on 8080
+  healthCheckPath: /
+  environment: []
+
+# Ingress configuration (generic, works with any controller)
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: ecr-viewer.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Database configuration
+# DATABASE_URL must be provided externally (e.g., via Helm value override)
+# Example: DATABASE_URL=postgresql://user:password@host:5432/database
+database:
+  # Set to true if you want the chart to wait for database connectivity
+  # Note: The actual DATABASE_URL must be provided via values-dev.yaml or values-prod.yaml
+  required: true
+
+# Pod disruption budget settings
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# Affinity rules for pod placement
+affinity: {}
+
+# Node selector for pod placement
+nodeSelector: {}
+
+# Tolerations for pod placement
+tolerations: []

--- a/deployment/helm/ecr-viewer/values.yaml
+++ b/deployment/helm/ecr-viewer/values.yaml
@@ -72,7 +72,7 @@ fhir-converter:
       cpu: 256m
       memory: 512Mi
   containerPort: 8080
-  servicePort: 8082  # Exposed on 8082 but container listens on 8080
+  servicePort: 8082 # Exposed on 8082 but container listens on 8080
   healthCheckPath: /
   environment: []
 
@@ -86,7 +86,7 @@ ingestion:
       cpu: 128m
       memory: 256Mi
   containerPort: 8080
-  servicePort: 8083  # Exposed on 8083 but container listens on 8080
+  servicePort: 8083 # Exposed on 8083 but container listens on 8080
   healthCheckPath: /
   environment:
     - name: SMARTY_AUTH_ID
@@ -104,7 +104,7 @@ message-parser:
       cpu: 128m
       memory: 256Mi
   containerPort: 8080
-  servicePort: 8085  # Exposed on 8085 but container listens on 8080
+  servicePort: 8085 # Exposed on 8085 but container listens on 8080
   healthCheckPath: /
   environment:
     - name: FHIR_CONVERTER_URL
@@ -122,7 +122,7 @@ trigger-code-reference:
       cpu: 128m
       memory: 256Mi
   containerPort: 8080
-  servicePort: 8086  # Exposed on 8086 but container listens on 8080
+  servicePort: 8086 # Exposed on 8086 but container listens on 8080
   healthCheckPath: /
   environment: []
 

--- a/deployment/scripts/deploy-ecs.sh
+++ b/deployment/scripts/deploy-ecs.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# eCR Viewer Stack - AWS ECS Fargate Deployment Script
+#
+# This script builds Docker images, pushes them to ECR, and deploys to ECS Fargate.
+# It requires AWS CLI, Docker, and proper AWS credentials/configuration.
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_DIR/deployment/docker-compose.yml"
+TASK_DEFINITION="$PROJECT_DIR/deployment/ecs/ecs-task-definition.json"
+REGION="${AWS_REGION:-us-east-1}"
+REPOSITORY_PREFIX="ecr-viewer"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Print functions
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# =============================================================================
+# Pre-flight Checks
+# =============================================================================
+
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+
+    # Check AWS CLI
+    if ! command -v aws &> /dev/null; then
+        print_error "AWS CLI is not installed or not in PATH"
+        exit 1
+    fi
+
+    # Check Docker
+    if ! command -v docker &> /dev/null; then
+        print_error "Docker is not installed or not in PATH"
+        exit 1
+    fi
+
+    # Check if task definition exists
+    if [ ! -f "$TASK_DEFINITION" ]; then
+        print_error "Task definition file not found: $TASK_DEFINITION"
+        exit 1
+    fi
+
+    # Check AWS credentials
+    if ! aws sts get-caller-identity &> /dev/null; then
+        print_error "AWS credentials not configured or invalid"
+        print_status "Please run: aws configure"
+        exit 1
+    fi
+
+    print_status "Prerequisites check passed"
+}
+
+check_aws_configuration() {
+    print_status "Checking AWS configuration..."
+
+    # Get account ID
+    ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+    echo "AWS Account ID: $ACCOUNT_ID"
+    echo "AWS Region: $REGION"
+
+    # Confirm before proceeding
+    echo ""
+    print_warning "This will deploy to ECS Fargate in region $REGION"
+    read -p "Continue? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_status "Deployment cancelled"
+        exit 0
+    fi
+}
+
+create_ecr_repositories() {
+    print_status "Checking/creating ECR repositories..."
+
+    local services=("ecr-viewer" "orchestration" "fhir-converter" "ingestion" "message-parser" "trigger-code-reference")
+
+    for service in "${services[@]}"; do
+        local repo_name="$REPOSITORY_PREFIX-$service"
+        print_status "Checking repository: $repo_name"
+
+        if ! aws ecr describe-repositories --repository-names "$repo_name" --region "$REGION" &> /dev/null; then
+            print_status "Creating ECR repository: $repo_name"
+            aws ecr create-repository --repository-name "$repo_name" --region "$REGION" > /dev/null
+        else
+            print_status "Repository exists: $repo_name"
+        fi
+    done
+
+    print_status "ECR repositories ready"
+}
+
+get_login_password() {
+    print_status "Getting ECR login credentials..."
+
+    # Get login token
+    aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com"
+
+    print_status "Docker logged in to ECR"
+}
+
+build_and_push_images() {
+    print_status "Building and pushing Docker images to ECR..."
+
+    cd "$PROJECT_DIR"
+
+    local services=("ecr-viewer" "orchestration" "fhir-converter" "ingestion" "message-parser" "trigger-code-reference")
+
+    for service in "${services[@]}"; do
+        print_status "Processing service: $service"
+
+        # Get ECR repository URI
+        local repo_uri="$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$REPOSITORY_PREFIX-$service"
+
+        # Build image
+        print_status "Building image for $service..."
+        if [ "$service" = "ecr-viewer" ]; then
+            # ecr-viewer has a different context path
+            docker build -t "$repo_uri:$VERSION" "../containers/$service/"
+        else
+            docker build -t "$repo_uri:$VERSION" "../containers/$service/"
+        fi
+
+        # Push image
+        print_status "Pushing image to ECR: $repo_uri:$VERSION"
+        docker push "$repo_uri:$VERSION"
+    done
+
+    print_status "All images pushed to ECR successfully"
+}
+
+update_task_definition() {
+    print_status "Updating ECS task definition..."
+
+    # Update placeholders in task definition
+    local task_def_content=$(cat "$TASK_DEFINITION")
+    task_def_content=$(echo "$task_def_content" | sed "s|ACCOUNT_ID|$ACCOUNT_ID|g")
+    task_def_content=$(echo "$task_def_content" | sed "s|REGION|$REGION|g")
+
+    # Write updated task definition to temp file
+    local temp_file=$(mktemp)
+    echo "$task_def_content" > "$temp_file"
+
+    # Register new task definition
+    print_status "Registering new task definition..."
+    local result=$(aws ecs register-task-definition --cli-input-json file://"$(echo "$temp_file")" --region "$REGION")
+    rm -f "$temp_file"
+
+    # Extract task definition ARN
+    TASK_DEFINITION_ARN=$(echo "$result" | jq -r '.taskDefinition.taskDefinitionArn')
+    print_status "Task definition registered: $TASK_DEFINITION_ARN"
+}
+
+update_ecs_service() {
+    print_status "Updating ECS service..."
+
+    # Get service name from ECS cluster
+    # Default cluster name
+    local cluster_name="default"
+    local service_name="ecr-viewer-service"
+
+    # Check if cluster exists
+    if ! aws ecs describe-clusters --cluster "$cluster_name" --region "$REGION" &> /dev/null; then
+        print_warning "ECS cluster '$cluster_name' does not exist"
+        print_status "Please create a cluster first, then update the service manually"
+        print_status ""
+        print_status "To deploy manually, run:"
+        print_status "  aws ecs update-service --cluster $cluster_name --service $service_name --force-new-deployment --region $REGION"
+        print_status ""
+        print_status "Task Definition ARN to use: $TASK_DEFINITION_ARN"
+        return 0
+    fi
+
+    # Update service with new task definition
+    print_status "Updating service with new task definition..."
+    aws ecs update-service \
+        --cluster "$cluster_name" \
+        --service "$service_name" \
+        --task-definition "$TASK_DEFINITION_ARN" \
+        --force-new-deployment \
+        --region "$REGION"
+
+    print_status "ECS service update initiated"
+    print_status "Deployment in progress..."
+}
+
+show_endpoints() {
+    print_status ""
+    print_status "=== ECS Deployment Initiated ==="
+    print_status ""
+    print_status "Task Definition: $TASK_DEFINITION_ARN"
+    print_status "Cluster: default"
+    print_status "Service: ecr-viewer-service"
+    print_status ""
+    print_status "Note: It may take several minutes for the service to stabilize."
+    print_status "Check status with: aws ecs describe-services --cluster default --service ecr-viewer-service --region $REGION"
+    print_status ""
+    print_status "To find your load balancer endpoint:"
+    print_status "  aws ecs describe-services --cluster default --service ecr-viewer-service --region $REGION"
+    print_status ""
+}
+
+# =============================================================================
+# Main Execution
+# =============================================================================
+
+main() {
+    echo ""
+    print_status "eCR Viewer Stack - ECS Fargate Deployment"
+    print_status "=========================================="
+    echo ""
+
+    check_prerequisites
+    check_aws_configuration
+    create_ecr_repositories
+    get_login_password
+
+    # Get version from environment or default
+    VERSION="${VERSION:-latest}"
+    print_status "Image version: $VERSION"
+
+    build_and_push_images
+    update_task_definition
+    update_ecs_service
+    show_endpoints
+}
+
+main "$@"

--- a/deployment/scripts/deploy.sh
+++ b/deployment/scripts/deploy.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# eCR Viewer Stack - Local Docker Deployment Script
+#
+# This script builds and starts all eCR Viewer services using Docker Compose.
+# It requires Docker and Docker Compose to be installed and running.
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_DIR/deployment/docker-compose.yml"
+ENV_FILE="$PROJECT_DIR/deployment/.env"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Print functions
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# =============================================================================
+# Pre-flight Checks
+# =============================================================================
+
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+
+    # Check Docker
+    if ! command -v docker &> /dev/null; then
+        print_error "Docker is not installed or not in PATH"
+        exit 1
+    fi
+
+    # Check Docker Compose
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        print_error "Docker Compose is not installed or not in PATH"
+        exit 1
+    fi
+
+    # Check if compose file exists
+    if [ ! -f "$COMPOSE_FILE" ]; then
+        print_error "Docker Compose file not found: $COMPOSE_FILE"
+        exit 1
+    fi
+
+    print_status "Prerequisites check passed"
+}
+
+check_environment() {
+    print_status "Checking environment configuration..."
+
+    # Check if .env file exists, copy from example if not
+    if [ ! -f "$ENV_FILE" ]; then
+        print_warning ".env file not found, copying from example..."
+        cp "$PROJECT_DIR/deployment/docker-compose.env.example" "$ENV_FILE"
+        print_status "Created .env file. Please edit it with your values."
+        print_warning "Starting deployment with default (empty) values..."
+    fi
+
+    # Source .env file
+    set -a
+    source "$ENV_FILE"
+    set +a
+
+    # Check required variables
+    if [ -z "$DATABASE_URL" ]; then
+        print_error "DATABASE_URL is not set in .env file"
+        print_status "Please edit $ENV_FILE and set DATABASE_URL"
+        exit 1
+    fi
+
+    print_status "Environment check passed"
+}
+
+# =============================================================================
+# Deployment Functions
+# =============================================================================
+
+build_images() {
+    print_status "Building Docker images..."
+    print_status "This may take several minutes on the first run."
+
+    cd "$PROJECT_DIR"
+
+    if command -v docker-compose &> /dev/null; then
+        docker-compose -f "$COMPOSE_FILE" build
+    else
+        docker compose -f "$COMPOSE_FILE" build
+    fi
+
+    print_status "Docker images built successfully"
+}
+
+start_services() {
+    print_status "Starting services..."
+
+    cd "$PROJECT_DIR"
+
+    if command -v docker-compose &> /dev/null; then
+        docker-compose -f "$COMPOSE_FILE" up -d
+    else
+        docker compose -f "$COMPOSE_FILE" up -d
+    fi
+
+    print_status "Services started in detached mode"
+}
+
+wait_for_health() {
+    print_status "Waiting for services to become healthy..."
+
+    cd "$PROJECT_DIR"
+
+    # Define services to wait for
+    local services=("ecr-viewer" "orchestration" "fhir-converter" "ingestion" "message-parser" "trigger-code-reference")
+    local max_wait=300  # 5 minutes max
+    local waited=0
+    local healthy_count=0
+
+    while [ $healthy_count -lt ${#services[@]} ] && [ $waited -lt $max_wait ]; do
+        sleep 10
+        waited=$((waited + 10))
+
+        healthy_count=0
+        for service in "${services[@]}"; do
+            # Get container status
+            local status=""
+            if command -v docker-compose &> /dev/null; then
+                status=$(docker-compose -f "$COMPOSE_FILE" ps -q "$service" 2>/dev/null | xargs docker inspect --format='{{.State.Health.Status}}' 2>/dev/null || echo "checking")
+            else
+                status=$(docker compose -f "$COMPOSE_FILE" ps -q "$service" 2>/dev/null | xargs docker inspect --format='{{.State.Health.Status}}' 2>/dev/null || echo "checking")
+            fi
+
+            if [ "$status" = "healthy" ]; then
+                healthy_count=$((healthy_count + 1))
+            fi
+        done
+
+        print_status "Healthy services: $healthy_count/${#services[@]} (waited ${waited}s)"
+    done
+
+    if [ $healthy_count -lt ${#services[@]} ]; then
+        print_warning "Not all services became healthy within timeout"
+        print_status "Check logs with: docker-compose -f $COMPOSE_FILE logs"
+    else
+        print_status "All services are healthy!"
+    fi
+}
+
+show_endpoints() {
+    print_status ""
+    print_status "=== eCR Viewer Stack is Running ==="
+    print_status ""
+    print_status "Service Endpoints:"
+    print_status "  eCR Viewer:        http://localhost:3000"
+    print_status "  Orchestration API: http://localhost:8080"
+    print_status "  FHIR Converter:    http://localhost:8082"
+    print_status "  Ingestion:         http://localhost:8083"
+    print_status "  Message Parser:    http://localhost:8085"
+    print_status "  Trigger Code Ref:  http://localhost:8086"
+    print_status ""
+    print_status "Health Check Endpoints:"
+    print_status "  eCR Viewer:        http://localhost:3000/"
+    print_status "  Orchestration:     http://localhost:8080/"
+    print_status "  FHIR Converter:    http://localhost:8082/"
+    print_status "  Ingestion:         http://localhost:8083/"
+    print_status "  Message Parser:    http://localhost:8085/"
+    print_status "  Trigger Code Ref:  http://localhost:8086/"
+    print_status ""
+    print_status "To view logs:      docker-compose -f $COMPOSE_FILE logs -f"
+    print_status "To stop services:  docker-compose -f $COMPOSE_FILE down"
+    print_status ""
+}
+
+# =============================================================================
+# Main Execution
+# =============================================================================
+
+main() {
+    echo ""
+    print_status "eCR Viewer Stack Deployment"
+    print_status "============================"
+    echo ""
+
+    check_prerequisites
+    check_environment
+    build_images
+    start_services
+    wait_for_health
+    show_endpoints
+}
+
+main "$@"

--- a/deployment/vm/dibbs-ecr-viewer-wizard.sh
+++ b/deployment/vm/dibbs-ecr-viewer-wizard.sh
@@ -1,0 +1,409 @@
+#!/bin/bash
+
+# This script is a setup wizard for the eCR Viewer application. It guides the user through the process of configuring
+# environment variables and setting up the necessary configurations for running the application using Docker Compose.
+#
+# Functions:
+# - clear_dot_env: Clears the .wizard file.
+# - display_intro: Displays an introductory message and documentation link.
+# - config_name: Prompts the user to select a configuration name from a list of options.
+# - confirm_dot_env_var: Prompts the user to input a value for a given environment variable, displays the current value from .env.
+# - set_dot_vars: Sets environment variables based on the selected configuration name and calls relevant functions to set additional variables.
+# - confirm_update: Displays the current environment variables and prompts the user to confirm them.
+# - restart_docker_compose: Restarts Docker Compose with the updated environment variables.
+# - add_env: Adds a key-value pair to the dibbs_ecr_viewer_wizard file.
+# - pg: Sets environment variables for PostgreSQL configuration.
+# - sqlserver: Sets environment variables for SQL Server configuration.
+# - nbs: Sets environment variables for NBS (National Electronic Disease Surveillance System Base System) configuration.
+# - aws: Sets environment variables for AWS configuration.
+# - azure: Sets environment variables for Azure configuration.
+#
+# The script follows these steps:
+# 1. Clears the dibbs_ecr_viewer_wizard file.
+# 2. Displays an introductory message.
+# 3. Prompts the user to select a configuration name.
+# 4. Sets environment variables based on the selected configuration.
+# 5. Prompts the user to confirm the environment variables.
+# 6. Replaces the contents of the dibbs_ecr_viewer_env file with the contents of the dibbs_ecr_viewer_wizard file.
+# 7. Restarts Docker Compose with the updated environment variables.
+
+project_dir=$HOME/dibbs-vm/dibbs-ecr-viewer
+dibbs_ecr_viewer_env=$project_dir/dibbs-ecr-viewer.env
+dibbs_ecr_viewer_bak=$project_dir/dibbs-ecr-viewer.bak
+dibbs_ecr_viewer_wizard=$project_dir/dibbs-ecr-viewer.wizard
+
+clear_dot_env() {
+  echo "" >"$dibbs_ecr_viewer_wizard"
+}
+
+display_intro() {
+  echo ""
+  echo -e "\e[1;32m**********************************************\e[0m"
+  echo -e "\e[1;32m*                                            *\e[0m"
+  echo -e "\e[1;32m*\e[0m   \e[1;37mWelcome to the eCR Viewer setup wizard\e[0m   \e[1;32m*\e[0m"
+  echo -e "\e[1;32m*                                            *\e[0m"
+  echo -e "\e[1;32m**********************************************\e[0m"
+  echo ""
+  echo -e "\e[1;32mDocumentation can be found at: \e[4;36mhttps://github.com/CDCgov/dibbs-vm\e[0m"
+  echo ""
+}
+
+set_vars() {
+  while IFS= read -r line; do
+    case $line in
+    CONFIG_NAME=*)
+      config_name=$(echo "$line" | cut -d'=' -f2-)
+      ;;
+    esac
+  done <"$dibbs_ecr_viewer_env"
+  if [ -z "$config_name" ]; then
+    config_name="\e[1;33mNONE SELECTED\e[0m"
+  fi
+  echo -e "Current configuration: $config_name"
+  echo ""
+  PS3='
+  Please select your CONFIG_NAME: '
+  options=(
+    "AWS_PG_NON_INTEGRATED"
+    "AWS_PG_DUAL"
+    "AWS_SQLSERVER_NON_INTEGRATED"
+    "AWS_SQLSERVER_DUAL"
+    "AWS_INTEGRATED"
+    "AZURE_PG_NON_INTEGRATED"
+    "AZURE_PG_DUAL"
+    "AZURE_SQLSERVER_NON_INTEGRATED"
+    "AZURE_SQLSERVER_DUAL"
+    "AZURE_INTEGRATED"
+    "GCP_PG_NON_INTEGRATED"
+    "GCP_PG_DUAL"
+    "GCP_SQLSERVER_NON_INTEGRATED"
+    "GCP_SQLSERVER_DUAL"
+    "GCP_INTEGRATED"
+    "Quit"
+  )
+  select opt in "${options[@]}"; do
+    echo ""
+    echo -e "\e[1;36m  Setting: CONFIG_NAME=$opt\e[0m"
+    echo ""
+    case $opt in
+    "AWS_PG_NON_INTEGRATED")
+      CONFIG_NAME="AWS_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_PG_DUAL")
+      CONFIG_NAME="AWS_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="AWS_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_SQLSERVER_DUAL")
+      CONFIG_NAME="AWS_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_INTEGRATED")
+      CONFIG_NAME="AWS_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_PG_NON_INTEGRATED")
+      CONFIG_NAME="AZURE_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_PG_DUAL")
+      CONFIG_NAME="AWS_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="AZURE_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_SQLSERVER_DUAL")
+      CONFIG_NAME="AZURE_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_INTEGRATED")
+      CONFIG_NAME="AZURE_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_PG_NON_INTEGRATED")
+      CONFIG_NAME="GCP_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_PG_DUAL")
+      CONFIG_NAME="GCP_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="GCP_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_SQLSERVER_DUAL")
+      CONFIG_NAME="GCP_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_INTEGRATED")
+      CONFIG_NAME="GCP_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "Quit")
+      break
+      ;;
+    *) echo "invalid option $REPLY" ;;
+    esac
+  done
+}
+
+confirm_dot_env_var() {
+  value=$1
+  default=$2
+  read -rp $'  \e[3m'"$value (Current Value: $default): "$'\e[0m' choice
+  if [ -z "$choice" ]; then
+    choice="$default"
+  fi
+  echo ""
+  echo -e "  \e[1;36mSetting: $value=$choice\e[0m"
+  echo ""
+  add_env "$value" "$choice"
+}
+
+confirm_update() {
+  echo -e "\e[1;33mPlease confirm the following settings (Double check for special characters that should be escaped):\e[0m"
+  vars=$(cat "$dibbs_ecr_viewer_wizard")
+  echo -e "\e[1;36m$vars\e[0m"
+  echo ""
+  read -p "Is this information correct? (y/n): " choice
+  if [ "$choice" != "y" ]; then
+    echo "Please run the script again and provide the correct information."
+    exit 1
+  fi
+  echo -e "\e[1;32mSettings confirmed. Updating your configuration.\e[0m"
+  cp "$dibbs_ecr_viewer_env" "$dibbs_ecr_viewer_bak"
+  cat "$dibbs_ecr_viewer_wizard" >"$dibbs_ecr_viewer_env"
+  while IFS= read -r line; do
+    # if line has an = sign, check the variable
+    if [[ $line == *"="* ]]; then
+      var=$(echo "$line" | cut -d'=' -f1-)
+      value=$(echo "$line" | cut -d'=' -f2-)
+      # if the variable is empty or just quotes, delete the line
+      if [[ $value == "" || $value == "\"\"" ]]; then
+        echo -e "\e[1;33mRemoving empty variable from configuration: $var\e[0m"
+        sed -i "/$var=/d" "$dibbs_ecr_viewer_env"
+      fi
+    fi
+  done <"$dibbs_ecr_viewer_env"
+  echo ""
+}
+
+restart_docker_compose() {
+  cd "$project_dir" || exit
+  docker compose down
+  docker compose up -d
+  cd -
+}
+
+add_env() {
+  if [[ $2 == \"*\" ]]; then
+    # variable is already quoted
+    echo "$1=$2" >>"$dibbs_ecr_viewer_wizard"
+  else
+    # variable is not quoted
+    echo "$1=\"$2\"" >>"$dibbs_ecr_viewer_wizard"
+  fi
+}
+
+pg() {
+  check_var DATABASE_URL "PostgreSQL connection string format: postgres://USER:PASSWORD@HOST:PORT/DATABASE_NAME"
+  check_var METADATA_DATABASE_SCHEMA "Schema options are: 'core' or 'extended'"
+  check_var METADATA_DATABASE_MIGRATION_SECRET "Migration secret used to trigger migrations"
+}
+
+sqlserver() {
+  check_var SQL_SERVER_USER
+  check_var SQL_SERVER_PASSWORD
+  check_var SQL_SERVER_HOST
+  check_var DB_CIPHER
+  check_var METADATA_DATABASE_SCHEMA "Schema options are: 'core' or 'extended'"
+  check_var METADATA_DATABASE_MIGRATION_SECRET "Migration secret used to trigger migrations, one will be generated and output to ecr-viewer logs if you do not provide one"
+}
+
+nbs() {
+  check_var NBS_API_PUB_KEY
+  check_var NBS_PUB_KEY
+}
+
+auth() {
+  check_var AUTH_PROVIDER "Valid options are 'ad' or 'keycloak'"
+  check_var AUTH_CLIENT_ID
+  check_var AUTH_CLIENT_SECRET
+  check_var AUTH_ISSUER
+  check_var AUTH_SESSION_DURATION_MIN "Optional: leave blank for use defaults"
+  check_var NEXTAUTH_URL "URL for the eCR Viewer application authentication: http(s)://(DOMAIN||IP:PORT)/ecr-viewer/api/auth/"
+}
+
+nextauth() {
+  check_var NEXTAUTH_SECRET "Generate a random secret using: openssl rand -base64 32"
+}
+
+optional() {
+  check_var SAVE_XML "Optional: leave blank for use defaults"
+  check_var DISPLAY_FEEDBACK_LINKS "Optional: leave blank for use defaults"
+  check_var ECR_PROCESSING_TIMEOUT "Optional: leave blank for use defaults"
+}
+
+aws() {
+  check_var AWS_REGION
+  check_var ECR_BUCKET_NAME
+}
+
+azure() {
+  check_var AZURE_STORAGE_CONNECTION_STRING
+  check_var AZURE_CONTAINER_NAME
+}
+
+gcp() {
+  check_var GCP_PROJECT_ID
+  check_var ECR_BUCKET_NAME
+}
+
+check_var() {
+  if [ -n "$2" ]; then
+    printf "\e[1;31m%s\e[0m" "INFO: $2"
+    echo ""
+  fi
+  if [ "$1" == "DIBBS_SERVICE" ]; then
+    echo -e "  \e[1;36mSetting: DIBBS_SERVICE=dibbs-ecr-viewer\e[0m"
+    echo ""
+    add_env "$1" "dibbs-ecr-viewer"
+  elif [ "$1" == "ORCHESTRATION_URL" ]; then
+    echo -e "  \e[1;36mSetting: ORCHESTRATION_URL=http://dibbs-orchestration:8080\e[0m"
+    echo ""
+    add_env "$1" "http://dibbs-orchestration:8080"
+  else
+    while IFS= read -r line; do
+      case $line in
+      $1=*)
+        # get the value after the first =, do not cut any other = signs
+        # this is to avoid cutting the value in case it has an = sign
+        var=$(echo "$line" | cut -d'=' -f2-)
+        ;;
+      esac
+    done <"$dibbs_ecr_viewer_env"
+    if [[ $var == "" ]]; then
+      echo -e "\e[1;33m$1 is not set.\e[0m"
+      echo ""
+    fi
+    confirm_dot_env_var "$1" "$var"
+    # clear var to avoid reusing previous value
+    var=""
+  fi
+}
+
+docker_compose_vars() {
+  # parse ecr-viewer.env file for environment variables
+  echo -e "\e[1;33mParsing eCR Viewer for default environment variables...\e[0m"
+  echo ""
+  check_var DIBBS_SERVICE
+  check_var ORCHESTRATION_URL
+  check_var DIBBS_VERSION
+}
+
+clear_dot_env
+display_intro
+docker_compose_vars
+set_vars
+confirm_update
+restart_docker_compose


### PR DESCRIPTION
## Summary

Adds comprehensive deployment infrastructure supporting three environments: local Docker Compose, AWS ECS Fargate, and Kubernetes/Helm. Covers all 6 microservices (ecr-viewer, orchestration, fhir-converter, ingestion, message-parser, trigger-code-reference).

## Changes

- **Docker Compose** — 6-service stack with health checks, depends_on conditions, port mappings, and env example
- **ECS Fargate** — Task definition with container definitions, CPU/memory allocations, health checks, environment variables
- **Helm Chart** — Chart.yaml, values (default/dev/prod), helpers, templates for 6 deployments, 6 services, configmap, secret, ingress, NOTES.txt
- **Scripts** — Local deploy.sh (Docker Compose) and ECS deploy-ecs.sh (ECR build/push + ECS service update)
- **VM Wizard** — Interactive setup script with 15 configuration profiles (AWS/Azure/GCP × PostgreSQL/SQLServer × integrated/dual)

## Why

The eCR Viewer microservices lacked deployment configurations for production environments. This provides a complete, multi-platform deployment path from local development to cloud production.

## Known Issues

- Helm secret.yaml missing keys referenced by ecr-viewer/orchestration/ingestion deployments (will address in follow-up)
- ECS task CPU/memory totals exceed Fargate allocation (will fix in follow-up)
- Helm ingress only routes to ecr-viewer, not other services
- deploy-ecs.sh missing `set -o pipefail`

## Testing

- [ ] Helm lint: `helm lint deployment/helm/ecr-viewer/`
- [ ] Docker Compose: `docker compose -f deployment/docker-compose.yml config`
- [ ] ECS task definition: JSON schema validation