### PR TITLE
fix: Update design review script

### DIFF
--- a/containers/ecr-viewer/design-review/README.md
+++ b/containers/ecr-viewer/design-review/README.md
@@ -30,8 +30,8 @@ Follow these steps to run script and spin up a local instance of the eCR Viewer.
    - Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. Default value is `true`.
    - If any other text is used for this second argument, an error message will be displayed: `Invalid value for IS_NON_INTEGRATED. It must be 'true' or 'false'`.
 6. Replace `<CONVERT_SEED_DATA>` with either `true` or `false`.
-   - `true`: Runs the FHIR conversion process on the available seed data. Use this option when new sample eCRs have been added to the repository. Without running the converter, the new eCRs will not be viewable in the eCR Viewer.
-   - `false` (default): Skips the FHIR conversion step, which can save time. Use this option when no new seed data has been added.
+   - `true` (default): Runs the FHIR conversion process on the available seed data. Use this option when new sample eCRs have been added to the repository. Without running the converter, the new eCRs will not be viewable in the eCR Viewer.
+   - `false`: Skips the FHIR conversion step, which can save time. Use this option when no new seed data has been added.
    - If any other text is used for this second argument, an error message will be displayed: `Invalid value for CONVERT_SEED_DATA. It must be 'true' or 'false'`.
 7. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
    - Note: If the landing page of the eCR Viewer displays `Something went wrong!`, try reloading the page to resolve the error.

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -29,7 +29,7 @@ if [ -n "$3" ]; then
         exit 1
     fi
 else
-    CONVERT_SEED_DATA=false
+    CONVERT_SEED_DATA=true
 fi
 
 # Function to check if a command exists
@@ -108,7 +108,8 @@ fi
 npm run local-docker:silent
 
 # Wait for eCR Viewer to be available
-while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -q "200"; do
+# 200 for OK, or 307 for redirect to sign-in page
+while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -qE "200|307"; do
     echo "Waiting for $URL to be available..."
     sleep 5
 done


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Accept status code `307` for redirect (to sign-in page) -- prevents script from waiting forever
- Update README

## Related Issue

Fixes # N/A

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Eh, down the line, might want to deprecate the `CONVERT_SEED_DATA` flag (setting it to `false` will result in an `eCR Viewer setup is incomplete` error page).

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
