### PR TITLE
Add permissions to read and write to build release containers job

### DIFF
--- a/.github/workflows/create-new-pre-release.yaml
+++ b/.github/workflows/create-new-pre-release.yaml
@@ -29,6 +29,9 @@ jobs:
       - list-containers
       - test-for-release
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     strategy:
       matrix:
         container-to-build: ${{fromJson(needs.list-containers.outputs.all-containers)}}


### PR DESCRIPTION
# PULL REQUEST

Add permissions to read and write to build release containers job

## Summary

The build release containers job fails for the new fhir converter proxy container because the container doesn't exist the project structure and needs to be created and the job doesn't have permission to do it.

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
