### PR TITLE
fix: getComputedStyle in useEffect

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -242,15 +242,19 @@ const SideNav: React.FC<{
     [ecrDocumentNavConfig],
   );
 
-  const topOffset = useMemo(() => {
-    return 5 * parseFloat(getComputedStyle(document.documentElement).fontSize);
-  }, []);
   const parentMap = buildParentMap(sectionConfigs);
 
+  const [topOffset, setTopOffset] = useState(80);
   const [activeSection, setActiveSection] = useState<string>("");
 
   useEffect(() => {
     if (sectionConfigs.length === 0) return;
+
+    const oneRem = parseFloat(
+      getComputedStyle(document.documentElement).fontSize
+    );
+    setTopOffset(5 * oneRem);
+
     const validIds = new Set(
       (function flatten(items: SectionConfig[]): string[] {
         return items.flatMap(({ id, subNavItems }) => [

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -251,7 +251,7 @@ const SideNav: React.FC<{
     if (sectionConfigs.length === 0) return;
 
     const oneRem = parseFloat(
-      getComputedStyle(document.documentElement).fontSize
+      getComputedStyle(document.documentElement).fontSize,
     );
     setTopOffset(5 * oneRem);
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Moved calculating topOffset into `useEffect` (client-side) to prevent error from accessing `getComputedStyle` during server rendering.

## Related Issue

Fixes NA. Found issue below:

<img width="979" height="384" alt="Screenshot 2026-06-01 at 11 26 38" src="https://github.com/user-attachments/assets/79d42b41-8d0c-41cb-a942-d5bcc2124223" />

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
