### PR TITLE
fix: authentication for subsequent browser API calls

### DIFF
--- a/containers/ecr-viewer/docker-compose.yaml
+++ b/containers/ecr-viewer/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       - CONFIG_NAME=${CONFIG_NAME:-AWS_SQLSERVER_NON_INTEGRATED}
       - JWT_PUB_KEY
       - JWT_API_PUB_KEY
+      - NBS_PUB_KEY
+      - NBS_API_PUB_KEY
       - SAVE_XML=false
       # METADATA DATABASE
       - DATABASE_URL=${DATABASE_URL:-postgres://postgres:pw@localhost:5432/ecr_viewer_db}

--- a/containers/ecr-viewer/src/middlewares/withJwtAuth.ts
+++ b/containers/ecr-viewer/src/middlewares/withJwtAuth.ts
@@ -154,13 +154,24 @@ const handleApi = async (
   end: ChainableMiddleware,
 ): Promise<NextResponse> => {
   const apiPubKey = resolveKey("JWT_API_PUB_KEY", "NBS_API_PUB_KEY");
-  if (!apiPubKey) return next(request);
+  const bearerToken = getTokenFromHeaders(request);
 
-  const token = getTokenFromHeaders(request);
-  if (!token) return next(request);
+  if (apiPubKey && bearerToken) {
+    try {
+      await jwtVerify(bearerToken, await importSPKI(apiPubKey.trim(), "RS256"));
+      return end(request);
+    } catch {
+      return next(request);
+    }
+  }
+
+  // If no Bearer token try the JWT cookie for subsequent API calls
+  // (e.g. View XML button), verified against the same API key.
+  const cookieToken = request.cookies.get(JWT_AUTH_COOKIE)?.value;
+  if (!cookieToken || !apiPubKey) return next(request);
 
   try {
-    await jwtVerify(token, await importSPKI(apiPubKey.trim(), "RS256"));
+    await jwtVerify(cookieToken, await importSPKI(apiPubKey.trim(), "RS256"));
     return end(request);
   } catch {
     return next(request);

--- a/containers/ecr-viewer/tests/unit/middlewares/withJwtAuth.test.ts
+++ b/containers/ecr-viewer/tests/unit/middlewares/withJwtAuth.test.ts
@@ -355,5 +355,41 @@ describe("JWT Auth Middleware", () => {
       const resp = await middleware(req);
       expect(resp.status).toBe(401);
     });
+
+    it("should authorize /api/ routes with a valid page JWT cookie when no Bearer token is present", async () => {
+      (jwtVerify as jest.Mock).mockResolvedValue({ payload: {} });
+      const req = new NextRequest(
+        "https://www.example.com/ecr-viewer/api/view-xml?id=1234",
+      );
+      req.cookies.set("jwt-auth-token", "mytoken");
+
+      const resp = await middleware(req);
+      expect(jwtVerify).toHaveBeenCalled();
+      expect(importSPKI).toHaveBeenCalledWith("mock-api-pub-key", "RS256");
+      expect(resp.status).toBe(200);
+    });
+
+    it("should pass through (401) with a page JWT cookie when JWT_API_PUB_KEY is not set", async () => {
+      delete process.env.JWT_API_PUB_KEY;
+      const req = new NextRequest(
+        "https://www.example.com/ecr-viewer/api/view-xml?id=1234",
+      );
+      req.cookies.set("jwt-auth-token", "mytoken");
+
+      const resp = await middleware(req);
+      expect(jwtVerify).not.toHaveBeenCalled();
+      expect(resp.status).toBe(401);
+    });
+
+    it("should pass through (401) when page JWT cookie fails verification", async () => {
+      (jwtVerify as jest.Mock).mockRejectedValue(new Error("invalid"));
+      const req = new NextRequest(
+        "https://www.example.com/ecr-viewer/api/view-xml?id=1234",
+      );
+      req.cookies.set("jwt-auth-token", "badtoken");
+
+      const resp = await middleware(req);
+      expect(resp.status).toBe(401);
+    });
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

* Fixed authentication for subsequent API calls in integrated mode.
* Added logic to check JWT_AUTH_COOKIE when bearer token is not present. 
## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
