### PR TITLE
fix: Error from multiple specimens

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.0 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/fix-specimen --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/fix-specimen --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.1 --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -290,8 +290,12 @@
         "nullable": true
       },
       "specimen_type": {
-        "fhir_path": "Observation.extension.where(url='http://hl7.org/fhir/R4/specimen.html').extension.where(url='specimen source').valueString",
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).type.coding.display",
         "data_type": "string",
+        "reference_lookup": [
+          "Observation.id",
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
+        ],
         "nullable": true
       },
       "performing_lab": {
@@ -300,8 +304,12 @@
         "nullable": true
       },
       "specimen_collection_date": {
-        "fhir_path": "Observation.extension.where(url='http://hl7.org/fhir/R4/specimen.html').extension.where(url='specimen collection time').valueDateTime",
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).collection.collectedPeriod.start | Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).collection.collectedDateTime",
         "data_type": "datetime",
+        "reference_lookup": [
+          "Observation.id",
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
+        ],
         "nullable": true
       }
     }

--- a/containers/message-parser/app/default_schemas/ecr_with_metadata.json
+++ b/containers/message-parser/app/default_schemas/ecr_with_metadata.json
@@ -358,8 +358,12 @@
         "nullable": true
       },
       "specimen_type": {
-        "fhir_path": "Observation.extension.where(url='http://hl7.org/fhir/R4/specimen.html').extension.where(url='specimen source').valueString",
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).type.coding.display",
         "data_type": "string",
+        "reference_lookup": [
+          "Observation.id",
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
+        ],
         "nullable": true
       },
       "performing_lab": {
@@ -368,8 +372,12 @@
         "nullable": true
       },
       "specimen_collection_date": {
-        "fhir_path": "Observation.extension.where(url='http://hl7.org/fhir/R4/specimen.html').extension.where(url='specimen collection time').valueDateTime",
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).collection.collectedPeriod.start | Bundle.entry.resource.where(resourceType = 'Specimen' and id = %ref).collection.collectedDateTime",
         "data_type": "datetime",
+        "reference_lookup": [
+          "Observation.id",
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
+        ],
         "nullable": true
       }
     }

--- a/containers/message-parser/app/default_schemas/extended.json
+++ b/containers/message-parser/app/default_schemas/extended.json
@@ -302,7 +302,7 @@
         "data_type": "string",
         "reference_lookup": [
           "Observation.id",
-          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen.reference"
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
         ],
         "nullable": true
       },
@@ -316,7 +316,7 @@
         "data_type": "datetime",
         "reference_lookup": [
           "Observation.id",
-          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen.reference"
+          "Bundle.entry.resource.where(resourceType = 'DiagnosticReport').where(result.where(reference.endsWith(%ref)).exists()).specimen[0].reference"
         ],
         "nullable": true
       }


### PR DESCRIPTION
# PULL REQUEST


## Summary

- FHIR converter: Prevent empty specimen resources (based off of `nullFlavor`s from being created)
- Pull only the first specimen from `DiagnosticReport` resource

## Related Issue

Fixes #1544 

Bug found after merging https://github.com/CDCgov/dibbs-ecr-viewer/pull/1500
Related FHIR converter PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/139

Issue found with pregnancy_3 from TN where it was resulting in the error below because of multiple Specimen references

```
ValueError: Provided `reference_lookup` location points to many referencing identifiers
```

## Acceptance Criteria

- Fix bug

## Additional Information

Angela note: I'm not completely certain this is the best solution, because a DiagnosticReport can have multiple specimens. But for the Viewer, we also only display the first specimen if there are multiple.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
