### PR TITLE
fix: SideNav should expand and navigate collapsed sections

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -241,7 +241,6 @@ const SideNav: React.FC<{
     ],
     [ecrDocumentNavConfig]
   );
-  console.log(sectionConfigs);
 
   const topOffset = useMemo(() => {
     return 5 * parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -57,7 +57,7 @@ function buildParentMap(
 function findExpandButton(el: Element): HTMLButtonElement | null {
   // Element has expand button
   const childBtn = el.querySelector(
-    "button[aria-expanded]"
+    "button[aria-expanded]",
   ) as HTMLButtonElement | null;
   if (childBtn) return childBtn;
 
@@ -70,7 +70,7 @@ function findExpandButton(el: Element): HTMLButtonElement | null {
         (child) =>
           child !== current &&
           child.tagName === "BUTTON" &&
-          child.hasAttribute("aria-expanded")
+          child.hasAttribute("aria-expanded"),
       ) as HTMLButtonElement | undefined;
       if (siblingBtn) return siblingBtn;
     }
@@ -149,7 +149,7 @@ function expandAndNavigate(
   parentMap: Map<string, string>,
 ) {
   const heading = document.querySelector(
-    `[data-sectionid="${sectionId}"]`
+    `[data-sectionid="${sectionId}"]`,
   ) as HTMLElement | null;
 
   // Case 1: Heading in DOM & visible - expand accordion if collapsed
@@ -172,7 +172,7 @@ function expandAndNavigate(
     const parentId = parentMap.get(sectionId);
     if (parentId) {
       const parentHeading = document.querySelector(
-        `[data-sectionid="${parentId}"]`
+        `[data-sectionid="${parentId}"]`,
       ) as HTMLElement | null;
       if (parentHeading) {
         const parentBtn = findExpandButton(parentHeading);
@@ -202,7 +202,7 @@ function expandAndNavigate(
 
   while (parentId) {
     const candidate = document.querySelector(
-      `[data-sectionid="${parentId}"]`
+      `[data-sectionid="${parentId}"]`,
     ) as HTMLElement | null;
     if (candidate && !isHidden(candidate)) {
       parentHeading = candidate;
@@ -235,11 +235,11 @@ const SideNav: React.FC<{
       new SectionConfig(
         "eCR Document",
         ecrDocumentNavConfig.map(
-          (item) => new SectionConfig(item.title, item.subNavItems)
-        )
+          (item) => new SectionConfig(item.title, item.subNavItems),
+        ),
       ),
     ],
-    [ecrDocumentNavConfig]
+    [ecrDocumentNavConfig],
   );
   console.log(sectionConfigs);
 
@@ -258,7 +258,7 @@ const SideNav: React.FC<{
           id,
           ...flatten(subNavItems || []),
         ]);
-      })(sectionConfigs)
+      })(sectionConfigs),
     );
 
     // Intersection Observer: sets section in view as active section
@@ -280,7 +280,7 @@ const SideNav: React.FC<{
           window.innerHeight - topOffset - 1
         }px 0px`,
         threshold: 0,
-      }
+      },
     );
     const observedIds = new Set<string>();
 
@@ -288,7 +288,7 @@ const SideNav: React.FC<{
     // Runs on initial load & when the DOM changes
     const tagAndObserve = () => {
       const headingElements = Array.from(
-        document.querySelector("main")?.querySelectorAll(headingSelector) || []
+        document.querySelector("main")?.querySelectorAll(headingSelector) || [],
       ) as HTMLElement[];
 
       headingElements.forEach((heading) => {
@@ -316,7 +316,7 @@ const SideNav: React.FC<{
     setActiveSection(
       initialActive?.getAttribute("data-sectionid") ??
         tagged[0]?.getAttribute("data-sectionid") ??
-        ""
+        "",
     );
 
     // Mutation Observer: Watch for DOM changes (sections render after expand)
@@ -368,7 +368,7 @@ const SideNav: React.FC<{
       if (section.subNavItems) {
         const subSideNavItems = buildSideNav(section.subNavItems, topOffset);
         sideNavItems.push(
-          <UswdsSideNav isSubnav={true} items={subSideNavItems} />
+          <UswdsSideNav isSubnav={true} items={subSideNavItems} />,
         );
       }
     }

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -356,6 +356,7 @@ const SideNav: React.FC<{
           data-testid="sidenav-link"
           onClick={(e) => {
             e.preventDefault();
+            setActiveSection(section.id); // Set on click; prevents some sections not being tagged as active due to short page height
             expandAndNavigate(section.id, topOffset, parentMap);
           }}
         >

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -34,6 +34,195 @@ const headingSelector =
   "h2:not([id^='unavailable-']):not(.side-nav-ignore), h3:not([id^='unavailable-']):not(.side-nav-ignore), h4:not([id^='unavailable-']):not(.side-nav-ignore)";
 
 /**
+ * Builds flat map of child ID -> parent ID from the SectonConfig tree.
+ * Determines which section needs to be expanded when a child's
+ * heading is collapsed or not yet in the DOM.
+ */
+function buildParentMap(
+  configs: SectionConfig[],
+  parentId: string | null = null,
+  map: Map<string, string> = new Map(),
+): Map<string, string> {
+  for (const config of configs) {
+    if (parentId !== null) map.set(config.id, parentId);
+    if (config.subNavItems) buildParentMap(config.subNavItems, config.id, map);
+  }
+  return map;
+}
+
+/**
+ * Walks up the DOM from a heading element looking for an expand <button>
+ * at any ancestor level.
+ */
+function findExpandButton(el: Element): HTMLButtonElement | null {
+  // Element has expand button
+  const childBtn = el.querySelector(
+    "button[aria-expanded]"
+  ) as HTMLButtonElement | null;
+  if (childBtn) return childBtn;
+
+  // Walk up DOM to look expand button
+  let current: Element | null = el;
+  while (current && current !== document.body) {
+    const parent = current.parentElement;
+    if (parent) {
+      const siblingBtn = Array.from(parent.children).find(
+        (child) =>
+          child !== current &&
+          child.tagName === "BUTTON" &&
+          child.hasAttribute("aria-expanded")
+      ) as HTMLButtonElement | undefined;
+      if (siblingBtn) return siblingBtn;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Check if element is hidden.
+ */
+function isHidden(el: Element): boolean {
+  const rect = (el as HTMLElement).getBoundingClientRect();
+  return (
+    (el as HTMLElement).offsetParent === null ||
+    (rect.width === 0 && rect.height === 0)
+  );
+}
+
+/**
+ * Scrolls to the heading tagged with the given sectionId.
+ */
+function scrollToSection(sectionId: string, topOffset: number) {
+  const heading = document.querySelector(
+    `[data-sectionid="${sectionId}"]`,
+  ) as HTMLElement | null;
+  if (!heading) return;
+  const top = heading.getBoundingClientRect().top + window.scrollY - topOffset;
+  window.scrollTo({ top, behavior: "instant" });
+}
+
+/**
+ * Waits for a heading with the given sectionId to appear in the DOM
+ * (i.e. after its parent accordion is expanded), then scrolls to it.
+ * Falls back after a timeout if it never appears.
+ */
+function waitForHeadingThenScroll(sectionId: string, topOffset: number) {
+  const TIMEOUT_MS = 2000;
+  let settled = false;
+
+  const observer = new MutationObserver(() => {
+    const heading = document.querySelector(
+      `[data-sectionid="${sectionId}"]`,
+    ) as HTMLElement | null;
+    if (heading && !isHidden(heading)) {
+      settled = true;
+      observer.disconnect();
+      scrollToSection(sectionId, topOffset);
+    }
+  });
+
+  observer.observe(document.querySelector("main") || document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+  });
+
+  // Safety valve: disconnect if the heading never appears
+  setTimeout(() => {
+    if (!settled) observer.disconnect();
+  }, TIMEOUT_MS);
+}
+
+/**
+ * Expands the parent section (if needed) and navigates to the target section.
+ *
+ * Cases:
+ * 1. Heading is in the DOM and visible → scroll immediately.
+ * 2. Heading is in the DOM but hidden (parent collapsed) → click expand button, then scroll.
+ * 3. Heading is not in the DOM yet (never opened) → find parent heading,
+ *    click its expand button, wait for child to render, then scroll.
+ */
+function expandAndNavigate(
+  sectionId: string,
+  topOffset: number,
+  parentMap: Map<string, string>,
+) {
+  const heading = document.querySelector(
+    `[data-sectionid="${sectionId}"]`
+  ) as HTMLElement | null;
+
+  // Case 1: Heading in DOM & visible - expand accordion if collapsed
+  if (heading && !isHidden(heading)) {
+    const btn = findExpandButton(heading);
+    // If button exists and is not expanded, expand it
+    if (btn && btn.getAttribute("aria-expanded") !== "true") {
+      btn.click();
+      waitForHeadingThenScroll(sectionId, topOffset);
+    } else {
+      // Already expanded or no button, just scroll
+      scrollToSection(sectionId, topOffset);
+    }
+    return;
+  }
+
+  // Case 2: Heading in DOM, but hidden - expand parent accordion if collapsed
+  // Wait for expand -> scroll to section
+  if (heading && isHidden(heading)) {
+    const parentId = parentMap.get(sectionId);
+    if (parentId) {
+      const parentHeading = document.querySelector(
+        `[data-sectionid="${parentId}"]`
+      ) as HTMLElement | null;
+      if (parentHeading) {
+        const parentBtn = findExpandButton(parentHeading);
+        // If parent button exists and is not expanded, expand it first
+        if (parentBtn && parentBtn.getAttribute("aria-expanded") !== "true") {
+          expandAndNavigate(parentId, topOffset, parentMap);
+          waitForHeadingThenScroll(sectionId, topOffset);
+          return;
+        }
+      }
+    }
+
+    const btn = findExpandButton(heading);
+    if (btn) {
+      btn.click();
+      waitForHeadingThenScroll(sectionId, topOffset);
+    } else {
+      scrollToSection(sectionId, topOffset);
+    }
+    return;
+  }
+
+  // Case 3: Heading not in DOM. — find & expand nearest parent in the DOM
+  // Wait for render & expand -> scroll to section
+  let parentId: string | undefined = parentMap.get(sectionId);
+  let parentHeading: HTMLElement | null = null;
+
+  while (parentId) {
+    const candidate = document.querySelector(
+      `[data-sectionid="${parentId}"]`
+    ) as HTMLElement | null;
+    if (candidate && !isHidden(candidate)) {
+      parentHeading = candidate;
+      break;
+    }
+    parentId = parentMap.get(parentId);
+  }
+
+  if (parentHeading) {
+    const btn = findExpandButton(parentHeading);
+    if (btn) {
+      btn.click();
+      waitForHeadingThenScroll(sectionId, topOffset);
+    } else {
+      scrollToSection(parentId!, topOffset);
+    }
+  }
+}
+
+/**
  * Functional component for the side navigation.
  * @returns The JSX element representing the side navigation.
  */
@@ -46,29 +235,30 @@ const SideNav: React.FC<{
       new SectionConfig(
         "eCR Document",
         ecrDocumentNavConfig.map(
-          (item) => new SectionConfig(item.title, item.subNavItems),
-        ),
+          (item) => new SectionConfig(item.title, item.subNavItems)
+        )
       ),
     ],
-    [ecrDocumentNavConfig],
+    [ecrDocumentNavConfig]
   );
+  console.log(sectionConfigs);
+
+  const topOffset = useMemo(() => {
+    return 5 * parseFloat(getComputedStyle(document.documentElement).fontSize);
+  }, []);
+  const parentMap = buildParentMap(sectionConfigs);
+
   const [activeSection, setActiveSection] = useState<string>("");
 
   useEffect(() => {
     if (sectionConfigs.length === 0) return;
-
-    const oneRem = parseFloat(
-      getComputedStyle(document.documentElement).fontSize,
-    );
-    const topOffset = 5 * oneRem;
-
     const validIds = new Set(
       (function flatten(items: SectionConfig[]): string[] {
         return items.flatMap(({ id, subNavItems }) => [
           id,
           ...flatten(subNavItems || []),
         ]);
-      })(sectionConfigs),
+      })(sectionConfigs)
     );
 
     // Intersection Observer: sets section in view as active section
@@ -90,7 +280,7 @@ const SideNav: React.FC<{
           window.innerHeight - topOffset - 1
         }px 0px`,
         threshold: 0,
-      },
+      }
     );
     const observedIds = new Set<string>();
 
@@ -98,7 +288,7 @@ const SideNav: React.FC<{
     // Runs on initial load & when the DOM changes
     const tagAndObserve = () => {
       const headingElements = Array.from(
-        document.querySelector("main")?.querySelectorAll(headingSelector) || [],
+        document.querySelector("main")?.querySelectorAll(headingSelector) || []
       ) as HTMLElement[];
 
       headingElements.forEach((heading) => {
@@ -126,7 +316,7 @@ const SideNav: React.FC<{
     setActiveSection(
       initialActive?.getAttribute("data-sectionid") ??
         tagged[0]?.getAttribute("data-sectionid") ??
-        "",
+        ""
     );
 
     // Mutation Observer: Watch for DOM changes (sections render after expand)
@@ -150,11 +340,12 @@ const SideNav: React.FC<{
    *   and potential sub-sections of the side navigation. Each `SectionConfig`
    *   should have an `id` for linking, a `title` for display, and may have
    *   `subNavItems` for nested navigation structures.
+   * @param topOffset - Scroll offset to account for fixed header spacing.
    * @returns An array of React nodes representing the side navigation items, including any
    *   nested sub-navigation items. These nodes are ready to be rendered in a React
    *   component to display the side navigation.
    */
-  function buildSideNav(sectionConfigs: SectionConfig[]) {
+  function buildSideNav(sectionConfigs: SectionConfig[], topOffset: number) {
     const sideNavItems: React.ReactNode[] = [];
     for (const section of sectionConfigs) {
       const sideNavItem = (
@@ -163,6 +354,10 @@ const SideNav: React.FC<{
           href={"#" + section.id}
           className={activeSection === section.id ? "usa-current" : ""}
           data-testid="sidenav-link"
+          onClick={(e) => {
+            e.preventDefault();
+            expandAndNavigate(section.id, topOffset, parentMap);
+          }}
         >
           {section.title}
         </a>
@@ -170,9 +365,9 @@ const SideNav: React.FC<{
       sideNavItems.push(sideNavItem);
 
       if (section.subNavItems) {
-        const subSideNavItems = buildSideNav(section.subNavItems);
+        const subSideNavItems = buildSideNav(section.subNavItems, topOffset);
         sideNavItems.push(
-          <UswdsSideNav isSubnav={true} items={subSideNavItems} />,
+          <UswdsSideNav isSubnav={true} items={subSideNavItems} />
         );
       }
     }
@@ -180,7 +375,7 @@ const SideNav: React.FC<{
     return sideNavItems;
   }
 
-  const sideNavItems = buildSideNav(sectionConfigs);
+  const sideNavItems = buildSideNav(sectionConfigs, topOffset);
 
   // Add a separate loading state here as the side nav is much slower than the main content
   return sectionConfigs.length === 0 ? (

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
@@ -58,12 +58,14 @@ test.describe("viewer page", () => {
         `/ecr-viewer/view-data?id=db734647-fc99-424c-a864-7e3cda82e703&${nbsAuthParam}`,
       );
       await page.getByText("Patient Name").first().waitFor();
-      await page.getByRole("button", { name: /expand all sections/i }).click();
     });
 
     test("clicking each link scrolls and highlights", async ({ page }) => {
       const nav = page.getByRole("navigation");
       await expect(nav).toBeVisible();
+
+      // Full DOM should not be rendered yet
+      await expect(page.getByText("Miscellaneous Notes")).not.toBeAttached();
 
       // use a test id here to avoid a lot of special casing around the back to
       // library link, which may or may not exist based on the config
@@ -72,14 +74,14 @@ test.describe("viewer page", () => {
       const navLinks = await navLinksLoc.all();
       expect(navLinks.length).toBe(21); // sanity check
 
-      // Make sure after collapsing and reopening, nav links still work
-      await page.getByText("Collapse all sections").click();
-      expect(page.getByText("Miscellaneous Notes")).not.toBeVisible();
-
+      // Make sure after expanding and collapsing, nav links still work
       await page.getByText("Expand all sections").click();
       expect(page.getByText("Miscellaneous Notes")).toBeVisible();
 
-      // make sure clicking each link scrolls the heading and highlights the corresponding
+      await page.getByText("Collapse all sections").click();
+      expect(page.getByText("Miscellaneous Notes")).not.toBeVisible();
+
+      // Clicking each link scrolls the heading and highlights the corresponding
       // side nav item
       for (const navLink of navLinks) {
         await navLink.scrollIntoViewIfNeeded();
@@ -96,9 +98,10 @@ test.describe("viewer page", () => {
     }) => {
       // some browsers struggle with the small scroll iteration here
       test.slow();
-
+      
       const nav = page.getByRole("navigation");
       await expect(nav).toBeVisible();
+      await page.getByRole("button", { name: /expand all sections/i }).click();
 
       // use a test id here to avoid a lot of special casing around the back to
       // library link, which may or may not exist based on the config

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
@@ -98,7 +98,7 @@ test.describe("viewer page", () => {
     }) => {
       // some browsers struggle with the small scroll iteration here
       test.slow();
-      
+
       const nav = page.getByRole("navigation");
       await expect(nav).toBeVisible();
       await page.getByRole("button", { name: /expand all sections/i }).click();

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx
@@ -646,8 +646,6 @@ Home: 123-456-6909`,
       expect(actual.availableData.filter((d) => d.title === "Contact")).toEqual(
         expectedContact,
       );
-
-      console.log(actual);
     });
   });
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Fixes SideNav so that it now expands collapsed sections and navigates directly to the target. Also updates `e2e` tests.

## Related Issue

Fixes #1433

## Acceptance Criteria

- [X] Clicking a section in the side navigation automatically expands the section if it is collapsed.
- [X] Users can navigate directly to any section from the side navigation without manually expanding it first.
- [X] The selected section is scrolled into view after expansion.
- [X] Existing side navigation behavior continues to work for already expanded sections.

## Additional Information

Now that sections are collapsed at default, this behavior is more crucial for a smooth UX.
