### PR TITLE
feat: Return 409 early when duplicate ECR is detected in DB

### DIFF
--- a/containers/ecr-viewer/seed-scripts/docker-compose-load.yaml
+++ b/containers/ecr-viewer/seed-scripts/docker-compose-load.yaml
@@ -1,11 +1,4 @@
 services:
-  migrator:
-    image: curlimages/curl
-    command: >
-      sh -c " echo 'Running migrations' && curl -v -X POST https://dev42.dibbs.cloud/ecr-viewer/api/migrate-db -H 'Authorization: Bearer '"$DUMMY_NBS_JWT" -F 'migration_secret=test' -F 'init_admin_email=ecr-viewer@admin.com' && echo 'Migrations complete' exit 0"
-    environment:
-      - DUMMY_NBS_JWT=${DUMMY_NBS_JWT}
-
   locust:
     image: locustio/locust
     ports:
@@ -17,9 +10,6 @@ services:
     command: >
       -f /home/locust/locustfile.py
       --web-host 0.0.0.0
-      --host https://dev42.dibbs.cloud/ecr-viewer
+      --host https://dev7.dibbs.cloud/ecr-viewer
     environment:
       - DUMMY_NBS_JWT=${DUMMY_NBS_JWT}
-    depends_on:
-      migrator:
-        condition: service_completed_successfully

--- a/containers/ecr-viewer/src/app/api/process-ecr/route.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/route.ts
@@ -2,13 +2,7 @@ import { Bundle, FhirResource } from "fhir/r4";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
-import { deleteFromStorage } from "@/app/api/save-fhir-data/service";
-
-import {
-  orchestrationRequest,
-  getEcrIdFromXml,
-  zipAndSaveXml,
-} from "./service";
+import { orchestrationRequest } from "./service";
 
 interface ProcessEcrResponse {
   message: string;
@@ -60,7 +54,6 @@ export const POST = async (
   // Parse out the form from the request
   const shouldSaveXml = process.env.SAVE_XML === "true";
   let rawBody: object;
-  let ecrId: string | undefined = undefined;
   try {
     const contentType = request.headers.get("content-type");
     if (contentType?.includes("form-")) {
@@ -82,39 +75,12 @@ export const POST = async (
 
   try {
     const { return_fhir_bundle, ...body } = routeSchema.parse(rawBody);
-    const promises: [
-      Promise<{
-        message: string;
-        status: number;
-        bundle?: Bundle<FhirResource>;
-      }>,
-      Promise<void>?,
-    ] = [orchestrationRequest(body, return_fhir_bundle === "true")];
-
-    if (shouldSaveXml) {
-      ecrId = await getEcrIdFromXml(body);
-      promises.push(zipAndSaveXml(body, ecrId));
-    }
-
-    const [orchestrationResult, saveResult] =
-      await Promise.allSettled(promises);
-
-    if (
-      orchestrationResult.status === "rejected" ||
-      orchestrationResult.value.status >= 500
-    ) {
-      if (shouldSaveXml && ecrId && saveResult!.status === "fulfilled") {
-        await deleteFromStorage(ecrId, process.env.SOURCE, "xml");
-      }
-
-      const errMsg =
-        orchestrationResult.status === "rejected"
-          ? String(orchestrationResult.reason)
-          : orchestrationResult.value.message;
-      return NextResponse.json({ message: errMsg }, { status: 500 });
-    }
-
-    const { status, ...payload } = orchestrationResult.value;
+    const { status, ...payload } = await orchestrationRequest(
+      body,
+      return_fhir_bundle === "true",
+      undefined,
+      shouldSaveXml,
+    );
     return NextResponse.json(payload, { status });
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {

--- a/containers/ecr-viewer/src/app/api/process-ecr/service.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/service.ts
@@ -12,6 +12,8 @@ import {
   BundleExtendedMetadata,
   BundleMetadata,
 } from "@/app/api/save-fhir-data/types";
+import { getDb } from "@/app/data/metadataDb/database";
+import { Core } from "@/app/data/metadataDb/types/core";
 import { dbDialect, dbSchema } from "@/app/data/metadataDb/utils/db-config";
 import { getEcrIdFromIdentifier, resolveEcrId } from "@/app/utils/ecrid-utils";
 
@@ -182,6 +184,22 @@ export const orchestrationRequest = async (
   returnBundle: boolean = false,
   fetchAgent = createOrchestrationAgent(),
 ) => {
+  if (dbDialect()) {
+    try {
+      const ecrId = await getEcrIdFromXml(body);
+      const existing = await getDb<Core>()
+        .selectFrom("ecr_data")
+        .select((eb) => eb.fn.countAll().as("num_ecr"))
+        .where("ecr_data.eicr_id", "=", ecrId)
+        .executeTakeFirst();
+      if (existing && Number(existing.num_ecr) > 0) {
+        return { message: `eCR already loaded: ${ecrId}`, status: 409 };
+      }
+    } catch {
+      // If ID can't be extracted from input, proceed and let the later check handle it
+    }
+  }
+
   let orchestrationResp: BundleInfo;
   try {
     orchestrationResp = await getOrchestrationResponse(body, fetchAgent);

--- a/containers/ecr-viewer/src/app/api/process-ecr/service.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/service.ts
@@ -5,6 +5,7 @@ import { fetch, Agent, FormData } from "undici";
 import xpath from "xpath";
 
 import {
+  deleteFromStorage,
   saveToStorage,
   saveWithMetadata,
 } from "@/app/api/save-fhir-data/service";
@@ -183,47 +184,72 @@ export const orchestrationRequest = async (
   body: RequestBody,
   returnBundle: boolean = false,
   fetchAgent = createOrchestrationAgent(),
+  shouldSaveXml: boolean = false,
 ) => {
+  const ecrId = await getEcrIdFromXml(body);
+
   if (dbDialect()) {
-    try {
-      const ecrId = await getEcrIdFromXml(body);
-      const existing = await getDb<Core>()
-        .selectFrom("ecr_data")
-        .select((eb) => eb.fn.countAll().as("num_ecr"))
-        .where("ecr_data.eicr_id", "=", ecrId)
-        .executeTakeFirst();
-      if (existing && Number(existing.num_ecr) > 0) {
-        return { message: `eCR already loaded: ${ecrId}`, status: 409 };
-      }
-    } catch {
-      // If ID can't be extracted from input, proceed and let the later check handle it
+    const existing = await getDb<Core>()
+      .selectFrom("ecr_data")
+      .select((eb) => eb.fn.countAll().as("num_ecr"))
+      .where("ecr_data.eicr_id", "=", ecrId)
+      .executeTakeFirst();
+    if (existing && Number(existing.num_ecr) > 0) {
+      return { message: `eCR already loaded: ${ecrId}`, status: 409 };
     }
   }
 
-  let orchestrationResp: BundleInfo;
-  try {
-    orchestrationResp = await getOrchestrationResponse(body, fetchAgent);
-  } catch (error: unknown) {
-    const message = "Failed to process orchestration response";
-    console.error({ message, error });
+  const promises: [
+    Promise<{ message: string; status: number; bundle?: Bundle }>,
+    Promise<void>?,
+  ] = [
+    (async () => {
+      let orchestrationResp: BundleInfo;
+      try {
+        orchestrationResp = await getOrchestrationResponse(body, fetchAgent);
+      } catch (error: unknown) {
+        const message = "Failed to process orchestration response";
+        console.error({ message, error });
+        return {
+          message:
+            error instanceof Error && error.message ? error.message : message,
+          status: 500,
+        };
+      }
 
-    return {
-      message:
-        error instanceof Error && error.message ? error.message : message,
-      status: 500,
-    };
+      const res = await saveToSource(
+        orchestrationResp.ecr,
+        orchestrationResp.metadata,
+      );
+      if (returnBundle) {
+        return { ...res, bundle: orchestrationResp.ecr };
+      }
+      return res;
+    })(),
+  ];
+
+  if (shouldSaveXml) {
+    promises.push(zipAndSaveXml(body, ecrId));
   }
 
-  const res = await saveToSource(
-    orchestrationResp.ecr,
-    orchestrationResp.metadata,
-  );
+  const [orchestrationResult, saveResult] = await Promise.allSettled(promises);
 
-  if (returnBundle) {
-    return { ...res, bundle: orchestrationResp.ecr };
-  } else {
-    return res;
+  if (
+    orchestrationResult.status === "rejected" ||
+    orchestrationResult.value.status >= 500
+  ) {
+    if (shouldSaveXml && saveResult?.status === "fulfilled") {
+      await deleteFromStorage(ecrId, process.env.SOURCE, "xml");
+    }
+
+    const errMsg =
+      orchestrationResult.status === "rejected"
+        ? String(orchestrationResult.reason)
+        : orchestrationResult.value.message;
+    return { message: errMsg, status: 500 };
   }
+
+  return orchestrationResult.value;
 };
 
 /**

--- a/containers/ecr-viewer/tests/unit/app/api/process-ecr/route.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/api/process-ecr/route.test.ts
@@ -5,15 +5,9 @@ import { Bundle } from "fhir/r4";
 import { NextRequest } from "next/server";
 
 import { POST } from "@/app/api/process-ecr/route";
-import {
-  getEcrIdFromXml,
-  orchestrationRequest,
-  zipAndSaveXml,
-} from "@/app/api/process-ecr/service";
-import { deleteFromStorage } from "@/app/api/save-fhir-data/service";
+import { orchestrationRequest } from "@/app/api/process-ecr/service";
 
 jest.mock("@/app/api/process-ecr/service");
-jest.mock("@/app/api/save-fhir-data/service");
 
 const bundle: Bundle = {
   type: "document",
@@ -130,7 +124,7 @@ describe("POST Process ecr", () => {
 
       expect(response.status).toEqual(500);
       expect(await response.json()).toEqual({
-        message: "Error: oh no!",
+        message: "Internal Server Error",
       });
     });
   }
@@ -250,8 +244,6 @@ describe("POST Process ecr", () => {
   });
 
   describe("Saving XML features", () => {
-    const mockDeleteFromStorage = deleteFromStorage as jest.Mock;
-
     const makeRequest = (body: any, url = "http://localhost/api/process-ecr") =>
       new NextRequest(url, {
         method: "POST",
@@ -264,13 +256,7 @@ describe("POST Process ecr", () => {
       delete process.env.SAVE_XML;
     });
 
-    it("returns orchestration payload when SAVE_XML is not set", async () => {
-      (getEcrIdFromXml as jest.Mock).mockImplementation(() => {
-        throw new Error("getEcrIdFromXml should not be called");
-      });
-      (zipAndSaveXml as jest.Mock).mockImplementation(() => {
-        throw new Error("zipAndSaveXml should not be called");
-      });
+    it("calls orchestrationRequest with shouldSaveXml=false when SAVE_XML is not set", async () => {
       (orchestrationRequest as jest.Mock).mockResolvedValue({
         message: "ok",
         status: 200,
@@ -278,22 +264,19 @@ describe("POST Process ecr", () => {
 
       const req = makeRequest({ ecr: "<xml />" });
       const res = await POST(req);
-      const json = await res.json();
 
       expect(res.status).toBe(200);
-      expect(json).toEqual({ message: "ok" });
-      expect(orchestrationRequest).toHaveBeenCalledTimes(1);
+      expect(orchestrationRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        false,
+        undefined,
+        false,
+      );
     });
 
-    it("returns orchestration payload when SAVE_XML is 'false'", async () => {
+    it("calls orchestrationRequest with shouldSaveXml=false when SAVE_XML is 'false'", async () => {
       (process.env as any).SAVE_XML = "false";
 
-      (getEcrIdFromXml as jest.Mock).mockImplementation(() => {
-        throw new Error("getEcrIdFromXml should not be called");
-      });
-      (zipAndSaveXml as jest.Mock).mockImplementation(() => {
-        throw new Error("zipAndSaveXml should not be called");
-      });
       (orchestrationRequest as jest.Mock).mockResolvedValue({
         status: 200,
         message: "done",
@@ -301,20 +284,19 @@ describe("POST Process ecr", () => {
 
       const req = makeRequest({ ecr: "<xml />" });
       const res = await POST(req);
-      const json = await res.json();
 
-      expect(getEcrIdFromXml).not.toHaveBeenCalled();
-      expect(zipAndSaveXml).not.toHaveBeenCalled();
-      expect(orchestrationRequest).toHaveBeenCalledTimes(1);
       expect(res.status).toBe(200);
-      expect(json.message).toBe("done");
+      expect(orchestrationRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        false,
+        undefined,
+        false,
+      );
     });
 
-    it("runs zipAndSaveXml and orchestration request when SAVE_XML is 'true'", async () => {
+    it("calls orchestrationRequest with shouldSaveXml=true when SAVE_XML is 'true'", async () => {
       (process.env as any).SAVE_XML = "true";
 
-      (getEcrIdFromXml as jest.Mock).mockResolvedValue("abc-123");
-      (zipAndSaveXml as jest.Mock).mockResolvedValue(undefined);
       (orchestrationRequest as jest.Mock).mockResolvedValue({
         status: 200,
         message: "done",
@@ -322,33 +304,14 @@ describe("POST Process ecr", () => {
 
       const req = makeRequest({ ecr: "<xml />" });
       const res = await POST(req);
-      const json = await res.json();
 
-      expect(getEcrIdFromXml).toHaveBeenCalled();
-      expect(zipAndSaveXml).toHaveBeenCalledWith(expect.anything(), "abc-123");
-      expect(orchestrationRequest).toHaveBeenCalled();
       expect(res.status).toBe(200);
-      expect(json.message).toBe("done");
-    });
-
-    it("deletes XML if orchestration rejects", async () => {
-      (process.env as any).SAVE_XML = "true";
-      (process.env as any).SOURCE = "aws";
-
-      (getEcrIdFromXml as jest.Mock).mockResolvedValue("abc");
-      (zipAndSaveXml as jest.Mock).mockResolvedValue(undefined);
-      (orchestrationRequest as jest.Mock).mockRejectedValue(new Error("fail"));
-
-      const errorSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const req = makeRequest({ ecr: "<xml />" });
-      const res = await POST(req);
-
-      expect(mockDeleteFromStorage).toHaveBeenCalledWith("abc", "aws", "xml");
-
-      expect(res.status).toBe(500);
+      expect(orchestrationRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        false,
+        undefined,
+        true,
+      );
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/api/process-ecr/service.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/api/process-ecr/service.test.ts
@@ -15,6 +15,7 @@ import {
   zipAndSaveXml,
 } from "@/app/api/process-ecr/service";
 import {
+  deleteFromStorage,
   saveToStorage,
   saveWithMetadata,
 } from "@/app/api/save-fhir-data/service";
@@ -30,9 +31,7 @@ const mockAgent = new MockAgent();
 mockAgent.disableNetConnect();
 
 describe("orchestrationRequest", () => {
-  const mockFile = new File(["content"], "test.zip", {
-    type: "application/zip",
-  });
+  let mockFile: File;
   const mockEcr = {
     id: "123",
     identifier: { system: "hello", value: "world" },
@@ -41,9 +40,19 @@ describe("orchestrationRequest", () => {
 
   let mockPool: Interceptable;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.SOURCE = S3_SOURCE;
     process.env.ORCHESTRATION_URL = "http://orchestration-service";
+
+    const zip = new JSZip();
+    zip.file(
+      "ecr.xml",
+      `<ClinicalDocument xmlns="urn:hl7-org:v3"><id root="test-root" extension="test-ext" /></ClinicalDocument>`,
+    );
+    const buf = await zip.generateAsync({ type: "nodebuffer" });
+    mockFile = new File([buf as BlobPart], "test.zip", {
+      type: "application/zip",
+    });
   });
 
   beforeEach(() => {
@@ -334,6 +343,90 @@ describe("orchestrationRequest", () => {
     });
   });
 
+  describe("XML save coordination", () => {
+    const xmlBody = {
+      ecr: `<ClinicalDocument xmlns="urn:hl7-org:v3"><id root="xml-root" extension="xml-ext" /></ClinicalDocument>`,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      delete process.env.METADATA_DATABASE_TYPE;
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("saves XML in parallel with orchestration when shouldSaveXml is true", async () => {
+      mockPool
+        .intercept({ path: "/process-message", method: "POST" })
+        .reply(200, {
+          processed_values: {
+            responses: [{ stamped_ecr: { extended_bundle: mockEcr } }],
+          },
+        });
+
+      (saveToStorage as jest.Mock).mockResolvedValue({
+        status: 200,
+        message: "ok",
+      });
+
+      await orchestrationRequest(
+        xmlBody,
+        false,
+        mockAgent as unknown as Agent,
+        true,
+      );
+
+      const calls = (saveToStorage as jest.Mock).mock.calls;
+      expect(calls.some(([, , , type]) => type === "xml")).toBe(true);
+    });
+
+    it("deletes XML when orchestration fails and XML save succeeded", async () => {
+      mockPool
+        .intercept({ path: "/process-message", method: "POST" })
+        .reply(500, { detail: "fail" });
+
+      (saveToStorage as jest.Mock).mockResolvedValue(undefined);
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await orchestrationRequest(
+        xmlBody,
+        false,
+        mockAgent as unknown as Agent,
+        true,
+      );
+
+      expect(deleteFromStorage).toHaveBeenCalledWith(
+        "xml-root^xml-ext",
+        S3_SOURCE,
+        "xml",
+      );
+      expect(result.status).toBe(500);
+    });
+
+    it("does not delete XML when XML save also failed", async () => {
+      mockPool
+        .intercept({ path: "/process-message", method: "POST" })
+        .reply(500, { detail: "fail" });
+
+      (saveToStorage as jest.Mock).mockRejectedValue(
+        new Error("storage failure"),
+      );
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await orchestrationRequest(
+        xmlBody,
+        false,
+        mockAgent as unknown as Agent,
+        true,
+      );
+
+      expect(deleteFromStorage).not.toHaveBeenCalled();
+      expect(result.status).toBe(500);
+    });
+  });
+
   describe("createOrchestrationAgent", () => {
     describe("Default timeout path", () => {
       it("If ECR_PROCESSING_TIMEOUT is not set, defaults to 900000ms timeout when creating the orchestration Agent", () => {
@@ -491,6 +584,23 @@ describe("orchestrationRequest", () => {
       appendMock = jest.spyOn(FormData.prototype, "append");
       process.env.METADATA_DATABASE_TYPE = undefined;
       process.env.METADATA_DATABASE_SCHEMA = undefined;
+
+      const dbChain = {
+        selectFrom: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        executeTakeFirst: jest.fn().mockResolvedValue({ num_ecr: 0 }),
+      };
+      (getDb as jest.Mock).mockReturnValue(dbChain);
+
+      (saveToStorage as jest.Mock).mockResolvedValue({
+        status: 200,
+        message: "ok",
+      });
+      (saveWithMetadata as jest.Mock).mockResolvedValue({
+        status: 200,
+        message: "ok",
+      });
     });
     it("should use bundle-only.json when no metadata db", async () => {
       delete process.env.METADATA_DATABASE_TYPE;

--- a/containers/ecr-viewer/tests/unit/app/api/process-ecr/service.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/api/process-ecr/service.test.ts
@@ -19,9 +19,12 @@ import {
   saveWithMetadata,
 } from "@/app/api/save-fhir-data/service";
 import { S3_SOURCE } from "@/app/data/blobStorage/utils";
+import { getDb } from "@/app/data/metadataDb/database";
 
 jest.mock("@/app/api/save-fhir-data/service");
-jest.mock("@/app/data/metadataDb/database");
+jest.mock("@/app/data/metadataDb/database", () => ({
+  getDb: jest.fn(),
+}));
 
 const mockAgent = new MockAgent();
 mockAgent.disableNetConnect();
@@ -240,6 +243,94 @@ describe("orchestrationRequest", () => {
     expect(response).toEqual({
       message: "Failed to process orchestration response",
       status: 500,
+    });
+  });
+
+  describe("early duplicate check", () => {
+    const xmlBody = {
+      ecr: `<ClinicalDocument xmlns="urn:hl7-org:v3"><id root="test-root" extension="test-ext" /></ClinicalDocument>`,
+    };
+
+    //mock database query chain, configure how many records query should return
+    const makeDbMock = (count: number) => {
+      const chain = {
+        selectFrom: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        executeTakeFirst: jest.fn().mockResolvedValue({ num_ecr: count }),
+      };
+      (getDb as jest.Mock).mockReturnValue(chain);
+      return chain;
+    };
+
+    afterEach(() => {
+      delete process.env.METADATA_DATABASE_TYPE;
+    });
+
+    it("returns 409 without calling orchestration when ECR already exists in DB", async () => {
+      process.env.METADATA_DATABASE_TYPE = "postgres";
+      makeDbMock(1);
+
+      const response = await orchestrationRequest(xmlBody);
+
+      expect(response).toEqual({
+        message: "eCR already loaded: test-root^test-ext",
+        status: 409,
+      });
+      expect(saveWithMetadata).not.toHaveBeenCalled();
+      expect(saveToStorage).not.toHaveBeenCalled();
+    });
+
+    it("proceeds with orchestration when ECR does not exist in DB", async () => {
+      process.env.METADATA_DATABASE_TYPE = "postgres";
+      makeDbMock(0);
+
+      mockPool
+        .intercept({ path: "/process-message", method: "POST" })
+        .reply(200, {
+          processed_values: {
+            responses: [{ stamped_ecr: { extended_bundle: mockEcr } }],
+          },
+        });
+
+      (saveToStorage as jest.Mock).mockResolvedValue({
+        status: 200,
+        message: "Success",
+      });
+
+      const response = await orchestrationRequest(
+        xmlBody,
+        false,
+        mockAgent as unknown as Agent,
+      );
+
+      expect(response).toEqual({ status: 200, message: "Success" });
+    });
+
+    it("skips the check and proceeds when no DB is configured", async () => {
+      delete process.env.METADATA_DATABASE_TYPE;
+
+      mockPool
+        .intercept({ path: "/process-message", method: "POST" })
+        .reply(200, {
+          processed_values: {
+            responses: [{ stamped_ecr: { extended_bundle: mockEcr } }],
+          },
+        });
+
+      (saveToStorage as jest.Mock).mockResolvedValue({
+        status: 200,
+        message: "Success",
+      });
+
+      const response = await orchestrationRequest(
+        xmlBody,
+        false,
+        mockAgent as unknown as Agent,
+      );
+
+      expect(response).toEqual({ status: 200, message: "Success" });
+      expect(getDb).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# PULL REQUEST

Return 409 early when duplicate ECR is detected in DB

## Summary

Before forwarding to orchestration, check if an ECR with the same ID already exists in the metadata DB and short-circuit with 409 if so.

## Related Issue

Fixes #1332 

## Acceptance Criteria

IF I send an eCR to /process-ecr
AND the ID of that eCR already exists in the ecr_id column of the ecr_data table
THEN I will return a 409 without sending the eCR to the orchestration service
AND the load testing script will now send eCRs to dev7 instead of dev42

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
