### PR TITLE
fix: OOM Exception fix in FHIR converter when using to_json_string

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.0.6 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch laura/to-json-string-fix --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch laura/to-json-string-fix --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.1.1 --depth 1 /App
 
 WORKDIR /App
 


### PR DESCRIPTION
## Summary

Pointing Viewer to converter fix.

## Related Issue

Fixes #1351 

## Additional Information
Converter PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/124 
