### PR TITLE
feat: eCR deletion scripts

### DIFF
--- a/containers/ecr-viewer/guides/setup.md
+++ b/containers/ecr-viewer/guides/setup.md
@@ -182,12 +182,12 @@ When using the curl command to send zip files to ecr-viewer, the user has to use
 
 SQL scripts for removing eCR records from the metadata database are provided in `seed-scripts/sql/`. Each script targets one database type and handles foreign key constraints automatically.
 
-| Script | Database | Behavior |
-| --- | --- | --- |
-| `seed-scripts/sql/postgres/delete-ecrs-by-date.sql` | Postgres | Deletes eCRs (and all child records) created before a given date |
+| Script                                               | Database   | Behavior                                                         |
+| ---------------------------------------------------- | ---------- | ---------------------------------------------------------------- |
+| `seed-scripts/sql/postgres/delete-ecrs-by-date.sql`  | Postgres   | Deletes eCRs (and all child records) created before a given date |
 | `seed-scripts/sql/sqlserver/delete-ecrs-by-date.sql` | SQL Server | Deletes eCRs (and all child records) created before a given date |
-| `seed-scripts/sql/postgres/delete-all-data.sql` | Postgres | Deletes **all** data from every table in the `ecr_viewer` schema |
-| `seed-scripts/sql/sqlserver/delete-all-data.sql` | SQL Server | Deletes **all** data from every table in the `ecr_viewer` schema |
+| `seed-scripts/sql/postgres/delete-all-data.sql`      | Postgres   | Deletes **all** data from every table in the `ecr_viewer` schema |
+| `seed-scripts/sql/sqlserver/delete-all-data.sql`     | SQL Server | Deletes **all** data from every table in the `ecr_viewer` schema |
 
 ### Delete by date
 

--- a/containers/ecr-viewer/guides/setup.md
+++ b/containers/ecr-viewer/guides/setup.md
@@ -178,6 +178,46 @@ curl --location '<DIBBS_URL>/ecr-viewer/api/process-ecr' \
 
 When using the curl command to send zip files to ecr-viewer, the user has to use the flag type=application/zip. If not, they will receive this response message {"message":"Failed to process orchestration response"} and will see the error in the screenshot in their ecr-viewer logs.
 
+## Deleting data
+
+SQL scripts for removing eCR records from the metadata database are provided in `seed-scripts/sql/`. Each script targets one database type and handles foreign key constraints automatically.
+
+| Script | Database | Behavior |
+| --- | --- | --- |
+| `seed-scripts/sql/postgres/delete-ecrs-by-date.sql` | Postgres | Deletes eCRs (and all child records) created before a given date |
+| `seed-scripts/sql/sqlserver/delete-ecrs-by-date.sql` | SQL Server | Deletes eCRs (and all child records) created before a given date |
+| `seed-scripts/sql/postgres/delete-all-data.sql` | Postgres | Deletes **all** data from every table in the `ecr_viewer` schema |
+| `seed-scripts/sql/sqlserver/delete-all-data.sql` | SQL Server | Deletes **all** data from every table in the `ecr_viewer` schema |
+
+### Delete by date
+
+Open the appropriate script for your database and set the `cutoff_date` variable near the top of the file to the earliest date you want to **keep** (records created before that date will be deleted). Then run:
+
+```bash
+# Postgres
+psql "$DATABASE_URL" -f seed-scripts/sql/postgres/delete-ecrs-by-date.sql
+
+# SQL Server
+sqlcmd -S <server> -U <user> -P <password> -i seed-scripts/sql/sqlserver/delete-ecrs-by-date.sql
+```
+
+Both scripts are safe to run against core and extended schema deployments — extended schema tables (`ecr_labs`, `ecr_immunizations`, `patient_address`) are deleted only when present.
+
+### Delete all data
+
+> [!WARNING]
+> The delete-all scripts remove every row from every table in the `ecr_viewer` schema, including user accounts and program areas. This cannot be undone. Take a database backup before running.
+
+```bash
+# Postgres
+psql "$DATABASE_URL" -f seed-scripts/sql/postgres/delete-all-data.sql
+
+# SQL Server
+sqlcmd -S <server> -U <user> -P <password> -i seed-scripts/sql/sqlserver/delete-all-data.sql
+```
+
+After running a delete-all script, re-initialize the database by calling the `/migrate-db` endpoint with `init_admin_email` before the app can be used again (see [Database Migrations](#database-migrations)).
+
 ## User and Program Area Setup
 
 ### Initialization

--- a/containers/ecr-viewer/seed-scripts/sql/postgres/delete-all-data.sql
+++ b/containers/ecr-viewer/seed-scripts/sql/postgres/delete-all-data.sql
@@ -1,0 +1,37 @@
+-- Deletes ALL data from every table in the ecr_viewer schema.
+--
+-- WARNING: This is irreversible. Take a database backup before running.
+--
+-- Deleted data includes:
+--   - All eCR records and associated child tables (labs, immunizations, RR data, etc.)
+--   - Audit log entries
+--   - Condition reference data
+--   - User accounts, program areas, and user-program area assignments
+--
+-- The schema itself (tables, indexes, constraints) is preserved. You will need to
+-- re-run database initialization (POST /migrate-db with init_admin_email) to
+-- restore a usable admin account before the app can be used again.
+--
+-- TRUNCATE ... CASCADE is used to handle foreign key relationships, including the
+-- self-referential user.author_uuid FK, without requiring superuser privileges.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f delete-all-data.sql
+
+DO $$
+BEGIN
+  -- ECR records and all child tables (ecr_rr_conditions, ecr_rr_rule_summaries,
+  -- and extended schema tables ecr_labs, ecr_immunizations, patient_address if present).
+  TRUNCATE ecr_viewer.ecr_data CASCADE;
+
+  -- Audit log (no FK dependencies)
+  TRUNCATE ecr_viewer.audit_log;
+
+  -- User accounts and all dependent tables.
+  -- CASCADE handles user_program_area, program_area, and condition_reference
+  -- (via their FK chains back to user), as well as the self-referential
+  -- user.author_uuid FK.
+  TRUNCATE ecr_viewer."user" CASCADE;
+
+  RAISE NOTICE 'All data deleted from ecr_viewer schema.';
+END $$;

--- a/containers/ecr-viewer/seed-scripts/sql/postgres/delete-ecrs-by-date.sql
+++ b/containers/ecr-viewer/seed-scripts/sql/postgres/delete-ecrs-by-date.sql
@@ -1,0 +1,81 @@
+-- Deletes eCR records created before a specified cutoff date from the Postgres
+-- metadata database, along with all associated child records.
+--
+-- Usage:
+--   1. Set CUTOFF_DATE in the DECLARE block below (YYYY-MM-DD format).
+--   2. Run against your database:
+--        psql "$DATABASE_URL" -f delete-ecrs-by-date.sql
+--
+-- Records with ecr_data.date_created < cutoff_date will be permanently deleted.
+-- Take a database backup before running this script.
+
+DO $$
+DECLARE
+  cutoff_date TIMESTAMPTZ := '2024-01-01';  -- <-- Set your cutoff date here
+  ecr_count   INT;
+BEGIN
+  SELECT COUNT(*) INTO ecr_count
+  FROM ecr_viewer.ecr_data
+  WHERE date_created < cutoff_date;
+
+  RAISE NOTICE 'Deleting % eCR record(s) created before %.', ecr_count, cutoff_date;
+
+  -- Delete rule summaries first (FK: ecr_rr_rule_summaries - ecr_rr_conditions - ecr_data)
+  DELETE FROM ecr_viewer.ecr_rr_rule_summaries
+  WHERE ecr_rr_conditions_id IN (
+    SELECT uuid FROM ecr_viewer.ecr_rr_conditions
+    WHERE eicr_id IN (
+      SELECT eicr_id FROM ecr_viewer.ecr_data
+      WHERE date_created < cutoff_date
+    )
+  );
+
+  DELETE FROM ecr_viewer.ecr_rr_conditions
+  WHERE eicr_id IN (
+    SELECT eicr_id FROM ecr_viewer.ecr_data
+    WHERE date_created < cutoff_date
+  );
+
+  -- Extended schema tables (ecr_labs, ecr_immunizations, patient_address).
+  -- These tables only exist when METADATA_DATABASE_SCHEMA=extended.
+  -- Each block checks for the table before attempting deletion, so this script
+  -- is safe to run against both core and extended schema deployments.
+  IF EXISTS (
+    SELECT FROM information_schema.tables
+    WHERE table_schema = 'ecr_viewer' AND table_name = 'ecr_labs'
+  ) THEN
+    DELETE FROM ecr_viewer.ecr_labs
+    WHERE eicr_id IN (
+      SELECT eicr_id FROM ecr_viewer.ecr_data
+      WHERE date_created < cutoff_date
+    );
+  END IF;
+
+  IF EXISTS (
+    SELECT FROM information_schema.tables
+    WHERE table_schema = 'ecr_viewer' AND table_name = 'ecr_immunizations'
+  ) THEN
+    DELETE FROM ecr_viewer.ecr_immunizations
+    WHERE eicr_id IN (
+      SELECT eicr_id FROM ecr_viewer.ecr_data
+      WHERE date_created < cutoff_date
+    );
+  END IF;
+
+  IF EXISTS (
+    SELECT FROM information_schema.tables
+    WHERE table_schema = 'ecr_viewer' AND table_name = 'patient_address'
+  ) THEN
+    DELETE FROM ecr_viewer.patient_address
+    WHERE eicr_id IN (
+      SELECT eicr_id FROM ecr_viewer.ecr_data
+      WHERE date_created < cutoff_date
+    );
+  END IF;
+
+  -- Delete the parent eCR records last.
+  DELETE FROM ecr_viewer.ecr_data
+  WHERE date_created < cutoff_date;
+
+  RAISE NOTICE 'Done. % eCR record(s) deleted.', ecr_count;
+END $$;

--- a/containers/ecr-viewer/seed-scripts/sql/sqlserver/delete-all-data.sql
+++ b/containers/ecr-viewer/seed-scripts/sql/sqlserver/delete-all-data.sql
@@ -1,0 +1,70 @@
+-- Deletes ALL data from every table in the ecr_viewer schema.
+--
+-- WARNING: This is irreversible. Take a database backup before running.
+--
+-- Deleted data includes:
+--   - All eCR records and associated child tables (labs, immunizations, RR data, etc.)
+--   - Audit log entries
+--   - Condition reference data
+--   - User accounts, program areas, and user-program area assignments
+--
+-- The schema itself (tables, indexes, constraints) is preserved. You will need to
+-- re-run database initialization (POST /migrate-db with init_admin_email) to
+-- restore a usable admin account before the app can be used again.
+--
+-- Usage:
+--   sqlcmd -S <server> -U <user> -P <password> -i delete-all-data.sql
+--   Or via Docker (see seed-scripts/sql/sqlserver/Dockerfile):
+--   sqlcmd -S localhost -U sa -P "$SQL_SERVER_PASSWORD" -C -i delete-all-data.sql
+
+BEGIN TRANSACTION;
+
+BEGIN TRY
+  -- ECR child tables (FK order: deepest dependents first)
+  DELETE FROM ecr_viewer.ecr_rr_rule_summaries;
+  DELETE FROM ecr_viewer.ecr_rr_conditions;
+
+  -- Extended schema tables (only present when METADATA_DATABASE_SCHEMA=extended)
+  IF OBJECT_ID('ecr_viewer.ecr_labs', 'U') IS NOT NULL
+    DELETE FROM ecr_viewer.ecr_labs;
+
+  IF OBJECT_ID('ecr_viewer.ecr_immunizations', 'U') IS NOT NULL
+    DELETE FROM ecr_viewer.ecr_immunizations;
+
+  IF OBJECT_ID('ecr_viewer.patient_address', 'U') IS NOT NULL
+    DELETE FROM ecr_viewer.patient_address;
+
+  -- Parent ECR records
+  DELETE FROM ecr_viewer.ecr_data;
+
+  -- Audit log
+  DELETE FROM ecr_viewer.audit_log;
+
+  -- Condition reference (FK: condition_reference.program_area_uuid - program_area)
+  DELETE FROM ecr_viewer.condition_reference;
+
+  -- user_program_area must be cleared before user and program_area (FK constraints)
+  DELETE FROM ecr_viewer.user_program_area;
+
+  -- program_area.author_uuid references [user], so it must be deleted first
+  DELETE FROM ecr_viewer.program_area;
+
+  -- [user].author_uuid is a self-referential FK. Temporarily disable FK constraints
+  -- on this table so all rows can be deleted in a single pass without ordering issues.
+  ALTER TABLE ecr_viewer.[user] NOCHECK CONSTRAINT ALL;
+  DELETE FROM ecr_viewer.[user];
+  ALTER TABLE ecr_viewer.[user] CHECK CONSTRAINT ALL;
+
+  PRINT 'All data deleted from ecr_viewer schema.';
+  COMMIT TRANSACTION;
+
+END TRY
+BEGIN CATCH
+  -- Re-enable constraints if the transaction is rolling back
+  IF OBJECT_ID('ecr_viewer.[user]', 'U') IS NOT NULL
+    ALTER TABLE ecr_viewer.[user] CHECK CONSTRAINT ALL;
+
+  ROLLBACK TRANSACTION;
+  PRINT 'Error: ' + ERROR_MESSAGE();
+  THROW;
+END CATCH;

--- a/containers/ecr-viewer/seed-scripts/sql/sqlserver/delete-ecrs-by-date.sql
+++ b/containers/ecr-viewer/seed-scripts/sql/sqlserver/delete-ecrs-by-date.sql
@@ -1,0 +1,75 @@
+-- Deletes eCR records created before a specified cutoff date,
+-- along with all associated child records.
+--
+-- Usage:
+--   1. Set @cutoff_date in the DECLARE block below (YYYY-MM-DD format).
+--   2. Run against your database:
+--        sqlcmd -S <server> -U <user> -P <password> -i delete-ecrs-by-date.sql
+--      Or via Docker (see seed-scripts/sql/sqlserver/Dockerfile):
+--        sqlcmd -S localhost -U sa -P "$SQL_SERVER_PASSWORD" -C -i delete-ecrs-by-date.sql
+--
+-- Records with ecr_data.date_created < @cutoff_date will be permanently deleted.
+-- Take a database backup before running this script.
+
+DECLARE @cutoff_date DATETIMEOFFSET = '2024-01-01';  -- <-- Set your cutoff date here
+
+BEGIN TRANSACTION;
+
+BEGIN TRY
+  -- Preview: show how many eCRs will be deleted.
+  SELECT COUNT(*) AS ecrs_to_delete
+  FROM ecr_viewer.ecr_data
+  WHERE date_created < @cutoff_date;
+
+  -- Delete rule summaries first (FK: ecr_rr_rule_summaries - ecr_rr_conditions - ecr_data)
+  DELETE rs
+  FROM ecr_viewer.ecr_rr_rule_summaries rs
+  INNER JOIN ecr_viewer.ecr_rr_conditions rc ON rs.ecr_rr_conditions_id = rc.uuid
+  INNER JOIN ecr_viewer.ecr_data d ON rc.eicr_id = d.eicr_id
+  WHERE d.date_created < @cutoff_date;
+
+  DELETE rc
+  FROM ecr_viewer.ecr_rr_conditions rc
+  INNER JOIN ecr_viewer.ecr_data d ON rc.eicr_id = d.eicr_id
+  WHERE d.date_created < @cutoff_date;
+
+  -- Extended schema tables (only present when METADATA_DATABASE_SCHEMA=extended).
+  -- Each block checks for the table before attempting deletion, so this script
+  -- is safe to run against both core and extended schema deployments.
+  IF OBJECT_ID('ecr_viewer.ecr_labs', 'U') IS NOT NULL
+  BEGIN
+    DELETE el
+    FROM ecr_viewer.ecr_labs el
+    INNER JOIN ecr_viewer.ecr_data d ON el.eicr_id = d.eicr_id
+    WHERE d.date_created < @cutoff_date;
+  END
+
+  IF OBJECT_ID('ecr_viewer.ecr_immunizations', 'U') IS NOT NULL
+  BEGIN
+    DELETE ei
+    FROM ecr_viewer.ecr_immunizations ei
+    INNER JOIN ecr_viewer.ecr_data d ON ei.eicr_id = d.eicr_id
+    WHERE d.date_created < @cutoff_date;
+  END
+
+  IF OBJECT_ID('ecr_viewer.patient_address', 'U') IS NOT NULL
+  BEGIN
+    DELETE pa
+    FROM ecr_viewer.patient_address pa
+    INNER JOIN ecr_viewer.ecr_data d ON pa.eicr_id = d.eicr_id
+    WHERE d.date_created < @cutoff_date;
+  END
+
+  -- Delete the parent eCR records last.
+  DELETE FROM ecr_viewer.ecr_data
+  WHERE date_created < @cutoff_date;
+
+  PRINT 'Deletion complete.';
+  COMMIT TRANSACTION;
+
+END TRY
+BEGIN CATCH
+  ROLLBACK TRANSACTION;
+  PRINT 'Error: ' + ERROR_MESSAGE();
+  THROW;
+END CATCH;


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Adds two deletion scripts for clearing data from each database type:

* delete-all-data.sql — deletes all data from the database.
* delete-ecrs-by-date.sql — deletes all data created after a specified date.

Running the full local data deletion also removes the admin user. To recreate it, run /migrate-db.

## Related Issue

Fixes #1486 

## Acceptance Criteria

- [x] Script deletes all eCR data older than a given date in Postgres
- [x] Script deletes all eCR data older than a given date in SQL Server

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
