### PR TITLE
Revert "Add permissions to read and write to build release containers…

### DIFF
--- a/.github/workflows/create-new-pre-release.yaml
+++ b/.github/workflows/create-new-pre-release.yaml
@@ -29,9 +29,6 @@ jobs:
       - list-containers
       - test-for-release
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     strategy:
       matrix:
         container-to-build: ${{fromJson(needs.list-containers.outputs.all-containers)}}


### PR DESCRIPTION
This reverts commit 2f59e6f8067fa93fa383d81bcd78c385e7f53806.

# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Remove permissions added to prerelease workflow

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
