### PR TITLE
fix: Core db fields should be nullable

### DIFF
--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -29,9 +29,9 @@ This table stores the primary eCR data.
 | `set_id`               | `varchar(255)` | NULL        |                   | Identifier for a set of related eICRs        |
 | `eicr_version_number`  | `varchar(50)`  | NULL        |                   | Version number of the eICR                   |
 | `fhir_reference_link`  | `varchar(255)` | NULL        |                   | Reference link to the FHIR resource          |
-| `last_name`            | `varchar(255)` | NOT NULL    |                   | Patient's last name                          |
-| `first_name`           | `varchar(255)` | NOT NULL    |                   | Patient's first name                         |
-| `birth_date`           | `date`         | NOT NULL    |                   | Patient's birth date                         |
+| `last_name`            | `varchar(255)` | NULL        |                   | Patient's last name                          |
+| `first_name`           | `varchar(255)` | NULL        |                   | Patient's first name                         |
+| `birth_date`           | `date`         | NULL        |                   | Patient's birth date                         |
 | `encounter_start_date` | `datetime`     | NULL        |                   | Start date and time of the patient encounter |
 | `date_created`         | `datetime`     | NOT NULL    | Current timestamp | Date and time when the record was created    |
 

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20260623181952_name_birthdate_nullable.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20260623181952_name_birthdate_nullable.ts
@@ -1,0 +1,68 @@
+import { Kysely, sql } from "kysely";
+
+import { AnyDb } from "@/app/data/metadataDb/database";
+import { dbDialect, dbNamespace, dbSchema } from "@/app/data/metadataDb/utils/db-config";
+
+
+// kyseley's build in `setNotNull`/`dropNotNull` doesn't work with sql server :(
+const sqlServerAlterColumnNull = (
+  db: Kysely<AnyDb>,
+  column: string,
+  column_data_type: string,
+  nullable: boolean,
+) => {
+  return sql`ALTER TABLE ${sql.id(dbNamespace(), "ecr_data")} ALTER COLUMN ${sql.id(column)} ${sql.raw(column_data_type)} ${sql.raw(nullable ? "" : "not")} null`.compile(
+    db
+  );
+};
+
+/**
+ * Make birth_date, first_name, and last_name nullable.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+
+  const _db = db.withSchema(dbNamespace());
+
+  if (dbDialect() === "sqlserver") {
+      await _db.executeQuery(
+        sqlServerAlterColumnNull(db, "birth_date", "date", true)
+      );
+      await _db.executeQuery(
+        sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", true)
+      );
+      await _db.executeQuery(
+        sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", true)
+      );
+  } else {
+    await _db.schema
+      .alterTable("ecr_data")
+      .alterColumn("birth_date", (cb) => cb.dropNotNull())
+      .alterColumn("first_name", (cb) => cb.dropNotNull())
+      .alterColumn("last_name", (cb) => cb.dropNotNull())
+      .execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const _db = db.withSchema(dbNamespace());
+
+  if (dbDialect() === "sqlserver") {
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "birth_date", "date", false)
+    );
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", false)
+    );
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", false)
+    );
+  } else {
+    await _db.schema
+      .alterTable("ecr_data")
+      .alterColumn("birth_date", (cb) => cb.setNotNull())
+      .alterColumn("first_name", (cb) => cb.setNotNull())
+      .alterColumn("last_name", (cb) => cb.setNotNull())
+      .execute();
+  }
+
+}

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20260623181952_name_birthdate_nullable.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/20260623181952_name_birthdate_nullable.ts
@@ -1,8 +1,11 @@
 import { Kysely, sql } from "kysely";
 
 import { AnyDb } from "@/app/data/metadataDb/database";
-import { dbDialect, dbNamespace, dbSchema } from "@/app/data/metadataDb/utils/db-config";
-
+import {
+  dbDialect,
+  dbNamespace,
+  dbSchema,
+} from "@/app/data/metadataDb/utils/db-config";
 
 // kyseley's build in `setNotNull`/`dropNotNull` doesn't work with sql server :(
 const sqlServerAlterColumnNull = (
@@ -12,7 +15,7 @@ const sqlServerAlterColumnNull = (
   nullable: boolean,
 ) => {
   return sql`ALTER TABLE ${sql.id(dbNamespace(), "ecr_data")} ALTER COLUMN ${sql.id(column)} ${sql.raw(column_data_type)} ${sql.raw(nullable ? "" : "not")} null`.compile(
-    db
+    db,
   );
 };
 
@@ -20,19 +23,18 @@ const sqlServerAlterColumnNull = (
  * Make birth_date, first_name, and last_name nullable.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
-
   const _db = db.withSchema(dbNamespace());
 
   if (dbDialect() === "sqlserver") {
-      await _db.executeQuery(
-        sqlServerAlterColumnNull(db, "birth_date", "date", true)
-      );
-      await _db.executeQuery(
-        sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", true)
-      );
-      await _db.executeQuery(
-        sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", true)
-      );
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "birth_date", "date", true),
+    );
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", true),
+    );
+    await _db.executeQuery(
+      sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", true),
+    );
   } else {
     await _db.schema
       .alterTable("ecr_data")
@@ -48,13 +50,13 @@ export async function down(db: Kysely<unknown>): Promise<void> {
 
   if (dbDialect() === "sqlserver") {
     await _db.executeQuery(
-      sqlServerAlterColumnNull(db, "birth_date", "date", false)
+      sqlServerAlterColumnNull(db, "birth_date", "date", false),
     );
     await _db.executeQuery(
-      sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", false)
+      sqlServerAlterColumnNull(db, "first_name", "nvarchar (255)", false),
     );
     await _db.executeQuery(
-      sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", false)
+      sqlServerAlterColumnNull(db, "last_name", "nvarchar (255)", false),
     );
   } else {
     await _db.schema
@@ -64,5 +66,4 @@ export async function down(db: Kysely<unknown>): Promise<void> {
       .alterColumn("last_name", (cb) => cb.setNotNull())
       .execute();
   }
-
 }

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/index.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/core/index.ts
@@ -6,4 +6,5 @@ export default {
   "20250522120000_condition_fk.ts": require("./20250522120000_condition_fk"),
   "20250708095700_audit_log.ts": require("./20250708095700_audit_log"),
   "20250818153300_name_unicode.ts": require("./20250818153300_name_unicode"),
+  "20260623181952_name_birthdate_nullable.ts": require("./20260623181952_name_birthdate_nullable"),
 };

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/types.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/types.ts
@@ -54,9 +54,9 @@ interface RR {
 }
 
 export interface BundleMetadata {
-  last_name: string;
-  first_name: string;
-  birth_date: string;
+  last_name: string | undefined;
+  first_name: string | undefined;
+  birth_date: string | undefined;
   set_id: string | undefined;
   eicr_version_number: string | undefined;
   rr: RR[] | undefined;

--- a/containers/ecr-viewer/src/app/data/metadataDb/types/core.ts
+++ b/containers/ecr-viewer/src/app/data/metadataDb/types/core.ts
@@ -12,9 +12,9 @@ export interface ecr_data {
   eicr_version_number: string | undefined;
   fhir_reference_link: string | undefined;
   date_created: Generated<Date>;
-  last_name: string;
-  first_name: string;
-  birth_date: ColumnType<Date, string>;
+  last_name: string | undefined;
+  first_name: string | undefined;
+  birth_date: ColumnType<Date, string> | undefined;
   encounter_start_date: Date | undefined;
 }
 

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -30,18 +30,27 @@ import { formatPeriodDate } from "./formatDateService";
 export const formatName = (
   humanName: HumanName | undefined,
   withUse: boolean = false,
+  isPatient: boolean = false
 ): string => {
   if (!humanName) {
     return "";
   }
 
   const { use, prefix, given, family, suffix } = humanName;
+  const isOfficial: boolean = (use === "official") || (!use);
+
+  const normalizedGiven =
+    isPatient && isOfficial && (!given || given.length === 0)
+      ? ["UNKNOWN"]
+      : given;
+  const normalizedFamily =
+    isPatient && isOfficial && !family ? "UNKNOWN" : family;
 
   const segments = [
     ...(withUse && use ? [`${toSentenceCase(use)}:`] : []),
     ...(prefix ?? []),
-    ...(given ?? []),
-    family,
+    ...(normalizedGiven ?? []),
+    normalizedFamily,
     ...(suffix ?? []),
   ];
 
@@ -56,14 +65,15 @@ export const formatName = (
  */
 export const formatNameList = (
   humanNames: HumanName[] | HumanName | undefined,
+  isPatient: boolean = false
 ): string => {
   if (!humanNames) return "";
   if (Array.isArray(humanNames)) {
     return humanNames
-      .map((name) => formatName(name, humanNames.length > 1))
+      .map((name) => formatName(name, humanNames.length > 1, isPatient))
       .join("\n");
   } else {
-    return formatName(humanNames);
+    return formatName(humanNames, false, isPatient);
   }
 };
 

--- a/containers/ecr-viewer/src/app/services/formatService.ts
+++ b/containers/ecr-viewer/src/app/services/formatService.ts
@@ -30,14 +30,14 @@ import { formatPeriodDate } from "./formatDateService";
 export const formatName = (
   humanName: HumanName | undefined,
   withUse: boolean = false,
-  isPatient: boolean = false
+  isPatient: boolean = false,
 ): string => {
   if (!humanName) {
     return "";
   }
 
   const { use, prefix, given, family, suffix } = humanName;
-  const isOfficial: boolean = (use === "official") || (!use);
+  const isOfficial: boolean = use === "official" || !use;
 
   const normalizedGiven =
     isPatient && isOfficial && (!given || given.length === 0)
@@ -65,7 +65,7 @@ export const formatName = (
  */
 export const formatNameList = (
   humanNames: HumanName[] | HumanName | undefined,
-  isPatient: boolean = false
+  isPatient: boolean = false,
 ): string => {
   if (!humanNames) return "";
   if (Array.isArray(humanNames)) {

--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -274,11 +274,11 @@ export const processMetadata = (responseBody: MetadataModel[]) => {
       eicr_set_id: object.set_id,
       eicr_version_number: object.eicr_version_number,
       related_ecrs: object.related_ecrs || [],
-      patient_first_name: object.first_name || "",
-      patient_last_name: object.last_name || "",
+      patient_first_name: object.first_name || "UNKNOWN",
+      patient_last_name: object.last_name || "UNKNOWN",
       patient_date_of_birth: object.birth_date
-        ? formatDate(object.birth_date.toISOString())
-        : "",
+        ? formatDate((object.birth_date as Date).toISOString())
+        : "UNKNOWN",
       patient_report_date: object.encounter_start_date
         ? formatDateTime(object.encounter_start_date.toISOString())
         : "",

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -86,12 +86,11 @@ const ECRViewerPage = async ({
         ecrId={xmlsExist ? fhirId : undefined}
       >
         <EcrSummary
-          patientDetails={
-            evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex)
-          }
-          encounterDetails={
-            evaluateEcrSummaryEncounterDetails(fhirBundle)
-          }
+          patientDetails={evaluateEcrSummaryPatientDetails(
+            fhirBundle,
+            fhirIndex,
+          )}
+          encounterDetails={evaluateEcrSummaryEncounterDetails(fhirBundle)}
           conditionSummary={evaluateEcrSummaryConditionSummary(
             fhirBundle,
             fhirIndex,

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -88,10 +88,9 @@ const ECRViewerPage = async ({
         <EcrSummary
           patientDetails={
             evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex)
-              .availableData
           }
           encounterDetails={
-            evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
+            evaluateEcrSummaryEncounterDetails(fhirBundle)
           }
           conditionSummary={evaluateEcrSummaryConditionSummary(
             fhirBundle,

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -70,9 +70,10 @@ export const evaluateEcrSummaryPatientDetails = (
       ? [
           {
             title: "Parent/Guardian",
-            value: formatPatientContactList(
-              evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-            ) || noData,
+            value:
+              formatPatientContactList(
+                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
+              ) || noData,
           },
         ]
       : [];
@@ -101,9 +102,10 @@ export const evaluateEcrSummaryPatientDetails = (
     },
     {
       title: "Patient Address",
-      value: formatCurrentAddress(
-        evaluateAll(patient, fhirPathMappings.patientAddressList),
-      ) || noData,
+      value:
+        formatCurrentAddress(
+          evaluateAll(patient, fhirPathMappings.patientAddressList),
+        ) || noData,
     },
     {
       title: "Patient Contact",
@@ -145,12 +147,13 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
     },
     {
       title: "Facility Contact",
-      value: formatContactPoint(
-        evaluateOneReference<Organization>(
-          encounter,
-          fhirPathMappings.facilityOrgRef
-        )?.telecom
-      ) || noData,
+      value:
+        formatContactPoint(
+          evaluateOneReference<Organization>(
+            encounter,
+            fhirPathMappings.facilityOrgRef,
+          )?.telecom,
+        ) || noData,
     },
   ];
 };

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -10,10 +10,7 @@ import {
   Organization,
 } from "fhir/r4";
 
-import {
-  formatDate,
-  formatStartEndDateTime,
-} from "@/app/services/formatDateService";
+import { formatStartEndDateTime } from "@/app/services/formatDateService";
 import {
   formatCodeableConcept,
   formatCoding,
@@ -21,7 +18,7 @@ import {
   formatCurrentAddress,
   formatPatientContactList,
 } from "@/app/services/formatService";
-import { evaluateData } from "@/app/utils/data-utils";
+import { noData } from "@/app/utils/data-utils";
 import {
   evaluateAll,
   evaluateOne,
@@ -75,47 +72,47 @@ export const evaluateEcrSummaryPatientDetails = (
             title: "Parent/Guardian",
             value: formatPatientContactList(
               evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-            ),
+            ) || noData,
           },
         ]
       : [];
 
-  return evaluateData([
+  return [
     {
       title: "Patient Name",
       value: evaluatePatientName(patient, false),
     },
     {
       title: "DOB",
-      value: evaluatePatientDOB(patient),
+      value: evaluatePatientDOB(patient) || noData,
     },
     {
       title: "Sex",
       // Unknown and Other sex options removed to be in compliance with Executive Order 14168
-      value: censorGender(patientSex),
+      value: censorGender(patientSex) || noData,
     },
     {
       title: "Race",
-      value: evaluatePatientRace(patient),
+      value: evaluatePatientRace(patient) || noData,
     },
     {
       title: "Ethnicity",
-      value: evaluatePatientEthnicity(patient),
+      value: evaluatePatientEthnicity(patient) || noData,
     },
     {
       title: "Patient Address",
       value: formatCurrentAddress(
         evaluateAll(patient, fhirPathMappings.patientAddressList),
-      ),
+      ) || noData,
     },
     {
       title: "Patient Contact",
       value: formatContactPoint(
-        evaluateAll(patient, fhirPathMappings.patientTelecom),
+        evaluateAll(patient, fhirPathMappings.patientTelecom) || noData,
       ),
     },
     ...parentGuardian,
-  ]);
+  ];
 };
 
 /**
@@ -129,33 +126,33 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
     fhirPathMappings.compositionEncounterRef,
   );
 
-  return evaluateData([
+  return [
     {
       title: "Encounter Date/Time",
-      value: formatStartEndDateTime(encounter?.period),
+      value: formatStartEndDateTime(encounter?.period) || noData,
     },
     {
       title: "Encounter Type",
-      value: formatCoding(encounter?.class),
+      value: formatCoding(encounter?.class) || noData,
     },
     {
       title: "Encounter Diagnosis",
-      value: evaluateEncounterDiagnosis(fhirBundle, encounter),
+      value: evaluateEncounterDiagnosis(fhirBundle, encounter) || noData,
     },
     {
       title: "Facility Name",
-      value: getLocationName(fhirBundle, encounter),
+      value: getLocationName(fhirBundle, encounter) || noData,
     },
     {
       title: "Facility Contact",
       value: formatContactPoint(
         evaluateOneReference<Organization>(
           encounter,
-          fhirPathMappings.facilityOrgRef,
-        )?.telecom,
-      ),
+          fhirPathMappings.facilityOrgRef
+        )?.telecom
+      ) || noData,
     },
-  ]);
+  ];
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/evaluateFhirDataService.tsx
@@ -120,10 +120,10 @@ export const evaluatePatientName = (
 
   if (isPatientBanner) {
     const officialName = nameList.find((n) => n.use === "official");
-    return formatName(officialName ?? nameList[0]);
+    return formatName(officialName ?? nameList[0], false, true);
   }
 
-  return formatNameList(nameList);
+  return formatNameList(nameList, true);
 };
 
 /**

--- a/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/services/formatService.test.tsx
@@ -57,6 +57,57 @@ describe("FormatService tests", () => {
       expect(result).toEqual(expectedName);
     });
 
+    it("should return UNKNOWN UNKNOWN if no patient name", () => {
+      const emptyPatientName = {
+        given: [],
+        family: "",
+        prefix: [],
+        suffix: [],
+      } as HumanName;
+      const expectedName = "UNKNOWN UNKNOWN";
+
+      const result = formatName(emptyPatientName, false, true);
+      expect(result).toEqual(expectedName);
+    });
+
+    it("should return UNKNOWN if no patient family or given name", () => {
+      const noGivenName = {
+        given: [],
+        family: "Everywoman",
+        prefix: [],
+        suffix: [],
+      } as HumanName;
+      const expectedNoGivenName = "UNKNOWN Everywoman";
+
+      const resultNoGiven = formatName(noGivenName, false, true);
+      expect(resultNoGiven).toEqual(expectedNoGivenName);
+
+      const noFamilyName = {
+        given: ["Eve"],
+        family: "",
+        prefix: [],
+        suffix: [],
+      } as HumanName;
+      const expectedNoFamilyName = "Eve UNKNOWN";
+
+      const resultNoFamily = formatName(noFamilyName, false, true);
+      expect(resultNoFamily).toEqual(expectedNoFamilyName);
+    });
+
+    it("should return name as is if given usual name", () => {
+      const noGivenName = {
+        use: "usual",
+        given: [],
+        family: "Rihanna",
+        prefix: [],
+        suffix: [],
+      } as HumanName;
+      const expectedNoGivenName = "Rihanna";
+
+      const resultNoGiven = formatName(noGivenName, false, true);
+      expect(resultNoGiven).toEqual(expectedNoGivenName);
+    });
+
     it("should not format", () => {
       const mixedHumanName = {
         given: ["I aM", "A Name"],

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -18,6 +18,7 @@ import {
   FhirIndex,
   getFhirIndex,
 } from "@/app/view-data/services/fhirResourcesIndexService";
+import { evaluateData } from "@/app/utils/data-utils";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
@@ -307,7 +308,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      expect(actual.unavailableData).toBeEmpty();
+      expect(evaluateData(actual).unavailableData).toBeEmpty();
     });
 
     it("should not show parent/guardian info if adult", () => {
@@ -316,7 +317,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      const guardian = actual.availableData.find(
+      const guardian = actual.find(
         (d) => d.title === "Parent/Guardian",
       );
 
@@ -341,7 +342,7 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexBundle = getFhirIndex(bundle);
       const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
 
-      const guardian = actual.availableData.find(
+      const guardian = actual.find(
         (d) => d.title === "Parent/Guardian",
       );
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -317,9 +317,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      const guardian = actual.find(
-        (d) => d.title === "Parent/Guardian",
-      );
+      const guardian = actual.find((d) => d.title === "Parent/Guardian");
 
       expect(guardian).toBeUndefined();
     });
@@ -342,9 +340,7 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexBundle = getFhirIndex(bundle);
       const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
 
-      const guardian = actual.find(
-        (d) => d.title === "Parent/Guardian",
-      );
+      const guardian = actual.find((d) => d.title === "Parent/Guardian");
 
       expect(guardian?.value).toEqual(
         `Grandparent\nLuthen Rael\n1357 Galactic Drive\nSometown, OR 94949\nUS\nHome: 123-456-6909`,


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Update core db & documentation so that `birth_date`, `first_name`, and `last_name` are now nullable. 
    - For these fields, missing data will have a database value of NULL (values that will display differentl (i.e. "UNKNOWN") are handled in the presentation layer)
- Update how missing name(s) and the birth date are displayed if unavailable (see below)
- Missing patient and encounter details in the eCR Summary now display _No data_ if information DNE (rather than disappearing)
- Update relevant tests

**Missing first name/last name/birthday UX behavior:**
- eCR Summary Patient Details
    - If official name (or there is no use) → will replace with UNKNOWN
    - If not official name (i.e. usual, temp, nickname) → Will not display name that DNE
    - Will display *No data* if DOB is missing
- Patient Info → Demographics
    - If official name (or there is no use) → will replace with UNKNOWN
    - If not official name (i.e. usual, temp, nickname) → Will not display name that DNE
    - Missing DOB will go to Unavailable Info section
- Patient Banner
    - Will replace either first and/or last name with UNKNOWN
    - Does not display birth date
- eCR Library
    - Will replace either first and/or last name with UNKNOWN
    - Will replace birth date with DOB: UNKNOWN

## Related Issue

Fixes #1566

## Acceptance Criteria

- eCRs without a birthdate, first name, and/or last name should be able to be processed through the pipeline
- Create any necessary migration files
- Add/update any relevant tests

## Additional Information

For example eCR: I simply modified an existing eCR to not have name(s) and a birth date

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
