### PR TITLE
fix: Display No Data when eCR Summary info is unavailable

### DIFF
--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -14,7 +14,9 @@ export type RenderableNode = string | React.JSX.Element;
 
 export const noData = <span className="text-italic text-base">No data</span>;
 // A11y: Rquires darker text against summary box to meet WCAG 2 AA minimum constrast ratio
-export const noDataSummary = <span className="text-italic text-ink">No data</span>;
+export const noDataSummary = (
+  <span className="text-italic text-ink">No data</span>
+);
 
 /**
  * Evaluates the provided display data to determine availability.

--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -13,7 +13,7 @@ export interface CompleteData {
 export type RenderableNode = string | React.JSX.Element;
 
 export const noData = <span className="text-italic text-base">No data</span>;
-// A11y: Rquires darker text against summary box to meet WCAG 2 AA minimum constrast ratio
+// A11y: Rquires darker text against summary box to meet WCAG 2 AA minimum contrast ratio
 export const noDataSummary = (
   <span className="text-italic text-ink">No data</span>
 );

--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -13,6 +13,8 @@ export interface CompleteData {
 export type RenderableNode = string | React.JSX.Element;
 
 export const noData = <span className="text-italic text-base">No data</span>;
+// A11y: Rquires darker text against summary box to meet WCAG 2 AA minimum constrast ratio
+export const noDataSummary = <span className="text-italic text-ink">No data</span>;
 
 /**
  * Evaluates the provided display data to determine availability.

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -88,7 +88,7 @@ const ECRViewerPage = async ({
         <EcrSummary
           patientDetails={evaluateEcrSummaryPatientDetails(
             fhirBundle,
-            fhirIndex
+            fhirIndex,
           )}
           encounterDetails={evaluateEcrSummaryEncounterDetails(fhirBundle)}
           conditionSummary={evaluateEcrSummaryConditionSummary(

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -86,13 +86,11 @@ const ECRViewerPage = async ({
         ecrId={xmlsExist ? fhirId : undefined}
       >
         <EcrSummary
-          patientDetails={
-            evaluateEcrSummaryPatientDetails(fhirBundle, fhirIndex)
-              .availableData
-          }
-          encounterDetails={
-            evaluateEcrSummaryEncounterDetails(fhirBundle).availableData
-          }
+          patientDetails={evaluateEcrSummaryPatientDetails(
+            fhirBundle,
+            fhirIndex
+          )}
+          encounterDetails={evaluateEcrSummaryEncounterDetails(fhirBundle)}
           conditionSummary={evaluateEcrSummaryConditionSummary(
             fhirBundle,
             fhirIndex,

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -21,7 +21,7 @@ import {
   formatCurrentAddress,
   formatPatientContactList,
 } from "@/app/services/formatService";
-import { evaluateData } from "@/app/utils/data-utils";
+import { evaluateData, noData } from "@/app/utils/data-utils";
 import {
   evaluateAll,
   evaluateOne,
@@ -75,47 +75,47 @@ export const evaluateEcrSummaryPatientDetails = (
             title: "Parent/Guardian",
             value: formatPatientContactList(
               evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-            ),
+            ) || noData,
           },
         ]
       : [];
 
-  return evaluateData([
+  return [
     {
       title: "Patient Name",
-      value: evaluatePatientName(patient, false),
+      value: evaluatePatientName(patient, false) || noData,
     },
     {
       title: "DOB",
-      value: evaluatePatientDOB(patient),
+      value: evaluatePatientDOB(patient) || noData,
     },
     {
       title: "Sex",
       // Unknown and Other sex options removed to be in compliance with Executive Order 14168
-      value: censorGender(patientSex),
+      value: censorGender(patientSex) || noData,
     },
     {
       title: "Race",
-      value: evaluatePatientRace(patient),
+      value: evaluatePatientRace(patient) || noData,
     },
     {
       title: "Ethnicity",
-      value: evaluatePatientEthnicity(patient),
+      value: evaluatePatientEthnicity(patient) || noData,
     },
     {
       title: "Patient Address",
       value: formatCurrentAddress(
         evaluateAll(patient, fhirPathMappings.patientAddressList),
-      ),
+      ) || noData,
     },
     {
       title: "Patient Contact",
       value: formatContactPoint(
         evaluateAll(patient, fhirPathMappings.patientTelecom),
-      ),
+      ) || noData,
     },
     ...parentGuardian,
-  ]);
+  ];
 };
 
 /**
@@ -129,33 +129,31 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
     fhirPathMappings.compositionEncounterRef,
   );
 
-  return evaluateData([
+  const orgRef = evaluateOne(encounter, fhirPathMappings.facilityOrgRef);
+  const org = evaluateReference<Organization>(fhirBundle, orgRef);
+
+  return [
     {
       title: "Encounter Date/Time",
-      value: formatStartEndDateTime(encounter?.period),
+      value: formatStartEndDateTime(encounter?.period) || noData,
     },
     {
       title: "Encounter Type",
-      value: formatCoding(encounter?.class),
+      value: formatCoding(encounter?.class) || noData,
     },
     {
       title: "Encounter Diagnosis",
-      value: evaluateEncounterDiagnosis(fhirBundle, encounter),
+      value: evaluateEncounterDiagnosis(fhirBundle, encounter) || noData,
     },
     {
       title: "Facility Name",
-      value: getLocationName(fhirBundle, encounter),
+      value: getLocationName(fhirBundle, encounter) || noData,
     },
     {
       title: "Facility Contact",
-      value: formatContactPoint(
-        evaluateOneReference<Organization>(
-          encounter,
-          fhirPathMappings.facilityOrgRef,
-        )?.telecom,
-      ),
+      value: formatContactPoint(org?.telecom) || noData,
     },
-  ]);
+  ];
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -73,9 +73,10 @@ export const evaluateEcrSummaryPatientDetails = (
       ? [
           {
             title: "Parent/Guardian",
-            value: formatPatientContactList(
-              evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-            ) || noData,
+            value:
+              formatPatientContactList(
+                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
+              ) || noData,
           },
         ]
       : [];
@@ -104,15 +105,17 @@ export const evaluateEcrSummaryPatientDetails = (
     },
     {
       title: "Patient Address",
-      value: formatCurrentAddress(
-        evaluateAll(patient, fhirPathMappings.patientAddressList),
-      ) || noData,
+      value:
+        formatCurrentAddress(
+          evaluateAll(patient, fhirPathMappings.patientAddressList),
+        ) || noData,
     },
     {
       title: "Patient Contact",
-      value: formatContactPoint(
-        evaluateAll(patient, fhirPathMappings.patientTelecom),
-      ) || noData,
+      value:
+        formatContactPoint(
+          evaluateAll(patient, fhirPathMappings.patientTelecom),
+        ) || noData,
     },
     ...parentGuardian,
   ];

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -21,7 +21,7 @@ import {
   formatCurrentAddress,
   formatPatientContactList,
 } from "@/app/services/formatService";
-import { evaluateData, noData } from "@/app/utils/data-utils";
+import { noDataSummary } from "@/app/utils/data-utils";
 import {
   evaluateAll,
   evaluateOne,
@@ -75,7 +75,7 @@ export const evaluateEcrSummaryPatientDetails = (
             title: "Parent/Guardian",
             value: formatPatientContactList(
               evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
-            ) || noData,
+            ) || noDataSummary,
           },
         ]
       : [];
@@ -83,36 +83,36 @@ export const evaluateEcrSummaryPatientDetails = (
   return [
     {
       title: "Patient Name",
-      value: evaluatePatientName(patient, false) || noData,
+      value: evaluatePatientName(patient, false) || noDataSummary,
     },
     {
       title: "DOB",
-      value: evaluatePatientDOB(patient) || noData,
+      value: evaluatePatientDOB(patient) || noDataSummary,
     },
     {
       title: "Sex",
       // Unknown and Other sex options removed to be in compliance with Executive Order 14168
-      value: censorGender(patientSex) || noData,
+      value: censorGender(patientSex) || noDataSummary,
     },
     {
       title: "Race",
-      value: evaluatePatientRace(patient) || noData,
+      value: evaluatePatientRace(patient) || noDataSummary,
     },
     {
       title: "Ethnicity",
-      value: evaluatePatientEthnicity(patient) || noData,
+      value: evaluatePatientEthnicity(patient) || noDataSummary,
     },
     {
       title: "Patient Address",
       value: formatCurrentAddress(
         evaluateAll(patient, fhirPathMappings.patientAddressList),
-      ) || noData,
+      ) || noDataSummary,
     },
     {
       title: "Patient Contact",
       value: formatContactPoint(
         evaluateAll(patient, fhirPathMappings.patientTelecom),
-      ) || noData,
+      ) || noDataSummary,
     },
     ...parentGuardian,
   ];
@@ -135,23 +135,23 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
   return [
     {
       title: "Encounter Date/Time",
-      value: formatStartEndDateTime(encounter?.period) || noData,
+      value: formatStartEndDateTime(encounter?.period) || noDataSummary,
     },
     {
       title: "Encounter Type",
-      value: formatCoding(encounter?.class) || noData,
+      value: formatCoding(encounter?.class) || noDataSummary,
     },
     {
       title: "Encounter Diagnosis",
-      value: evaluateEncounterDiagnosis(fhirBundle, encounter) || noData,
+      value: evaluateEncounterDiagnosis(fhirBundle, encounter) || noDataSummary,
     },
     {
       title: "Facility Name",
-      value: getLocationName(fhirBundle, encounter) || noData,
+      value: getLocationName(fhirBundle, encounter) || noDataSummary,
     },
     {
       title: "Facility Contact",
-      value: formatContactPoint(org?.telecom) || noData,
+      value: formatContactPoint(org?.telecom) || noDataSummary,
     },
   ];
 };

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -383,7 +383,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexPatientEmpty,
       );
       actual.forEach((a) => {
-        expect(a.value === noDataSummary);
+        expect(a.value).toEqual(noDataSummary);
       });
     });
   });
@@ -422,7 +422,7 @@ describe("ecrSummaryService Tests", () => {
       } as unknown as Bundle;
       const actual = evaluateEcrSummaryEncounterDetails(BundleEncounterEmpty);
       actual.forEach((a) => {
-        expect(a.value === noDataSummary);
+        expect(a.value).toEqual(noDataSummary);
       });
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -20,7 +20,7 @@ import {
   FhirIndex,
   getFhirIndex,
 } from "@/app/view-data/services/fhirResourcesIndexService";
-import { evaluateData, noData } from "@/app/utils/data-utils";
+import { evaluateData, noDataSummary } from "@/app/utils/data-utils";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
@@ -387,7 +387,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexPatientEmpty
       );
       actual.forEach((a) => {
-        expect(a.value === noData);
+        expect(a.value === noDataSummary);
       });
     });
   });
@@ -430,7 +430,7 @@ describe("ecrSummaryService Tests", () => {
         BundleEncounterEmpty
       );
       actual.forEach((a) => {
-        expect(a.value === noData);
+        expect(a.value === noDataSummary);
       });
     });
   })

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -321,9 +321,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      const guardian = actual.find(
-        (d) => d.title === "Parent/Guardian",
-      );
+      const guardian = actual.find((d) => d.title === "Parent/Guardian");
 
       expect(guardian).toBeUndefined();
     });
@@ -346,9 +344,7 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexBundle = getFhirIndex(bundle);
       const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
 
-      const guardian = actual.find(
-        (d) => d.title === "Parent/Guardian",
-      );
+      const guardian = actual.find((d) => d.title === "Parent/Guardian");
 
       expect(guardian?.value).toEqual(
         `Grandparent\nLuthen Rael\n1357 Galactic Drive\nSometown, OR 94949\nUS\nHome: 123-456-6909`,
@@ -357,34 +353,34 @@ describe("ecrSummaryService Tests", () => {
 
     it("should display noData if no patient details are available", () => {
       const BundlePatientEmpty = {
-        "resourceType": "Bundle",
-        "type": "document",
-        "entry": [
+        resourceType: "Bundle",
+        type: "document",
+        entry: [
           {
-            "fullUrl": "urn:uuid:99999999-4p89-4b96-b6ab-c46406839cea",
-            "resource": {
-              "resourceType": "Patient",
-              "id": "99999999-4p89-4b96-b6ab-c46406839cea",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            fullUrl: "urn:uuid:99999999-4p89-4b96-b6ab-c46406839cea",
+            resource: {
+              resourceType: "Patient",
+              id: "99999999-4p89-4b96-b6ab-c46406839cea",
+              meta: {
+                profile: [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
                 ],
-                "source": ["ecr"]
+                source: ["ecr"],
               },
-              "identifier": [
+              identifier: [
                 {
-                  "system": "urn:oid:0.0.000.000000.0.00.000.0.0.0.000000.000",
-                  "value": "1234567890"
-                }
+                  system: "urn:oid:0.0.000.000000.0.00.000.0.0.0.000000.000",
+                  value: "1234567890",
+                },
               ],
-            }
-          }
-        ]
+            },
+          },
+        ],
       } as unknown as Bundle;
       const fhirIndexPatientEmpty = getFhirIndex(BundlePatientEmpty);
       const actual = evaluateEcrSummaryPatientDetails(
         BundlePatientEmpty,
-        fhirIndexPatientEmpty
+        fhirIndexPatientEmpty,
       );
       actual.forEach((a) => {
         expect(a.value === noData);
@@ -394,9 +390,7 @@ describe("ecrSummaryService Tests", () => {
 
   describe("Evaluate eCR Summary Encounter Details", () => {
     it("should get all relevant encounter details", () => {
-      const actual = evaluateEcrSummaryEncounterDetails(
-        BundleEcrMetadata
-      );
+      const actual = evaluateEcrSummaryEncounterDetails(BundleEcrMetadata);
       expect(evaluateData(actual).unavailableData).toBeEmpty();
     });
 
@@ -426,12 +420,10 @@ describe("ecrSummaryService Tests", () => {
           },
         ],
       } as unknown as Bundle;
-      const actual = evaluateEcrSummaryEncounterDetails(
-        BundleEncounterEmpty
-      );
+      const actual = evaluateEcrSummaryEncounterDetails(BundleEncounterEmpty);
       actual.forEach((a) => {
         expect(a.value === noData);
       });
     });
-  })
+  });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -5,11 +5,13 @@ import { Bundle } from "fhir/r4";
 
 import _BundleWithClinicalInfo from "../../../../../../../test-data/fhir/BundleClinicalInfo.json";
 import _BundleEcrSummary from "../../../../../../../test-data/fhir/BundleEcrSummary.json";
+import _BundleEcrMetadata from "../../../../../../../test-data/fhir/BundleEcrMetadata.json";
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundlePatient from "../../../../../../../test-data/fhir/BundlePatient.json";
 import _BundleRRConditionValueString from "../../../../../../../test-data/fhir/BundleRRConditionValueString.json";
 import {
   evaluateEcrSummaryConditionSummary,
+  evaluateEcrSummaryEncounterDetails,
   evaluateEcrSummaryPatientDetails,
   evaluateEcrSummaryRelevantClinicalDetails,
   evaluateEcrSummaryRelevantLabResults,
@@ -18,12 +20,15 @@ import {
   FhirIndex,
   getFhirIndex,
 } from "@/app/view-data/services/fhirResourcesIndexService";
+import { evaluateData, noData } from "@/app/utils/data-utils";
 
 const BundleLab = _BundleLab as unknown as Bundle;
 const fhirIndexBundleLab = getFhirIndex(BundleLab);
 
 const BundleEcrSummary = _BundleEcrSummary as unknown as Bundle;
 const fhirIndexBundleEcrSummary = getFhirIndex(BundleEcrSummary);
+
+const BundleEcrMetadata = _BundleEcrMetadata as unknown as Bundle;
 
 const BundleRRConditionValueString =
   _BundleRRConditionValueString as unknown as Bundle;
@@ -307,7 +312,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      expect(actual.unavailableData).toBeEmpty();
+      expect(evaluateData(actual).unavailableData).toBeEmpty();
     });
 
     it("should not show parent/guardian info if adult", () => {
@@ -316,7 +321,7 @@ describe("ecrSummaryService Tests", () => {
         fhirIndexBundlePatient,
       );
 
-      const guardian = actual.availableData.find(
+      const guardian = actual.find(
         (d) => d.title === "Parent/Guardian",
       );
 
@@ -341,7 +346,7 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexBundle = getFhirIndex(bundle);
       const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
 
-      const guardian = actual.availableData.find(
+      const guardian = actual.find(
         (d) => d.title === "Parent/Guardian",
       );
 
@@ -349,5 +354,84 @@ describe("ecrSummaryService Tests", () => {
         `Grandparent\nLuthen Rael\n1357 Galactic Drive\nSometown, OR 94949\nUS\nHome: 123-456-6909`,
       );
     });
+
+    it("should display noData if no patient details are available", () => {
+      const BundlePatientEmpty = {
+        "resourceType": "Bundle",
+        "type": "document",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:99999999-4p89-4b96-b6ab-c46406839cea",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "99999999-4p89-4b96-b6ab-c46406839cea",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                ],
+                "source": ["ecr"]
+              },
+              "identifier": [
+                {
+                  "system": "urn:oid:0.0.000.000000.0.00.000.0.0.0.000000.000",
+                  "value": "1234567890"
+                }
+              ],
+            }
+          }
+        ]
+      } as unknown as Bundle;
+      const fhirIndexPatientEmpty = getFhirIndex(BundlePatientEmpty);
+      const actual = evaluateEcrSummaryPatientDetails(
+        BundlePatientEmpty,
+        fhirIndexPatientEmpty
+      );
+      actual.forEach((a) => {
+        expect(a.value === noData);
+      });
+    });
   });
+
+  describe("Evaluate eCR Summary Encounter Details", () => {
+    it("should get all relevant encounter details", () => {
+      const actual = evaluateEcrSummaryEncounterDetails(
+        BundleEcrMetadata
+      );
+      expect(evaluateData(actual).unavailableData).toBeEmpty();
+    });
+
+    it("should display noData if no patient details are available", () => {
+      const BundleEncounterEmpty = {
+        resourceType: "Bundle",
+        type: "document",
+        entry: [
+          {
+            fullUrl: "urn:uuid:99999999-4p89-4b96-b6ab-c46406839cea",
+            resource: {
+              resourceType: "Encounter",
+              id: "99999999-4p89-4b96-b6ab-c46406839cea",
+              meta: {
+                profile: [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                ],
+                source: ["ecr"],
+              },
+              identifier: [
+                {
+                  system: "urn:oid:0.0.000.000000.0.00.000.0.0.0.000000.000",
+                  value: "1234567890",
+                },
+              ],
+            },
+          },
+        ],
+      } as unknown as Bundle;
+      const actual = evaluateEcrSummaryEncounterDetails(
+        BundleEncounterEmpty
+      );
+      actual.forEach((a) => {
+        expect(a.value === noData);
+      });
+    });
+  })
 });

--- a/test-data/fhir/BundleEcrMetadata.json
+++ b/test-data/fhir/BundleEcrMetadata.json
@@ -754,6 +754,11 @@
             ]
           }
         ],
+        "class": {
+          "code": "IMP",
+          "system": "urn:oid:2.16.840.1.113883.5.4",
+          "display": "inpatient encounter"
+        },
         "participant": [
           {
             "type": [
@@ -772,6 +777,9 @@
             }
           }
         ],
+        "serviceProvider": {
+          "reference": "Organization/e69fcefd-731c-5e6a-b917-301e9c22a1c7"
+        },
         "diagnosis": [
           {
             "condition": {
@@ -814,6 +822,38 @@
               "display": "OTHER MUSCLE SPASM"
             }
           ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e69fcefd-731c-5e6a-b917-301e9c22a1c7",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "e69fcefd-731c-5e6a-b917-301e9c22a1c7",
+        "name": "Good Health Hospital",
+        "address": [
+          {
+            "line": ["1000 Hospital Lane"],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "1+(555)-555-1212",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "1+(555)-555-3333",
+            "use": "work"
+          }
+        ],
+        "meta": {
+          "source": "ecr"
         }
       }
     }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Added important fix:
- Fix `Facility Contact` FHIR evaluation in eCR Summary. Previous evaluation was incorrect -> resulting in no data (even when it exists). -- Ex. Mon Mothma

Main fixes:
- Displays "No Data" when the eCR Summary patient and/or encounter information is unavailable 
- Update eCR Summary patient details tests
- Add eCR Summary encounter details tests

## Screenshots

Note: _No data_ text was made darker for the summary box because it triggered the following accessibility error that requires darker text against summary box to meet WCAG 2 AA minimum contrast ratio. 
@echinelo-skylight Let me know what you think.

<img width="1319" height="638" alt="Screenshot 2026-06-25 at 12 26 53" src="https://github.com/user-attachments/assets/225a239f-64b1-440b-b5b0-cabb3b366a40" />
<img width="1317" height="293" alt="Screenshot 2026-06-25 at 12 27 08" src="https://github.com/user-attachments/assets/e336997a-c4e9-417b-bdf3-320bebb1222a" />

## Related Issue

Fixes #1571 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)