### PR TITLE
fix: fall back to pattern matching when zip files use original CDA names

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/services/xmlService.ts
+++ b/containers/ecr-viewer/src/app/view-data/services/xmlService.ts
@@ -41,8 +41,22 @@ export const getEcrXmls = async (id: string): Promise<EcrXmls> => {
   const buffer = Buffer.from(await Body.transformToByteArray());
   const zip = await JSZip.loadAsync(buffer);
 
-  const ecrFile = zip.file(`${id}-CDA_eICR.xml`);
-  const rrFile = zip.file(`${id}-CDA_RR.xml`);
+  let ecrFile = zip.file(`${id}-CDA_eICR.xml`);
+  let rrFile = zip.file(`${id}-CDA_RR.xml`);
+
+  if (!ecrFile || !rrFile) {
+    for (const [name, entry] of Object.entries(zip.files)) {
+      if (entry.dir || name.startsWith("__MACOSX/") || name.startsWith("._"))
+        continue;
+      if (!name.endsWith(".xml")) continue;
+      const baseName = name.split("/").pop()!;
+      if (!ecrFile && /eicr/i.test(baseName)) {
+        ecrFile = entry;
+      } else if (!rrFile && /_rr/i.test(baseName)) {
+        rrFile = entry;
+      }
+    }
+  }
 
   if (!ecrFile && !rrFile)
     throw new XmlNotFoundError("No XML files found in archive");


### PR DESCRIPTION
# PULL REQUEST

## Summary

  * The View XML button returned a 404 for ECRs ingested via zip upload because getEcrXmls looked for files named ${id}-CDA_eICR.xml / ${id}-CDA_RR.xml inside the zip, but zip uploads are saved to S3 keeping their original names (CDA_eICR.xml / CDA_RR.xml)
  * Added a fallback in getEcrXmls that iterates zip entries and matches by filename pattern (eicr / _rr, case-insensitive) when the exact-name lookup misses either file
  * The fallback pattern is consistent with how the orchestration service identifies eICR and RR files (substring match on CDA_eICR.xml / CDA_RR.xml)

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
