### PR TITLE
fix: Display Hospital admission diagnosis & Hospital discharge diagnosis

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -442,7 +442,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
 
   hospitalEncounterDiagnosisRef: {
     type: "Reference",
-    path: "entry.resource.Composition.section.where(code.coding.code = %code).entry",
+    path: "entry.resource.Composition.section.where(code.coding.exists(code = %code)).entry",
   },
 
   facilityOrgRef: {

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.2 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/1578-admission-discharge-diagnoses --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/1578-admission-discharge-diagnoses --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.3 --depth 1 /App
 
 WORKDIR /App
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

TN UAT bug

Update FHIR path to ensure the `Hospital Admisison Diagnosis` and `Hospital Discharge Diagnosis` fields are correctly displaying

## Related Issue

Fixes #1578 

Relevant FHIR converter PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/145

## Screenshots
Before:
<img width="800" alt="Screenshot 2026-06-26 at 13 05 51" src="https://github.com/user-attachments/assets/7c1cf8ce-2050-4b2e-ba0b-6aa7aa6f4928" />
After:
<img width="800" alt="Screenshot 2026-06-26 at 13 07 24" src="https://github.com/user-attachments/assets/077b528f-cadf-454d-bbe4-ecc1bd57fb08" />


## Acceptance Criteria

- [ ] If data is available, Hospital Admission and Discharge Diagnosis sections and their reference resources should be converted to FHIR
- [ ] Add any relevant FHIR converter unit tests
- [ ] Make any adjustments necessary on the Viewer-side
- [ ] Add snapshot tests

## Additional Information

Example eCRs:
- Hospital Admission Diagnosis: Dash Rendar, Al Testwright
- Hospital Discharge Diagnosis: Dash Rendar

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
