### PR TITLE
chore: Update Docker Postgres 18 volume mount directory

### DIFF
--- a/containers/ecr-viewer/docker-compose.yaml
+++ b/containers/ecr-viewer/docker-compose.yaml
@@ -75,13 +75,13 @@ services:
         required: false
 
   postgres:
-    image: "postgres:17-alpine"
+    image: "postgres:alpine"
     ports:
       - "5432:5432"
     volumes:
       - ./sql/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./seed-scripts/sql/postgres/.pgpass/:/usr/local/lib/.pgpass # Keep if needed
-      - db:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/
     environment:
       - POSTGRES_USER=postgres
       - PGUSER=postgres


### PR DESCRIPTION
# PULL REQUEST

Update Docker Postgres 18 volume mount directory. Previously pinned Postgres to 17 due to errors, but this was actually caused by the fact that when going from 17 to 18, the default volume mount directory changes from `/var/lib/postgresql` instead of `/var/lib/postgresql/data`.

## Summary

What changes are being proposed?

## Related Issue

Fixes # N/A

Change was originally made [here](https://github.com/CDCgov/dibbs-ecr-viewer/pull/1421/changes)

## Acceptance Criteria

- N/A -- shoudl jsut pass all tests

## Additional Information

https://www.reddit.com/r/selfhosted/comments/1nsjxm2/if_youre_moving_to_docker_postgres_18_you_should/

