### PR TITLE
 Exclude fhir-converter-proxy container from pre-release testing

### DIFF
--- a/.github/workflows/create-new-pre-release.yaml
+++ b/.github/workflows/create-new-pre-release.yaml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
+        exclude:
+          - container: fhir-converter-proxy
     uses: ./.github/workflows/run-container-workflow.yaml
     with:
       container: ${{ matrix.container }}


### PR DESCRIPTION
# PULL REQUEST

Exclude fhir-converter-proxy container from pre-release testing

## Summary

Excludes fhir-converter-proxy container from pre-release testing

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
