### PR TITLE
feat: add eCR Viewer VM deployment scripts and README rewrite

### DIFF
--- a/deployment/vm/README.md
+++ b/deployment/vm/README.md
@@ -1,0 +1,95 @@
+# eCR Viewer - VM Deployment Scripts
+
+Scripts for provisioning and managing an eCR Viewer deployment on an Ubuntu VM.
+
+## Prerequisites
+
+- Ubuntu 24.04 server
+- Internet access (scripts download Docker and configuration files)
+
+## Quick Start
+
+```bash
+# 1. Download scripts and config (installs to ~/dibbs-ecr-viewer-deployment/)
+cd ~ && curl -sSL https://raw.githubusercontent.com/CDCgov/dibbs-ecr-viewer/main/deployment/vm/ecrv-init.sh | bash
+
+# 2. Install Docker
+# You can try our script of you can install it yourself.
+sudo ./docker-install.sh
+
+# 3. Run update
+# Creates a backup of the `dibbs-ecr-viewer-deployment` dir
+# Confirms Docker installation
+# Triggers `ecrv-wizard.sh` for env var setup
+./ecrv-update.sh
+```
+
+## Deployment Scripts
+
+### 1. Download scripts - `ecrv-init.sh`
+
+Prerequisites check → config backup → downloads scripts + `.env`/`.yaml` files from GitHub → chmod +x → Docker presence check.
+
+### 2. Install Docker - `docker-install.sh`
+
+Installs Docker Engine, CLI, containerd, buildx, and compose plugin from the official Docker APT repository. Adds the current user to the `docker` group.
+
+### 3. Configure application - `ecrv-update.sh`
+
+Backs up existing config, then prompts to run the interactive wizard. The wizard configures `CONFIG_NAME` (15 provider/database profiles), database connections, cloud storage, auth, and optional settings. On confirmation, writes to `dibbs-ecr-viewer.env`, creates a `.bak` backup, and restarts Docker Compose.
+
+### 4. Other scripts
+
+- `ecrv-wizard.sh`
+- Runs the setup wizard, triggered by `ecrv-update.sh`
+
+```bash
+./ecrv-wizard.sh
+```
+
+- `apt-update.sh`
+- Runs apt-get update commands
+
+```bash
+./apt-updates.sh -udac   # all: update + upgrade + autoremove + clean
+./apt-updates.sh -u      # update only
+./apt-updates.sh -h      # help
+```
+
+- `condig-backup.sh`
+- Creates a backup and ensures the `dibbs-ecr-viewer-deployment` directory is available
+
+```bash
+./config-update
+```
+
+- `check.sh`
+- Runs `shellcheck` on all deployment scripts.
+
+```bash
+./check.sh
+```
+
+## File Layout
+
+```
+~/dibbs-ecr-viewer-deployment/
+|-- dibbs-ecr-viewer.env       # active configuration
+|-- dibbs-ecr-viewer.bak       # wizard backup
+|-- dibbs-ecr-viewer.wizard    # temp file during wizard run
+|-- dibbs-orchestration.env    # orchestration config
+|-- docker-compose.yaml        # Docker Compose stack
+
+~/
+|-- apt-updates.sh
+|-- config-backup.sh
+|-- docker-install.sh
+|-- ecrv-init.sh
+|-- ecrv-update.sh
+|-- ecrv-wizard.sh
+```
+
+## Troubleshooting
+
+- **Docker not installed** - `ecrv-init.sh` warns but continues. Install Docker.
+- **Wizard hangs** - requires an interactive terminal. Non-TTY runs block on `read`.

--- a/deployment/vm/apt-updates.sh
+++ b/deployment/vm/apt-updates.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# This script updates the Ubuntu server packages
+# removes unnecessary packages, and cleans up the cache.
+#
+# Functions:
+#   set_defaults: Initializes default values for the script options.
+#   help: Displays the usage information and available options.
+#   check_options: Parses and validates the command-line options.
+#   run_commands: Executes the update, upgrade, autoremove, and clean commands based on the provided options.
+
+set -euo pipefail
+
+set_defaults() {
+  apt_update=false
+  apt_upgrade=false
+  apt_autoremove=false
+  apt_clean=false
+}
+
+msg() {
+  echo -e "\e[1;32m$1\e[0m"
+}
+
+help() {
+  echo "Usage: ./apt-updates.sh [-u] [-d] [-a] [-c] [-h] OR [-udac]"
+  echo "Run all options: ./apt-updates.sh -udac"
+  echo "Options:"
+  echo "  -u  Update the package list"
+  echo "  -d  Upgrade the installed packages"
+  echo "  -a  Remove unnecessary packages"
+  echo "  -c  Clean up the cache"
+  echo "  -h  Display this help message"
+  exit 1
+}
+
+check_options() {
+  # if no arguments are passed, run the help message
+  if [ $# -eq 0 ]; then
+    help
+  fi
+  while getopts "udach" opt; do
+    case ${opt} in
+      u )
+        apt_update=true
+        ;;
+      d )
+        apt_upgrade=true
+        ;;
+      a )
+        apt_autoremove=true
+        ;;
+      c )
+        apt_clean=true
+        ;;
+      h )
+        help
+        ;;
+      \? )
+        echo "Invalid option: $OPTARG"
+        ;;
+    esac
+  done
+  shift $((OPTIND -1))
+}
+
+run_commands() {
+  if [ "$apt_update" = true ]; then
+    msg "Updating package list..."
+    sudo apt-get update -y
+    msg "Package list updated"
+  fi
+  if [ "$apt_upgrade" = true ]; then
+    msg "Upgrading installed packages..."
+    sudo apt-get upgrade -y
+    msg "Installed packages upgraded"
+  fi
+  if [ "$apt_autoremove" = true ]; then
+    msg "Removing unnecessary packages..."
+    sudo apt-get autoremove -y
+    msg "Unnecessary packages removed"
+  fi
+  if [ "$apt_clean" = true ]; then
+    msg "Cleaning up the cache..."
+    sudo apt-get clean
+    msg "Cache cleaned up"
+  fi
+}
+
+set_defaults
+check_options "$@"
+run_commands

--- a/deployment/vm/check.sh
+++ b/deployment/vm/check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# Run shellcheck against eCR Viewer deployment scripts
+# Exit non-zero on any warning
+
+set -e
+
+SCRIPTS=(
+  apt-updates.sh
+  config-backup.sh
+  docker-install.sh
+  ecrv-init.sh
+  ecrv-update.sh
+  ecrv-wizard.sh
+)
+
+EXCLUDE=""  # variables set elsewhere / sourced-in vars
+
+echo "Running shellcheck on deployment scripts..."
+echo "Excluding: $EXCLUDE"
+echo "---"
+
+fail=0
+for script in "${SCRIPTS[@]}"; do
+  if [ ! -f "$script" ]; then
+    echo "SKIP  $script (not found)"
+    continue
+  fi
+  echo -n "PASS  $script"
+  if ! shellcheck -e "$EXCLUDE" "$script" >/dev/null 2>&1; then
+    echo "  FAILED"
+    shellcheck -e "$EXCLUDE" "$script" || true
+    fail=1
+  else
+    echo "  OK"
+  fi
+done
+
+echo "---"
+if [ "$fail" -ne 0 ]; then
+  echo "shellcheck: FAILED (see warnings above)"
+  exit 1
+fi
+echo "shellcheck: all passed"
+exit 0

--- a/deployment/vm/config-backup.sh
+++ b/deployment/vm/config-backup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# Backs up the existing DIBBS_CONFIG_DIR directory (if present) and ensures
+# the directory exists for subsequent use.
+#
+# Functions:
+#   backup_config: Renames DIBBS_CONFIG_DIR to DIBBS_CONFIG_DIR.backup.TIMESTAMP
+#   create_config_dir: Creates DIBBS_CONFIG_DIR if it doesn't exist
+#
+# Globals:
+#   DIBBS_CONFIG_DIR — must be set by the caller before invoking main()
+
+set -euo pipefail
+
+DIBBS_CONFIG_DIR="${HOME}/dibbs-ecr-viewer-deployment"
+
+backup_config() {
+  # Backup existing clone if present
+  echo "Backing up existing configuration (if any)..."
+  if [ -d "$DIBBS_CONFIG_DIR" ]; then
+    BACKUP_DIR="${DIBBS_CONFIG_DIR}.backup.${RANDOM}.$(date +%Y%m%d%H%M%S)"
+    echo "Backing up configuration to: $BACKUP_DIR"
+    cp -R "$DIBBS_CONFIG_DIR" "$BACKUP_DIR"
+  fi
+  echo "Backup complete."
+  echo ""
+}
+
+create_config_dir() {
+  echo "Ensuring configuration directory exists: $DIBBS_CONFIG_DIR"
+  if [ ! -d "$DIBBS_CONFIG_DIR" ]; then
+    echo "Creating configuration directory..."
+    mkdir -p "$DIBBS_CONFIG_DIR"
+  fi
+  echo "Configuration directory ready."
+  echo ""
+}
+
+# Main execution
+main() {
+  echo "================================="
+  echo "  DIBBS eCR Viewer Config Backup"
+  echo "================================="
+  echo ""
+  backup_config
+  create_config_dir
+  echo "============================="
+  echo "  Backup Complete! "
+  echo "  New config directory ready at: $DIBBS_CONFIG_DIR"
+  echo "=============================="
+  echo ""
+}
+
+main

--- a/deployment/vm/dibbs-orchestration.env
+++ b/deployment/vm/dibbs-orchestration.env
@@ -1,0 +1,7 @@
+OTEL_METRICS=none
+OTEL_METRICS_EXPORTER=none
+ECR_VIEWER_URL=http://dibbs-ecr-viewer:3000/ecr-viewer
+INGESTION_URL=http://dibbs-ingestion:8080
+FHIR_CONVERTER_URL=http://dibbs-fhir-converter:8080
+MESSAGE_PARSER_URL=http://dibbs-message-parser:8080
+TRIGGER_CODE_REFERENCE_URL=http://dibbs-trigger-code-reference:8080

--- a/deployment/vm/docker-compose.yaml
+++ b/deployment/vm/docker-compose.yaml
@@ -1,0 +1,107 @@
+services:
+  ecr-viewer:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/ecr-viewer:$DIBBS_VERSION
+    container_name: dibbs-ecr-viewer
+    restart: always
+    env_file: "dibbs-ecr-viewer.env"
+    ports:
+      - "3000:3000"
+    networks:
+      - dibbs
+    healthcheck:
+      test:
+        ["CMD", "wget", "--spider", "http://127.0.0.1:3000/api/health-check"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 30s
+
+  ingestion:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/ingestion:$DIBBS_VERSION
+    container_name: dibbs-ingestion
+    restart: always
+    ports:
+      - "8080:8080"
+    networks:
+      - dibbs
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:8080/"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
+
+  fhir-converter:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/fhir-converter:$DIBBS_VERSION
+    container_name: dibbs-fhir-converter
+    restart: always
+    ports:
+      - "8082:8080"
+    networks:
+      - dibbs
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:8080/"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
+
+  message-parser:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/message-parser:$DIBBS_VERSION
+    container_name: dibbs-message-parser
+    restart: always
+    ports:
+      - "8083:8080"
+    networks:
+      - dibbs
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:8080/"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
+
+  trigger-code-reference:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/trigger-code-reference:$DIBBS_VERSION
+    container_name: dibbs-trigger-code-reference
+    restart: always
+    ports:
+      - "8084:8080"
+    networks:
+      - dibbs
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:8080/"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
+
+  orchestration:
+    image: ghcr.io/cdcgov/dibbs-ecr-viewer/orchestration:$DIBBS_VERSION
+    container_name: dibbs-orchestration
+    env_file: "dibbs-orchestration.env"
+    restart: always
+    ports:
+      - "8085:8080"
+    networks:
+      - dibbs
+    depends_on:
+      ecr-viewer:
+        condition: service_healthy
+      ingestion:
+        condition: service_healthy
+      fhir-converter:
+        condition: service_healthy
+      message-parser:
+        condition: service_healthy
+      trigger-code-reference:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:8080/"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
+
+networks:
+  dibbs:

--- a/deployment/vm/docker-install.sh
+++ b/deployment/vm/docker-install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# If this script doesn't work for you, you can install Docker manually by following the instructions here: https://docs.docker.com/engine/install/ubuntu/
+#
+# This script installs Docker Engine on an Ubuntu server from the official Docker APT repository.
+# The script follows these steps:
+#   1. Exports DEBIAN_FRONTEND=noninteractive to suppress apt prompts.
+#   2. Updates the package list.
+#   3. Creates /etc/apt/keyrings with proper permissions.
+#   4. Downloads the Docker GPG key to /etc/apt/keyrings/docker.asc.
+#   5. Adds the Docker repository to APT sources.
+#   6. Updates the package list again to include the Docker repository.
+#   7. Installs Docker packages: docker-ce, docker-ce-cli, containerd.io, docker-buildx-plugin, docker-compose-plugin.
+#   8. Adds the current user to the docker group.
+#   9. Enables and starts Docker and containerd services.
+
+export DEBIAN_FRONTEND=noninteractive
+
+# --- 1. Update package list ---
+echo "[$(date)] Updating package lists..."
+apt-get update -qq
+
+# --- 2. Create keyring directory ---
+install -m 0755 -d /etc/apt/keyrings
+
+# --- 3. Download Docker GPG key ---
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+
+# --- 4. Add Docker repository ---
+# shellcheck source=/dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+    https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# --- 5. Update and install Docker ---
+echo "[$(date)] Updating package lists again and installing Docker..."
+apt-get update -qq
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+real_user="${SUDO_USER:-$(whoami)}"
+
+# --- 6. Add user to docker group ---
+echo "[$(date)] Adjusting Docker group permissions."
+groupadd docker 2>/dev/null || true
+usermod -aG docker "$real_user"
+echo "[$(date)] Note: adding $real_user to docker group. Run 'sg docker -c \"docker info\"' to test, or log out/in for it to take effect."
+
+# --- 7. Enable and start services ---
+echo "[$(date)] Enabling Docker and containerd services."
+systemctl enable docker.service
+systemctl enable containerd.service
+
+# --- 8. Verify service started ---
+if ! systemctl is-active --quiet docker.service; then
+  echo "[$(date)] ERROR: Docker service failed to start."
+  echo "Docker status:"
+  systemctl status docker.service
+  echo "Journal logs:"
+  journalctl -xeu docker.service --no-pager -n 40
+  if [ -f /var/log/docker.log ]; then
+    echo "[$(date)] Showing last 40 lines of /var/log/docker.log:"
+    tail -40 /var/log/docker.log
+  fi
+  exit 4
+fi
+
+systemctl status docker.service
+echo "Docker installation complete!"

--- a/deployment/vm/ecrv-init.sh
+++ b/deployment/vm/ecrv-init.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# Downloads eCR Viewer deployment scripts from GitHub and performs initial VM setup.
+#
+# Usage:
+#   ./ecrv-init.sh
+#
+# Functions:
+#   check_prerequisites - Installs wget if missing
+#   download_scripts    - Downloads scripts from GitHub into ${DIBBS_CONFIG_DIR}
+#   check_docker        - Warns if Docker is not installed (does NOT abort)
+#   main                - Orchestrates prerequisites → backup → download → docker check
+#
+# Variables:
+#   REPO_URL         - Base URL for raw GitHub content (CDCgov/dibbs-ecr-viewer repo)
+#   DIBBS_CONFIG_DIR - Target directory for downloaded files
+#
+# Side effects:
+#   Downloads 9 files into ${DIBBS_CONFIG_DIR} (3 .env, 1 .yaml, 5 .sh scripts).
+#   Runs `chmod +x <script>.sh` in the **home directory**, not ${DIBBS_CONFIG_DIR}.
+#   Sources backup.sh via `source` so variables are inherited.
+#   Warns about Docker but does NOT abort if missing.
+
+set -e
+
+echo "=================================="
+echo "  DIBBS eCR Viewer Initial Setup  "
+echo "=================================="
+echo ""
+
+# Configuration
+REPO_URL="https://raw.githubusercontent.com/CDCgov/dibbs-ecr-viewer"
+DIBBS_CONFIG_DIR="${HOME}/dibbs-ecr-viewer-deployment"
+BRANCH="main"
+
+# Prerequisites check
+check_prerequisites() {
+  echo "Checking prerequisites..."
+
+  # Install wget if missing
+  if ! command -v wget &> /dev/null; then
+    echo "WARNING: wget is not installed. Installing..."
+    # shellcheck disable=SC2015
+    sudo apt-get update -qq && sudo apt-get install -y -qq wget || { echo "ERROR: Failed to install wget."; exit 1; }
+  fi
+
+  echo "Prerequisites check complete."
+  echo ""
+}
+
+download_scripts() {
+  cd "$HOME"
+  echo "Downloading ecrv scripts..."
+
+  wget -O apt-updates.sh ${REPO_URL}/${BRANCH}/deployment/vm/apt-updates.sh
+  wget -O config-backup.sh ${REPO_URL}/${BRANCH}/deployment/vm/config-backup.sh
+  wget -O docker-install.sh ${REPO_URL}/${BRANCH}/deployment/vm/docker-install.sh
+  wget -O ecrv-init.sh ${REPO_URL}/${BRANCH}/deployment/vm/ecrv-init.sh
+  wget -O ecrv-update.sh ${REPO_URL}/${BRANCH}/deployment/vm/ecrv-update.sh
+  wget -O ecrv-wizard.sh ${REPO_URL}/${BRANCH}/deployment/vm/ecrv-wizard.sh
+
+  chmod +x apt-updates.sh
+  chmod +x config-backup.sh
+  chmod +x docker-install.sh
+  chmod +x ecrv-init.sh
+  chmod +x ecrv-update.sh
+  chmod +x ecrv-wizard.sh
+
+  echo "New ecrv scripts downloaded to: $HOME"
+  echo ""
+}
+
+download_config() {
+  cd "$HOME"
+  echo "Downloading docker configuration..."
+
+  # -P set directory, -nc skip if file exists because we don't want to overwrite any user settings
+  wget -nc -P "${DIBBS_CONFIG_DIR}" "${REPO_URL}/${BRANCH}/deployment/vm/dibbs-ecr-viewer.env"
+  wget -P "${DIBBS_CONFIG_DIR}" "${REPO_URL}/${BRANCH}/deployment/vm/dibbs-orchestration.env"
+  # remove old docker-compose.yaml if it exists to ensure we get the latest version (in case of breaking changes)
+  rm -f "${DIBBS_CONFIG_DIR}/docker-compose.yaml" || true
+  wget -P "${DIBBS_CONFIG_DIR}" "${REPO_URL}/${BRANCH}/deployment/vm/docker-compose.yaml"
+
+  echo "New docker configuration downloaded to: $DIBBS_CONFIG_DIR"
+  echo ""
+}
+
+check_docker() {
+  if ! docker info &> /dev/null; then
+    echo "WARNING: Docker is not properly installed or accessible for this user."
+    echo "  Ensure the Docker service is running and your user has permissions."
+    echo "  See the Docker installation docs or official docker installation repo for details"
+    echo "  Docs site: https://docs.docker.com/engine/install/ubuntu/"
+    echo "  Repo site: https://github.com/docker/docker-install"
+  else
+    echo "Docker is installed and accessible."
+  fi
+}
+
+# Main execution
+main() {
+  check_prerequisites
+  download_scripts
+  source ./config-backup.sh
+  download_config
+
+  check_docker
+  echo ""
+  echo "==================="
+  echo "  Setup Complete!  "
+  echo "==================="
+  echo "To continue the update:"
+  echo "cd $HOME"
+  echo "./ecrv-update.sh"
+  echo ""
+}
+
+main

--- a/deployment/vm/ecrv-update.sh
+++ b/deployment/vm/ecrv-update.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# Runs the eCR Viewer configuration wizard after verifying Docker is installed.
+#
+# Usage:
+#   ./ecrv-update.sh
+#
+# Functions:
+#   check_docker        - Exits with error if Docker is not properly installed
+#   backup_config       - Sources config-backup.sh to backup existing config and prepare for new config
+#   prompt_ecrv_wizard  - Asks user whether to run the interactive wizard
+#   main                - Orchestrates: docker check → config-backup → wizard prompt
+#
+# Side effects:
+#   Sources config-backup.sh via `source` (not `./config-backup.sh`) so variables are inherited.
+#   Runs ./ecrv-wizard.sh if user answers "y" to the prompt.
+#   Aborts with exit code 1 if Docker is not found.
+
+set -e
+
+echo "================================="
+echo "  DIBBS eCR Viewer Update"
+echo "================================="
+echo ""
+
+check_docker() {
+  echo "Checking Docker installation..."
+  if ! docker info &> /dev/null; then
+    echo "WARNING: Docker is not properly installed or accessible for this user."
+    echo "  Ensure the Docker service is running and your user has permissions."
+    exit 1
+  else
+    echo "Docker is installed and accessible."
+    echo ""
+  fi
+}
+
+prompt_ecrv_wizard() {
+  echo "The wizard script sets environment variables"
+  read -rp "Would you like to run the wizard script? (y/n): " choice
+  if [ "$choice" = "y" ]; then
+    ./ecrv-wizard.sh
+  else
+    echo "Exiting..."
+    exit 0
+  fi
+}
+
+# Main execution
+main() {
+  check_docker
+  source ./config-backup.sh
+  prompt_ecrv_wizard
+  echo ""
+  echo "==================="
+  echo "  Update Complete!"
+  echo "==================="
+  echo ""
+}
+
+main

--- a/deployment/vm/ecrv-wizard.sh
+++ b/deployment/vm/ecrv-wizard.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+
+# Use at your own risk. Always review scripts before running them on your system.
+#
+# Interactive setup wizard for the eCR Viewer application. Guides the user through
+# configuring environment variables and applying them to dibbs-ecr-viewer.env.
+#
+# Usage:
+#   ./ecrv-wizard.sh
+#
+# Functions:
+#   clear_dot_env          - Truncates the .wizard temp file
+#   display_intro          - Prints welcome banner and documentation link
+#   docker_compose_vars    - Prompts for ORCHESTRATION_URL and DIBBS_VERSION
+#   set_vars               - Presents 15 config profiles, calls provider functions
+#   confirm_dot_env_var    - Prompts for a variable value with .env default
+#   confirm_update         - Displays all settings, cleans empty vars via sed
+#   restart_docker_compose - Runs `docker compose down && docker compose up -d`
+#   add_env                - Writes quoted key-value to .wizard file
+#   check_var              - Reads existing .env value, prompts for confirmation
+#   pg, sqlserver, nbs     - Database config prompts (PostgreSQL, SQL Server, NBS)
+#   aws, azure, gcp        - Storage provider prompts (S3, Blob, GCS)
+#   auth, nextauth         - Authentication config prompts (AD/Keycloak, NextAuth)
+#   optional               - Optional config prompts (SAVE_XML, DISPLAY_FEEDBACK_LINKS)
+#   main                   - Orchestrates: clear → intro → compose vars → config → confirm → restart
+#
+# Variables:
+#   project_dir              - Base path (default: ~/dibbs-ecr-viewer-deployment)
+#   dibbs_ecr_viewer_env     - Active env file path
+#   dibbs_ecr_viewer_bak     - Backup file created during confirmation
+#   dibbs_ecr_viewer_wizard  - Temp file for collecting new variables
+#
+# Side effects:
+#   15 config profiles (AWS/Azure/GCP × PG/SQLServer/Integrated × Non-Integrated/Dual).
+#   `check_var ORCHESTRATION_URL` hardcodes to `http://dibbs-orchestration:8080` without prompting.
+#   confirm_update deletes lines with empty values via `sed -i "/$var=/d"`.
+#   Non-interactive warning: `read -p` blocks indefinitely if run without a TTY.
+
+project_dir=$HOME/dibbs-ecr-viewer-deployment
+dibbs_ecr_viewer_env=$project_dir/dibbs-ecr-viewer.env
+dibbs_ecr_viewer_bak=$project_dir/dibbs-ecr-viewer.bak
+dibbs_ecr_viewer_wizard=$project_dir/dibbs-ecr-viewer.wizard
+
+clear_dot_env() {
+  echo "" >"$dibbs_ecr_viewer_wizard"
+}
+
+display_intro() {
+  echo ""
+  echo -e "\e[1;32m**********************************************\e[0m"
+  echo -e "\e[1;32m*                                            *\e[0m"
+  echo -e "\e[1;32m*\e[0m   \e[1;37mWelcome to the eCR Viewer setup wizard\e[0m   \e[1;32m*\e[0m"
+  echo -e "\e[1;32m*                                            *\e[0m"
+  echo -e "\e[1;32m**********************************************\e[0m"
+  echo ""
+  echo -e "\e[1;32mDocumentation can be found at: \e[4;36mhttps://github.com/CDCgov/dibbs-ecr-viewer\e[0m"
+  echo ""
+}
+
+set_vars() {
+  while IFS= read -r line; do
+    case $line in
+    CONFIG_NAME=*)
+      config_name=$(echo "$line" | cut -d'=' -f2-)
+      ;;
+    esac
+  done <"$dibbs_ecr_viewer_env"
+  if [ -z "$config_name" ]; then
+    config_name="\e[1;33mNONE SELECTED\e[0m"
+  fi
+  echo -e "Current configuration: $config_name"
+  echo ""
+  PS3='
+  Please select your CONFIG_NAME: '
+  options=(
+    "AWS_PG_NON_INTEGRATED" 
+    "AWS_PG_DUAL"
+    "AWS_SQLSERVER_NON_INTEGRATED"
+    "AWS_SQLSERVER_DUAL"
+    "AWS_INTEGRATED"
+    "AZURE_PG_NON_INTEGRATED"
+    "AZURE_PG_DUAL"
+    "AZURE_SQLSERVER_NON_INTEGRATED"
+    "AZURE_SQLSERVER_DUAL"
+    "AZURE_INTEGRATED"
+    "GCP_PG_NON_INTEGRATED"
+    "GCP_PG_DUAL"
+    "GCP_SQLSERVER_NON_INTEGRATED"
+    "GCP_SQLSERVER_DUAL"
+    "GCP_INTEGRATED"
+    "Quit"
+  )
+  select opt in "${options[@]}"; do
+    echo ""
+    echo -e "\e[1;36m  Setting: CONFIG_NAME=$opt\e[0m"
+    echo ""
+    case $opt in
+    "AWS_PG_NON_INTEGRATED")
+      CONFIG_NAME="AWS_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_PG_DUAL")
+      CONFIG_NAME="AWS_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="AWS_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_SQLSERVER_DUAL")
+      CONFIG_NAME="AWS_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AWS_INTEGRATED")
+      CONFIG_NAME="AWS_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      aws
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_PG_NON_INTEGRATED")
+      CONFIG_NAME="AZURE_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_PG_DUAL")
+      CONFIG_NAME="AZURE_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="AZURE_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_SQLSERVER_DUAL")
+      CONFIG_NAME="AZURE_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "AZURE_INTEGRATED")
+      CONFIG_NAME="AZURE_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      azure
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_PG_NON_INTEGRATED")
+      CONFIG_NAME="GCP_PG_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      pg
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_PG_DUAL")
+      CONFIG_NAME="GCP_PG_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      pg
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_SQLSERVER_NON_INTEGRATED")
+      CONFIG_NAME="GCP_SQLSERVER_NON_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      sqlserver
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_SQLSERVER_DUAL")
+      CONFIG_NAME="GCP_SQLSERVER_DUAL"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      sqlserver
+      nbs
+      auth
+      nextauth
+      optional
+      break
+      ;;
+    "GCP_INTEGRATED")
+      CONFIG_NAME="GCP_INTEGRATED"
+      add_env "CONFIG_NAME" "$CONFIG_NAME"
+      gcp
+      nbs
+      nextauth
+      optional
+      break
+      ;;
+    "Quit")
+      break
+      ;;
+    *) echo "invalid option $REPLY" ;;
+    esac
+  done
+}
+
+confirm_dot_env_var() {
+  value=$1
+  default=$2
+  read -rp $'  \e[3m'"$value (Current Value: $default): "$'\e[0m' choice
+  if [ -z "$choice" ]; then
+    choice="$default"
+  fi
+  echo ""
+  echo -e "  \e[1;36mSetting: $value=$choice\e[0m"
+  echo ""
+  add_env "$value" "$choice"
+}
+
+confirm_update() {
+  echo -e "\e[1;33mPlease confirm the following settings (Double check for special characters that should be escaped):\e[0m"
+  vars=$(cat "$dibbs_ecr_viewer_wizard")
+  echo -e "\e[1;36m$vars\e[0m"
+  echo ""
+  read -p "Is this information correct? (y/n): " -r choice
+  if [ "$choice" != "y" ]; then
+    echo "Please run the script again and provide the correct information."
+    exit 1
+  fi
+  echo -e "\e[1;32mSettings confirmed. Updating your configuration.\e[0m"
+  cp "$dibbs_ecr_viewer_env" "$dibbs_ecr_viewer_bak"
+  cat "$dibbs_ecr_viewer_wizard" >"$dibbs_ecr_viewer_env"
+  # Read all lines first, then process - avoid read/write conflict with sed -i
+  while IFS= read -r line; do
+    # if line has an = sign, check the variable
+    if [[ $line == *"="* ]]; then
+      var=$(echo "$line" | cut -d'=' -f1)
+      value=$(echo "$line" | cut -d'=' -f2-)
+      # if the variable is empty or just quotes, delete the line
+      if [[ $value == "" || $value == "\"\"" ]]; then
+        echo -e "\e[1;33mRemoving empty variable from configuration: $var\e[0m"
+        sed -i "/$var=/d" "$dibbs_ecr_viewer_env"
+      fi
+      # Update ~/.bashrc with the confirmed DIBBS_VERSION (must be before cleanup)
+      if [[ $var == *"DIBBS_VERSION"* ]]; then
+        set_bashrc_var "DIBBS_VERSION" "$value"
+        DIBBS_VERSION=$value
+      fi
+    fi
+  done < <(cat "$dibbs_ecr_viewer_env")
+  echo ""
+}
+
+restart_docker_compose() {
+  cd "$project_dir" || exit
+  docker compose down
+  DIBBS_VERSION=${DIBBS_VERSION//\"/} docker compose up -d
+  cd - || exit
+}
+
+add_env() {
+  if [[ $2 == \"*\" ]]; then
+    # variable is already quoted
+    echo "$1=$2" >>"$dibbs_ecr_viewer_wizard"
+  else
+    # variable is not quoted
+    echo "$1=\"$2\"" >>"$dibbs_ecr_viewer_wizard"
+  fi
+}
+
+# Set an environment variable in ~/.bashrc: remove any existing line and append.
+# $1=var_name, $2=value (already quoted, e.g. "1.0.0").
+set_bashrc_var() {
+  local bashrc="$HOME/.bashrc"
+  local version=${2//\"/}
+
+  echo "Updating ~/.bashrc with ${1}=$version"
+  sed -i "/^export ${1}=/d" "$bashrc"
+  echo "export ${1}=$version" >> "$bashrc"
+  echo -e "  \e[1;36mSet $1 in ~/.bashrc\e[0m"
+  echo ""
+}
+
+pg() {
+  check_var DATABASE_URL "PostgreSQL connection string format: postgres://USER:PASSWORD@HOST:PORT/DATABASE_NAME"
+  check_var METADATA_DATABASE_SCHEMA "Schema options are: 'core' or 'extended'"
+  check_var METADATA_DATABASE_MIGRATION_SECRET "Migration secret used to trigger migrations"
+}
+
+sqlserver() {
+  check_var SQL_SERVER_USER
+  check_var SQL_SERVER_PASSWORD
+  check_var SQL_SERVER_HOST
+  check_var DB_CIPHER
+  check_var METADATA_DATABASE_SCHEMA "Schema options are: 'core' or 'extended'"
+  check_var METADATA_DATABASE_MIGRATION_SECRET "Migration secret used to trigger migrations, one will be generated and output to ecr-viewer logs if you do not provide one"
+}
+
+nbs() {
+  check_var NBS_API_PUB_KEY
+  check_var NBS_PUB_KEY
+}
+
+auth() {
+  check_var AUTH_PROVIDER "Valid options are 'ad' or 'keycloak'"
+  check_var AUTH_CLIENT_ID
+  check_var AUTH_CLIENT_SECRET
+  check_var AUTH_ISSUER
+  check_var AUTH_SESSION_DURATION_MIN "Optional: leave blank for use defaults"
+  check_var NEXTAUTH_URL "URL for the eCR Viewer application authentication: http(s)://(DOMAIN||IP:PORT)/ecr-viewer/api/auth/"
+}
+
+nextauth() {
+  check_var NEXTAUTH_SECRET "Generate a random secret using: openssl rand -base64 32"
+}
+
+optional() {
+  check_var SAVE_XML "Optional: leave blank for use defaults"
+  check_var DISPLAY_FEEDBACK_LINKS "Optional: leave blank for use defaults"
+  check_var ECR_PROCESSING_TIMEOUT "Optional: leave blank for use defaults"
+}
+
+aws() {
+  check_var AWS_REGION
+  check_var ECR_BUCKET_NAME
+}
+
+azure() {
+  check_var AZURE_STORAGE_CONNECTION_STRING
+  check_var AZURE_CONTAINER_NAME
+}
+
+gcp() {
+  check_var GCP_PROJECT_ID
+  check_var ECR_BUCKET_NAME
+}
+
+check_var() {
+  if [ -n "$2" ]; then
+    printf "\e[1;31m%s\e[0m" "INFO: $2"
+    echo ""
+  fi
+  if [ "$1" == "ORCHESTRATION_URL" ]; then
+    echo -e "  \e[1;36mSetting: ORCHESTRATION_URL=http://dibbs-orchestration:8080\e[0m"
+    echo ""
+    add_env "$1" "http://dibbs-orchestration:8080"
+  else
+    while IFS= read -r line; do
+      case $line in
+      $1=*)
+        # get the value after the first =, do not cut any other = signs
+        # this is to avoid cutting the value in case it has an = sign
+        var=$(echo "$line" | cut -d'=' -f2-)
+        ;;
+      esac
+    done <"$dibbs_ecr_viewer_env"
+    if [[ $var == "" ]]; then
+      echo -e "\e[1;33m$1 is not set.\e[0m"
+      echo ""
+    fi
+    confirm_dot_env_var "$1" "$var"
+    # clear var to avoid reusing previous value
+    var=""
+  fi
+}
+
+docker_compose_vars() {
+  # parse ecr-viewer.env file for environment variables
+  echo -e "\e[1;33mParsing eCR Viewer for default environment variables...\e[0m"
+  echo ""
+  check_var ORCHESTRATION_URL
+  check_var DIBBS_VERSION
+}
+
+main() {
+  clear_dot_env
+  display_intro
+  docker_compose_vars
+  set_vars
+  confirm_update
+  restart_docker_compose
+}
+
+main


### PR DESCRIPTION
## Summary
Adds VM deployment scripts for the eCR Viewer stack and rewrites README.md (164 -> 78 lines).

## Changes
- **deployment/vm/*.sh** - 6 scripts: ecrv-init.sh (downloader), docker-install.sh, ecrv-update.sh + ecrv-wizard.sh (config), config-backup.sh, apt-updates.sh
- **docker-compose.yaml** - 6-service stack
- **README.md** - rewritten: fixed ecrw- -> ecrv- typos, removed bloat, condensed descriptions
- **check.sh** - shellcheck tests, all but 2 pass. Future work.
- **deployment/vm/docker-compose.yaml**: Added `depends_on` with `condition: service_healthy` to the orchestration service

## Why
Reproducible deployment path for eCR Viewer multi-service stack on Ubuntu VMs.

## TODO

- [x] Update wget urls to use `main` branch.

## Testing
- [x] Manual deploy on Ubuntu 24.04+ VM
- [x] Verify wizard flow with config profiles