### PR TITLE
fix: Adding more HAProxy env var configs

### DIFF
--- a/containers/fhir-converter-proxy/README.md
+++ b/containers/fhir-converter-proxy/README.md
@@ -45,7 +45,7 @@ Optional environment variables:
 - **FHIR_CONVERTER_PROXY_MAX_CONNECTIONS** - The maximum number of requests a single instance is allowed to process at a time. This value should be tuned based on instance resources and how many ECRs an instance can handle concurrently. Default set to 3.
 - **FHIR_CONVERTER_PROXY_INSTANCE_SLOTS** - Numebr of total "slots" that will be filled with instances as they are discovered, unused slots will not cause issues. Default set to 10.
 - **FHIR_CONVERTER_PROXY_CONNECT_TIMEOUT** - Maximum time to wait for a connection attempt to a server to succeed. If the server is located on the same LAN as HAProxy, the connection should be immediate (less than a few milliseconds). It is a good practice to cover one or several TCP packet losses by specifying timeouts that are slightly above multiples of 3 seconds (e.g. 4 or 5 seconds). Default set to 10s.
-- **FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT** - Maximum time for requests to wait in the queue for a connection slot to be free. Default set to 60s.
+- **FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT** - Maximum time for requests to wait in the queue for a connection slot to be free. Default set to 300s (for large ECR processing).
 - **FHIR_CONVERTER_PROXY_CLIENT_TIMEOUT** - Maximum inactivity time on the client side. The inactivity timeout applies when the client is expected to acknowledge or send data. Default set to 300s (for large ECR processing).
 - **FHIR_CONVERTER_PROXY_SERVER_TIMEOUT** - Maximum inactivity time on the server side. The inactivity timeout applies when the server is expected to acknowledge or send data. Default set to 300s (for large ECR processing).
 

--- a/containers/fhir-converter-proxy/README.md
+++ b/containers/fhir-converter-proxy/README.md
@@ -40,6 +40,15 @@ Expected environment variables:
 - **FHIR_CONVERTER_ECS_NAMESPACE** - Used to assemble the host URL for AWS ECS instances using the DNS resolver, can be left unset for local environments. This should be the AWS CloudMap namespace name used by ECS. This environment variable is set in the TF module along with the definition of the `fhir-converter-dns` resource used for the resolver host.
 - **FHIR_CONVERTER_PORT** - The FHIR Converter service port to route requests to. Usually set to: `8080`. Only the port is needed because the host is derived from the environment (for local) or the `FHIR_CONVERTER_ECS_NAMESPACE` for AWS.
 
+Optional environment variables:
+
+- **FHIR_CONVERTER_PROXY_MAX_CONNECTIONS** - The maximum number of requests a single instance is allowed to process at a time. This value should be tuned based on instance resources and how many ECRs an instance can handle concurrently. Default set to 3.
+- **FHIR_CONVERTER_PROXY_INSTANCE_SLOTS** - Numebr of total "slots" that will be filled with instances as they are discovered, unused slots will not cause issues. Default set to 10.
+- **FHIR_CONVERTER_PROXY_CONNECT_TIMEOUT** - Maximum time to wait for a connection attempt to a server to succeed. If the server is located on the same LAN as HAProxy, the connection should be immediate (less than a few milliseconds). It is a good practice to cover one or several TCP packet losses by specifying timeouts that are slightly above multiples of 3 seconds (e.g. 4 or 5 seconds). Default set to 10s.
+- **FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT** - Maximum time for requests to wait in the queue for a connection slot to be free. Default set to 60s.
+- **FHIR_CONVERTER_PROXY_CLIENT_TIMEOUT** - Maximum inactivity time on the client side. The inactivity timeout applies when the client is expected to acknowledge or send data. Default set to 300s (for large ECR processing).
+- **FHIR_CONVERTER_PROXY_SERVER_TIMEOUT** - Maximum inactivity time on the server side. The inactivity timeout applies when the server is expected to acknowledge or send data. Default set to 300s (for large ECR processing).
+
 ### Customizing and Publishing the HAProxy Image
 
 If you need to make changes to the routing logic, add a new backend, or tune the connection limits, you will need to update the `haproxy.cfg` file and build a new Docker image.

--- a/containers/fhir-converter-proxy/haproxy.cfg
+++ b/containers/fhir-converter-proxy/haproxy.cfg
@@ -11,8 +11,8 @@ defaults
     # 10 seconds for AWS internal networking to connect
     timeout connect "${FHIR_CONVERTER_PROXY_CONNECT_TIMEOUT-10s}"
     
-    # Timeout while requests sit in the queue (defaults to 60s)
-    timeout queue "${FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT-60s}"
+    # Timeout while requests sit in the queue (defaults to 300s)
+    timeout queue "${FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT-300s}"
     
     # Increased timeouts are critical for large uploads over the internal network
     timeout client "${FHIR_CONVERTER_PROXY_CLIENT_TIMEOUT-300s}"

--- a/containers/fhir-converter-proxy/haproxy.cfg
+++ b/containers/fhir-converter-proxy/haproxy.cfg
@@ -9,16 +9,19 @@ defaults
     option httplog
     
     # 10 seconds for AWS internal networking to connect
-    timeout connect 10s
+    timeout connect "${FHIR_CONVERTER_PROXY_CONNECT_TIMEOUT-10s}"
+    
+    # Timeout while requests sit in the queue (defaults to 60s)
+    timeout queue "${FHIR_CONVERTER_PROXY_QUEUE_TIMEOUT-60s}"
     
     # Increased timeouts are critical for large uploads over the internal network
-    timeout client 300s
-    timeout server 300s
+    timeout client "${FHIR_CONVERTER_PROXY_CLIENT_TIMEOUT-300s}"
+    timeout server "${FHIR_CONVERTER_PROXY_SERVER_TIMEOUT-300s}"
 
 frontend fhir_converter_proxy
-    bind *:${FHIR_CONVERTER_PROXY_PORT}
+    bind *:"${FHIR_CONVERTER_PROXY_PORT}"
     
-    # 1. Define an ACL that checks the ENVIRONMENT variable
+    # 1. Define an ACL that checks the ENVIRONMENT variable (read at runtime)
     acl is_local env(ENVIRONMENT) -m str local
     
     # 2. If the variable is 'local', send traffic to the local backend
@@ -36,9 +39,9 @@ backend local_converters
     # Checks server health every 5s; marks offline after 5 consecutive failures, and back online after 2 successes.
     default-server inter 5s fall 5 rise 2
 
-    # maxconn per server forces HAProxy to queue requests rather than crashing the converter
+    # maxconn (FHIR_CONVERTER_PROXY_MAX_CONNECTIONS default to 3) per server forces HAProxy to queue requests rather than crashing the converter
     #  - tune this number based on how many large eCRs a single task can handle in RAM at once
-    server converter-1 fhir-converter-service:${FHIR_CONVERTER_PORT} check maxconn 3 init-addr last,libc,none
+    server converter-1 fhir-converter-service:"${FHIR_CONVERTER_PORT}" check maxconn "${FHIR_CONVERTER_PROXY_MAX_CONNECTIONS-3}" init-addr last,libc,none
 
 # AWS VPC DNS Resolver (Always at this IP in AWS)
 resolvers aws_dns
@@ -54,8 +57,8 @@ backend ecs_converters
     # Checks server health every 5s; marks offline after 5 consecutive failures, and back online after 2 successes.
     default-server inter 5s fall 5 rise 2
 
-    # "server-template" creates 10 "slots", one for each converter instance registered with the resolver. 
+    # "server-template" creates FHIR_CONVERTER_PROXY_INSTANCE_SLOTS (default to 10) "slots", one for each converter instance registered with the resolver. 
     # HAProxy fills the slots by querying 'fhir-converter-dns.<aws_service_discovery_private_dns_namespace name>'
-    # maxconn per server forces HAProxy to queue requests rather than crashing the converter
+    # maxconn (FHIR_CONVERTER_PROXY_MAX_CONNECTIONS default to 3) per server forces HAProxy to queue requests rather than crashing the converter
     #  - tune this number based on how many large eCRs a single task can handle in RAM at once
-    server-template converter- 10 fhir-converter-dns.${FHIR_CONVERTER_ECS_NAMESPACE}:${FHIR_CONVERTER_PORT} check maxconn 3 resolvers aws_dns init-addr none
+    server-template converter- "${FHIR_CONVERTER_PROXY_INSTANCE_SLOTS-10}" fhir-converter-dns."${FHIR_CONVERTER_ECS_NAMESPACE}":"${FHIR_CONVERTER_PORT}" check maxconn "${FHIR_CONVERTER_PROXY_MAX_CONNECTIONS-3}" resolvers aws_dns init-addr none


### PR DESCRIPTION
## Summary

Adding support for making more configs be driven by environment variables. I ended up including all timeouts just in case. 

Also added double quotes to env var wraps to make sure they are properly parsed.

## Related Issue

Fixes #1454 

## Acceptance Criteria

- [x]  Update config to use environment variables and confirm it works
- [x]  Update README file with new environment variable descriptions
- [ ]  Update docker compose and TF files to set new env vars as needed - not needed since we can set default values.

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
