### PR TITLE
fix: Renamed Clinical Notes to History of Present Illness

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -16,7 +16,7 @@ interface ClinicalProps {
   vitalData: DisplayDataProps[];
   immunizationsDetails: DisplayDataProps[];
   treatmentData: DisplayDataProps[];
-  clinicalNotes: DisplayDataProps[];
+  historyOfPresentIllness: DisplayDataProps[];
 }
 
 const TableDetails = ({
@@ -40,39 +40,22 @@ const TableDetails = ({
   );
 };
 
-const ClinicalNotes = ({ details }: { details: DisplayDataProps[] }) => {
-  if (details?.length > 0) {
-    return (
-      <AccordionSubSection
-        title="Clinical Notes"
-        className="clinical_info_container"
-      >
-        {details.map((item, index) => {
-          if (item.table) {
-            return <TableDetails key={index} details={[item]} />;
-          }
-          return <DataDisplay item={item} key={index} />;
-        })}
-      </AccordionSubSection>
-    );
-  }
-
-  return <></>;
-};
-
 const SymptomsAndProblems = ({
   symptoms,
   problems,
   emergencyOutbreakInfo,
+  historyOfPresentIllness,
 }: {
   symptoms: DisplayDataProps[];
   problems: DisplayDataProps[];
   emergencyOutbreakInfo: DisplayDataProps[];
+  historyOfPresentIllness: DisplayDataProps[];
 }) => {
   if (
     symptoms?.length > 0 ||
     problems?.length > 0 ||
-    emergencyOutbreakInfo?.length > 0
+    emergencyOutbreakInfo?.length > 0 ||
+    historyOfPresentIllness?.length > 0
   ) {
     return (
       <AccordionSubSection title="Symptoms and Problems">
@@ -86,6 +69,14 @@ const SymptomsAndProblems = ({
             details={problems}
             className="table-clinical-problems"
           />
+        </div>
+        <div data-testid="history-of-present-illness">
+          {historyOfPresentIllness?.map((item, index) => {
+            if (item.table) {
+              return <TableDetails key={index} details={[item]} />;
+            }
+            return <DataDisplay item={item} key={index} />;
+          })}
         </div>
         <div data-testid="emergency-outbreak-info">
           {emergencyOutbreakInfo.map((item, index) => (
@@ -154,7 +145,7 @@ const VitalDetails = ({ details }: { details: DisplayDataProps[] }) => {
  * @param props.immunizationsDetails - The details of immunizations.
  * @param props.vitalData - The vital signs data.
  * @param props.treatmentData - The details of treatments.
- * @param props.clinicalNotes - The clinical notes data.
+ * @param props.historyOfPresentIllness - The history of present illness data.
  * @returns The JSX element representing the clinical information.
  */
 export const ClinicalInfo = ({
@@ -164,15 +155,16 @@ export const ClinicalInfo = ({
   immunizationsDetails,
   vitalData,
   treatmentData,
-  clinicalNotes,
+  historyOfPresentIllness,
 }: ClinicalProps) => {
   return (
     <AccordionSection>
-      <ClinicalNotes details={clinicalNotes} />
+
       <SymptomsAndProblems
         symptoms={reasonForVisitDetails}
         problems={activeProblemsDetails}
         emergencyOutbreakInfo={emergencyOutbreakInfo}
+        historyOfPresentIllness={historyOfPresentIllness}
       />
       <TreatmentDetails details={treatmentData} />
       <ImmunizationsDetails details={immunizationsDetails} />

--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -159,7 +159,6 @@ export const ClinicalInfo = ({
 }: ClinicalProps) => {
   return (
     <AccordionSection>
-
       <SymptomsAndProblems
         symptoms={reasonForVisitDetails}
         problems={activeProblemsDetails}

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -79,7 +79,7 @@ export const getEcrDocumentAccordionItems = (
       clinicalData.vitalData.unavailableData,
       clinicalData.immunizationsDetails.unavailableData,
       clinicalData.treatmentData.unavailableData,
-      clinicalData.clinicalNotes.unavailableData,
+      clinicalData.historyOfPresentIllness.unavailableData,
       ...ecrMetadata.eicrDetails.unavailableData,
       ...ecrMetadata.ecrCustodianDetails.unavailableData,
       ecrMetadata.eicrAuthorDetails.map((details) => details.unavailableData),
@@ -110,7 +110,6 @@ export const getEcrDocumentAccordionItems = (
     providerData.availableData.length > 0 && "Provider Details",
   );
   const subNavClinical = defined(
-    clinicalData.clinicalNotes.availableData.length > 0 && "Clinical Notes",
     (clinicalData.reasonForVisitDetails.availableData.length > 0 ||
       clinicalData.activeProblemsDetails.availableData.length > 0 ||
       clinicalData.emergencyOutbreakInfo.availableData.length > 0) &&
@@ -190,7 +189,7 @@ export const getEcrDocumentAccordionItems = (
         (section) => section.availableData.length > 0,
       ) ? (
         <ClinicalInfo
-          clinicalNotes={clinicalData.clinicalNotes.availableData}
+          historyOfPresentIllness={clinicalData.historyOfPresentIllness.availableData}
           reasonForVisitDetails={
             clinicalData.reasonForVisitDetails.availableData
           }
@@ -282,7 +281,7 @@ export const getEcrDocumentAccordionItems = (
                 clinicalData.treatmentData.unavailableData
               }
               clinicalNotesUnavailableData={
-                clinicalData.clinicalNotes.unavailableData
+                clinicalData.historyOfPresentIllness.unavailableData
               }
               ecrMetadataUnavailableData={[
                 ...ecrMetadata.eicrDetails.unavailableData,

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -189,7 +189,9 @@ export const getEcrDocumentAccordionItems = (
         (section) => section.availableData.length > 0,
       ) ? (
         <ClinicalInfo
-          historyOfPresentIllness={clinicalData.historyOfPresentIllness.availableData}
+          historyOfPresentIllness={
+            clinicalData.historyOfPresentIllness.availableData
+          }
           reasonForVisitDetails={
             clinicalData.reasonForVisitDetails.availableData
           }

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -68,7 +68,7 @@ import { FhirIndex } from "../../services/fhirResourcesIndexService";
  * Evaluates clinical data from the FHIR bundle and formats it into structured data for display.
  * @param fhirBundle - The FHIR bundle containing clinical data.
  * @returns An object containing evaluated and formatted clinical data.
- * @property {DisplayDataProps[]} clinicalNotes - Clinical notes data.
+ * @property {DisplayDataProps[]} historyOfPresentIllness - History of present illness data.
  * @property {DisplayDataProps[]} reasonForVisitDetails - Reason for visit details.
  * @property {DisplayDataProps[]} activeProblemsDetails - Active problems details.
  * @property {DisplayDataProps[]} treatmentData - Treatment-related data.
@@ -81,12 +81,11 @@ export const evaluateClinicalData = (
 ) => {
   const clinicalNotesTooltip =
     "Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.";
-  const clinicalNotes: DisplayDataProps[] = [
+  const historyOfPresentIllness: DisplayDataProps[] = [
     evaluateNotes(
       fhirBundle,
       fhirPathMappings.historyOfPresentIllness,
-      "Miscellaneous Notes",
-      clinicalNotesTooltip,
+      "History of Present Illness"
     ),
   ];
   const reasonForVisitData: DisplayDataProps[] = [
@@ -166,7 +165,7 @@ export const evaluateClinicalData = (
   ];
 
   return {
-    clinicalNotes: evaluateData(clinicalNotes),
+    historyOfPresentIllness: evaluateData(historyOfPresentIllness),
     reasonForVisitDetails: evaluateData(reasonForVisitData),
     activeProblemsDetails: evaluateData(activeProblemsTableData),
     emergencyOutbreakInfo: evaluateData(emergencyOutbreakInfo),

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/clinical-data.tsx
@@ -85,7 +85,7 @@ export const evaluateClinicalData = (
     evaluateNotes(
       fhirBundle,
       fhirPathMappings.historyOfPresentIllness,
-      "History of Present Illness"
+      "History of Present Illness",
     ),
   ];
   const reasonForVisitData: DisplayDataProps[] = [

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
@@ -68,16 +68,16 @@ test.describe("viewer page", () => {
       // use a test id here to avoid a lot of special casing around the back to
       // library link, which may or may not exist based on the config
       const navLinksLoc = nav.getByTestId("sidenav-link");
-      await expect(navLinksLoc).toHaveCount(21);
+      await expect(navLinksLoc).toHaveCount(20);
       const navLinks = await navLinksLoc.all();
-      expect(navLinks.length).toBe(21); // sanity check
+      expect(navLinks.length).toBe(20); // sanity check
 
       // Make sure after collapsing and reopening, nav links still work
       await page.getByText("Collapse all sections").click();
-      expect(page.getByText("Miscellaneous Notes")).not.toBeVisible();
+      expect(page.getByText("History of Present Illness")).not.toBeVisible();
 
       await page.getByText("Expand all sections").click();
-      expect(page.getByText("Miscellaneous Notes")).toBeVisible();
+      expect(page.getByText("History of Present Illness")).toBeVisible();
 
       // make sure clicking each link scrolls the heading and highlights the corresponding
       // side nav item
@@ -103,7 +103,7 @@ test.describe("viewer page", () => {
       // use a test id here to avoid a lot of special casing around the back to
       // library link, which may or may not exist based on the config
       const navLinksLoc = nav.getByTestId("sidenav-link");
-      await expect(navLinksLoc).toHaveCount(21);
+      await expect(navLinksLoc).toHaveCount(20);
       const numLinks = (await navLinksLoc.all()).length;
       let navIndex = 0;
       while (navIndex < numLinks) {

--- a/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/ecr-viewer.spec.ts
@@ -65,7 +65,9 @@ test.describe("viewer page", () => {
       await expect(nav).toBeVisible();
 
       // Full DOM should not be rendered yet
-      await expect(page.getByText("History of Present Illness")).not.toBeAttached();
+      await expect(
+        page.getByText("History of Present Illness"),
+      ).not.toBeAttached();
 
       // use a test id here to avoid a lot of special casing around the back to
       // library link, which may or may not exist based on the config

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
@@ -38,7 +38,7 @@ describe("Snapshot tests", () => {
     it("should match snapshot for all Clinical Info components", async () => {
       const { container } = render(
         <ClinicalInfo
-          clinicalNotes={[]}
+          historyOfPresentIllness={[]}
           activeProblemsDetails={testActiveProblemsData}
           emergencyOutbreakInfo={testOutbreakInfo}
           vitalData={testVitalSignsData}

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/Clinical.test.tsx
@@ -517,7 +517,7 @@ describe("Snapshot tests", () => {
 
       container = render(
         <ClinicalInfo
-          clinicalNotes={[]}
+          historyOfPresentIllness={[]}
           activeProblemsDetails={[]}
           emergencyOutbreakInfo={[]}
           vitalData={[]}
@@ -535,11 +535,11 @@ describe("Snapshot tests", () => {
     });
   });
 
-  describe("Snapshot test for Clinical Notes", () => {
+  describe("Snapshot test for History of Present Illness", () => {
     it("should match snapshot for non table notes", async () => {
-      const clinicalNotes = [
+      const historyOfPresentIllness = [
         {
-          title: "Miscellaneous Notes",
+          title: "History of Present Illness",
           value: (
             <p>
               This patient was only recently discharged for a recurrent GI bleed
@@ -550,7 +550,7 @@ describe("Snapshot tests", () => {
       ];
       const { container } = render(
         <ClinicalInfo
-          clinicalNotes={clinicalNotes}
+          historyOfPresentIllness={historyOfPresentIllness}
           activeProblemsDetails={[]}
           emergencyOutbreakInfo={[]}
           vitalData={[]}
@@ -616,7 +616,7 @@ describe("Snapshot tests", () => {
           },
         ],
       } as unknown as Bundle;
-      const clinicalNotes = [
+      const historyOfPresentIllness = [
         evaluateNotes(
           bundle,
           fhirPathMappings.historyOfPresentIllness,
@@ -626,7 +626,7 @@ describe("Snapshot tests", () => {
       ];
       const { container } = render(
         <ClinicalInfo
-          clinicalNotes={clinicalNotes}
+          historyOfPresentIllness={historyOfPresentIllness}
           activeProblemsDetails={[]}
           emergencyOutbreakInfo={[]}
           vitalData={[]}
@@ -651,7 +651,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={[]}
         treatmentData={[]}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 
@@ -676,7 +676,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={[]}
         treatmentData={[]}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 
@@ -705,7 +705,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={testVitalSignsData}
         treatmentData={[]}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 
@@ -744,7 +744,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={[]}
         treatmentData={[]}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 
@@ -765,7 +765,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={[]}
         treatmentData={testTreatmentData}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 
@@ -787,7 +787,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={testOutbreakInfo}
         vitalData={[]}
         treatmentData={[]}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
     const expectedEmergencyOutbreakElement = clinicalInfo.getByTestId(
@@ -805,7 +805,7 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
         emergencyOutbreakInfo={[]}
         vitalData={testVitalSignsData}
         treatmentData={testTreatmentData}
-        clinicalNotes={[]}
+        historyOfPresentIllness={[]}
       />,
     );
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -115,7 +115,6 @@ describe("Tests for eCR Document", () => {
       {
         title: "Clinical Info",
         subNavItems: [
-          "Clinical Notes",
           "Symptoms and Problems",
           "Immunizations",
         ],
@@ -144,12 +143,12 @@ describe("Tests for eCR Document", () => {
         BundleWithMiscNotes,
         fhirIndexBundleWithMiscNotes,
       );
-      render(actual.clinicalNotes.availableData[0].value as React.JSX.Element);
-      expect(actual.clinicalNotes.availableData[0].title).toEqual(
-        "Miscellaneous Notes",
+      render(actual.historyOfPresentIllness.availableData[0].value as React.JSX.Element);
+      expect(actual.historyOfPresentIllness.availableData[0].title).toEqual(
+        "History of Present Illness",
       );
       expect(screen.getByText("Active Problems")).toBeInTheDocument();
-      expect(actual.clinicalNotes.unavailableData).toBeEmpty();
+      expect(actual.historyOfPresentIllness.unavailableData).toBeEmpty();
     });
     it("Should not include Treatment details if medications is not available", () => {
       const actual = evaluateClinicalData(

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -114,10 +114,7 @@ describe("Tests for eCR Document", () => {
       },
       {
         title: "Clinical Info",
-        subNavItems: [
-          "Symptoms and Problems",
-          "Immunizations",
-        ],
+        subNavItems: ["Symptoms and Problems", "Immunizations"],
       },
       {
         title: "Lab Info",
@@ -143,7 +140,10 @@ describe("Tests for eCR Document", () => {
         BundleWithMiscNotes,
         fhirIndexBundleWithMiscNotes,
       );
-      render(actual.historyOfPresentIllness.availableData[0].value as React.JSX.Element);
+      render(
+        actual.historyOfPresentIllness.availableData[0]
+          .value as React.JSX.Element,
+      );
       expect(actual.historyOfPresentIllness.availableData[0].title).toEqual(
         "History of Present Illness",
       );

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -1536,51 +1536,7 @@ exports[`Tests for eCR Document Given no data, info message for empty sections s
                         <div
                           class="data-title padding-right-1"
                         >
-                          <div
-                            class="display-flex flex-align-baseline"
-                          >
-                            Miscellaneous Notes
-                            <span
-                              class="usa-tooltip"
-                              data-testid="tooltipWrapper"
-                            >
-                              <div
-                                aria-describedby="tooltip-r:id"
-                                class="usa-tooltip__trigger margin-left-05 usa-tooltip"
-                                data-testid="triggerElement"
-                                tabindex="0"
-                              >
-                                <svg
-                                  aria-label="description"
-                                  class="usa-icon tooltip-icon text-secondary flex-align-center"
-                                  focusable="false"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 24 24"
-                                  width="1em"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M0 0h24v24H0V0z"
-                                    fill="none"
-                                  />
-                                  <path
-                                    d="M11 7h2v2h-2V7zm0 4h2v6h-2v-6zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                                  />
-                                </svg>
-                              </div>
-                              <span
-                                aria-hidden="true"
-                                class="usa-tooltip__body"
-                                data-testid="tooltipBody"
-                                id="tooltip-r:id"
-                                role="tooltip"
-                                title="Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR."
-                              >
-                                Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.
-                              </span>
-                            </span>
-                          </div>
+                          History of Present Illness
                         </div>
                         <div
                           class="grid-col maxw7 text-pre-line p-list text-italic text-base"

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/Clinical.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/Clinical.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Snapshot tests Snapshot test for Clinical Notes should match snapshot for non table notes 1`] = `
+exports[`Snapshot tests Snapshot test for History of Present Illness should match snapshot for non table notes 1`] = `
 <div>
   <div
     class="margin-top-0"
@@ -16,34 +16,49 @@ exports[`Snapshot tests Snapshot test for Clinical Notes should match snapshot f
         >
           <h4
             class="usa-summary-box__heading padding-y-105"
-            id="clinical-notes"
+            id="symptoms-and-problems"
           >
-            Clinical Notes
+            Symptoms and Problems
           </h4>
           <div
-            class="usa-summary-box__text clinical_info_container"
+            class="usa-summary-box__text"
           >
-            <div>
-              <div
-                class="grid-row"
-              >
-                <div
-                  class="data-title padding-right-1"
-                >
-                  Miscellaneous Notes
-                </div>
-                <div
-                  class="grid-col maxw7 text-pre-line p-list"
-                >
-                  <p>
-                    This patient was only recently discharged for a recurrent GI bleed as described
-                  </p>
-                </div>
-              </div>
-              <div
-                class="section__line_gray"
-              />
+            <div
+              data-testid="reason-for-visit"
+            />
+            <div
+              data-testid="active-problems"
+            >
+              <div />
             </div>
+            <div
+              data-testid="history-of-present-illness"
+            >
+              <div>
+                <div
+                  class="grid-row"
+                >
+                  <div
+                    class="data-title padding-right-1"
+                  >
+                    History of Present Illness
+                  </div>
+                  <div
+                    class="grid-col maxw7 text-pre-line p-list"
+                  >
+                    <p>
+                      This patient was only recently discharged for a recurrent GI bleed as described
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="section__line_gray"
+                />
+              </div>
+            </div>
+            <div
+              data-testid="emergency-outbreak-info"
+            />
           </div>
         </div>
       </div>
@@ -52,7 +67,7 @@ exports[`Snapshot tests Snapshot test for Clinical Notes should match snapshot f
 </div>
 `;
 
-exports[`Snapshot tests Snapshot test for Clinical Notes should match snapshot for table notes 1`] = `
+exports[`Snapshot tests Snapshot test for History of Present Illness should match snapshot for table notes 1`] = `
 <div>
   <div
     class="margin-top-0"
@@ -68,123 +83,138 @@ exports[`Snapshot tests Snapshot test for Clinical Notes should match snapshot f
         >
           <h4
             class="usa-summary-box__heading padding-y-105"
-            id="clinical-notes"
+            id="symptoms-and-problems"
           >
-            Clinical Notes
+            Symptoms and Problems
           </h4>
           <div
-            class="usa-summary-box__text clinical_info_container"
+            class="usa-summary-box__text"
           >
-            <div>
-              <div
-                class="grid-row flex-column"
-              >
+            <div
+              data-testid="reason-for-visit"
+            />
+            <div
+              data-testid="active-problems"
+            >
+              <div />
+            </div>
+            <div
+              data-testid="history-of-present-illness"
+            >
+              <div>
                 <div
-                  class="data-title padding-right-1"
+                  class="grid-row flex-column"
                 >
-                  Miscellaneous Notes
-                </div>
-                <div
-                  class="grid-col width-full text-pre-line p-list"
-                >
-                  <table
-                    class="usa-table usa-table--borderless width-full table-caption-margin caption-normal-weight margin-bottom-2 border-top border-left border-right"
-                    data-testid="table"
+                  <div
+                    class="data-title padding-right-1"
                   >
-                    <caption>
-                      <div
-                        class="display-flex flex-align-baseline"
-                      >
+                    Miscellaneous Notes
+                  </div>
+                  <div
+                    class="grid-col width-full text-pre-line p-list"
+                  >
+                    <table
+                      class="usa-table usa-table--borderless width-full table-caption-margin caption-normal-weight margin-bottom-2 border-top border-left border-right"
+                      data-testid="table"
+                    >
+                      <caption>
                         <div
-                          class="data-title"
-                        >
-                          Miscellaneous Notes
-                        </div>
-                        <span
-                          class="usa-tooltip"
-                          data-testid="tooltipWrapper"
+                          class="display-flex flex-align-baseline"
                         >
                           <div
-                            aria-describedby="tooltip-r:id"
-                            class="usa-tooltip__trigger margin-left-05 usa-tooltip"
-                            data-testid="triggerElement"
-                            tabindex="0"
+                            class="data-title"
                           >
-                            <svg
-                              aria-label="description"
-                              class="usa-icon tooltip-icon text-secondary flex-align-center"
-                              focusable="false"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width="1em"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M0 0h24v24H0V0z"
-                                fill="none"
-                              />
-                              <path
-                                d="M11 7h2v2h-2V7zm0 4h2v6h-2v-6zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                              />
-                            </svg>
+                            Miscellaneous Notes
                           </div>
                           <span
-                            aria-hidden="true"
-                            class="usa-tooltip__body"
-                            data-testid="tooltipBody"
-                            id="tooltip-r:id"
-                            role="tooltip"
-                            title="Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR."
+                            class="usa-tooltip"
+                            data-testid="tooltipWrapper"
                           >
-                            Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.
+                            <div
+                              aria-describedby="tooltip-r:id"
+                              class="usa-tooltip__trigger margin-left-05 usa-tooltip"
+                              data-testid="triggerElement"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-label="description"
+                                class="usa-icon tooltip-icon text-secondary flex-align-center"
+                                focusable="false"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M0 0h24v24H0V0z"
+                                  fill="none"
+                                />
+                                <path
+                                  d="M11 7h2v2h-2V7zm0 4h2v6h-2v-6zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                                />
+                              </svg>
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="usa-tooltip__body"
+                              data-testid="tooltipBody"
+                              id="tooltip-r:id"
+                              role="tooltip"
+                              title="Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR."
+                            >
+                              Clinical notes from various parts of a medical record. Type of note found here depends on how the provider's EHR system onboarded to send eCR.
+                            </span>
                           </span>
-                        </span>
-                      </div>
-                    </caption>
-                    <thead>
-                      <tr>
-                        <th
-                          class="table-header bg-gray-5"
-                          scope="col"
-                          style="min-width: 10rem;"
-                        >
-                          Active Problems
-                        </th>
-                        <th
-                          class="table-header bg-gray-5"
-                          scope="col"
-                          style="min-width: 10rem;"
-                        >
-                          Noted Date
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>
-                          Parkinson's syndrome
-                        </td>
-                        <td>
-                          07/25/2022
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          Essential hypertension
-                        </td>
-                        <td>
-                          07/21/2022
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                        </div>
+                      </caption>
+                      <thead>
+                        <tr>
+                          <th
+                            class="table-header bg-gray-5"
+                            scope="col"
+                            style="min-width: 10rem;"
+                          >
+                            Active Problems
+                          </th>
+                          <th
+                            class="table-header bg-gray-5"
+                            scope="col"
+                            style="min-width: 10rem;"
+                          >
+                            Noted Date
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>
+                            Parkinson's syndrome
+                          </td>
+                          <td>
+                            07/25/2022
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>
+                            Essential hypertension
+                          </td>
+                          <td>
+                            07/21/2022
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
+                <div
+                  class="section__line_gray"
+                />
               </div>
-              <div
-                class="section__line_gray"
-              />
             </div>
+            <div
+              data-testid="emergency-outbreak-info"
+            />
           </div>
         </div>
       </div>
@@ -771,6 +801,9 @@ exports[`Snapshot tests Snapshot tests for Clinical Info components should match
                 </div>
               </div>
             </div>
+            <div
+              data-testid="history-of-present-illness"
+            />
             <div
               data-testid="emergency-outbreak-info"
             >


### PR DESCRIPTION
## Summary

The History of Present Illness was previously displayed under the Clinical Notes section as Miscellaneous Notes. The Clinical Notes section has been removed because it only contained Miscellaneous Notes, which have now been renamed to History of Present Illness and moved to the Symptoms and Problems section.

## Related Issue

Fixes #1344 

## Acceptance Criteria

- [x] History of Present Illness section has been added to Clinical Info -> Symptoms and Problems
- [x] Relevant tests have been added
- [x] Design review has been completed and approved (tag Chinelo in the PR when it's ready for review, and please attach any relevant screenshots or videos!)

## Additional Information
Before:
<img width="1320" height="417" alt="image" src="https://github.com/user-attachments/assets/9e186478-1893-402d-b57b-32a7f68b9a13" />

AfterI:
<img width="1310" height="351" alt="image" src="https://github.com/user-attachments/assets/3078e38a-381c-486f-b84c-188f91373057" />


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
