### PR TITLE
chore: Clean components/services layer pt. 5 - Encounter & eCR Summary

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -7,7 +7,7 @@ import { toKebabCase } from "@/app/utils/format-utils";
 import ClinicalInfo from "@/app/view-data/components/ClinicalInfo";
 import Demographics from "@/app/view-data/components/Demographics";
 import EcrMetadata from "@/app/view-data/components/EcrMetadata";
-import EncounterDetails from "@/app/view-data/components/Encounter";
+import EncounterInfo from "@/app/view-data/components/EncounterInfo";
 import LabInfo from "@/app/view-data/components/LabInfo";
 import PregnancyInfo from "@/app/view-data/components/PregnancyInfo";
 import SocialHistory from "@/app/view-data/components/SocialHistory";
@@ -18,7 +18,7 @@ import {
   evaluateProviderData,
   evaluateFacilityData,
   evaluateHospitalEncounterData,
-} from "@/app/view-data/services/evaluateFhirDataService";
+} from "@/app/view-data/services/encounterInfoService";
 import { evaluateSocialData } from "@/app/view-data/services/socialHistoryService";
 import { evaluateDemographicsData } from "@/app/view-data/services/demographicsService";
 import { evaluatePregnancyData } from "@/app/view-data/services/pregnancyInfoService";
@@ -168,7 +168,7 @@ export const getEcrDocumentAccordionItems = (
           hospitalEncounterData.availableData.length > 0 ||
           facilityData.availableData.length > 0 ||
           providerData.availableData.length > 0 ? (
-            <EncounterDetails
+            <EncounterInfo
               encounterData={encounterData.availableData}
               hospitalEncounterData={hospitalEncounterData.availableData}
               facilityData={facilityData.availableData}

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -8,8 +8,8 @@ import { toKebabCase } from "@/app/utils/format-utils";
 import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
 
 interface EcrSummaryProps {
-  patientDetails: DisplayDataProps[];
-  encounterDetails: DisplayDataProps[];
+  patientSummary: DisplayDataProps[];
+  encounterSummary: DisplayDataProps[];
   conditionSummary: ConditionSummary[];
   snomed?: string;
 }
@@ -19,22 +19,22 @@ export interface ConditionSummary {
   snomed: string;
   conditionDetails: DisplayDataProps[];
   clinicalDetails: DisplayDataProps[];
-  labDetails: DisplayDataProps[];
   immunizationDetails: DisplayDataProps[];
+  labDetails: DisplayDataProps[];
 }
 
 /**
  * Generates a JSX element to display eCR viewer summary
  * @param props - Properties for the eCR Viewer Summary section
- * @param props.patientDetails - Array of title and values to be displayed in patient details section
- * @param props.encounterDetails - Array of title and values to be displayed in encounter details section
+ * @param props.patientSummary - Array of title and values to be displayed in patient summary section
+ * @param props.encounterSummary - Array of title and values to be displayed in encounter summary section
  * @param props.conditionSummary - Array of condition details
  * @param props.snomed - SNOMED code being requested
  * @returns a react element for eCR Summary
  */
 const EcrSummary: React.FC<EcrSummaryProps> = ({
-  patientDetails,
-  encounterDetails,
+  patientSummary,
+  encounterSummary,
   conditionSummary,
   snomed,
 }) => {
@@ -98,7 +98,7 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
           </>
         ),
       };
-    },
+    }
   );
   return (
     <div
@@ -113,7 +113,7 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
           Patient Summary
         </h3>
         <div className="usa-summary-box__text">
-          {patientDetails.map((item, i) => (
+          {patientSummary.map((item, i) => (
             <DataDisplay item={item} key={`pat-${i}`} themeColor="blue" />
           ))}
         </div>
@@ -126,7 +126,7 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
           Encounter Summary
         </h3>
         <div className="usa-summary-box__text">
-          {encounterDetails.map((item, i) => (
+          {encounterSummary.map((item, i) => (
             <DataDisplay item={item} key={`enc-${i}`} themeColor="blue" />
           ))}
         </div>

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -98,7 +98,7 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
           </>
         ),
       };
-    }
+    },
   );
   return (
     <div

--- a/containers/ecr-viewer/src/app/view-data/components/EncounterInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EncounterInfo.tsx
@@ -7,7 +7,7 @@ import {
 
 import { DataDisplay, DataTableDisplay, DisplayDataProps } from "./DataDisplay";
 
-interface EncounterProps {
+interface EncounterInfoProps {
   encounterData: DisplayDataProps[];
   hospitalEncounterData: DisplayDataProps[];
   facilityData: DisplayDataProps[];
@@ -15,20 +15,20 @@ interface EncounterProps {
 }
 
 /**
- * Functional component for displaying encounter details.
- * @param props - Props containing encounter details.
+ * Functional component for displaying Encounter Info section.
+ * @param props - Props containing all encounter details.
  * @param props.encounterData - Encounter details to be displayed.
  * @param props.hospitalEncounterData - Hospital Encounter Diagnosis details to be displayed.
  * @param props.providerData - Provider details to be displayed.
  * @param props.facilityData - Facility details to be displayed.
  * @returns The JSX element representing the encounter details.
  */
-const EncounterDetails = ({
+const EncounterInfo = ({
   encounterData,
   hospitalEncounterData,
   facilityData,
   providerData,
-}: EncounterProps) => {
+}: EncounterInfoProps) => {
   return (
     <AccordionSection>
       <EncounterSection title="Encounter Details" data={encounterData} />
@@ -73,4 +73,4 @@ const EncounterSection = ({
     )
   );
 };
-export default EncounterDetails;
+export default EncounterInfo;

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -21,10 +21,10 @@ import { getFhirData, isSuccessResponse } from "./services/fhirDataService";
 import { ecrXmlsExist } from "./services/xmlService";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 import {
-  evaluateEcrSummaryConditionSummary,
-  evaluateEcrSummaryEncounterDetails,
-  evaluateEcrSummaryPatientDetails,
-} from "./services/ecrSummaryService";
+  evaluateEcrSummaryPatient,
+  evaluateEcrSummaryEncounter,
+  evaluateEcrSummaryCondition,
+} from "@/app/view-data/services/ecrSummaryService";
 
 /**
  * Functional component for rendering the eCR Viewer page.
@@ -86,15 +86,12 @@ const ECRViewerPage = async ({
         ecrId={xmlsExist ? fhirId : undefined}
       >
         <EcrSummary
-          patientDetails={evaluateEcrSummaryPatientDetails(
+          patientSummary={evaluateEcrSummaryPatient(fhirBundle, fhirIndex)}
+          encounterSummary={evaluateEcrSummaryEncounter(fhirBundle)}
+          conditionSummary={evaluateEcrSummaryCondition(
             fhirBundle,
             fhirIndex,
-          )}
-          encounterDetails={evaluateEcrSummaryEncounterDetails(fhirBundle)}
-          conditionSummary={evaluateEcrSummaryConditionSummary(
-            fhirBundle,
-            fhirIndex,
-            snomedCode,
+            snomedCode
           )}
           snomed={snomedCode}
         />

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -91,7 +91,7 @@ const ECRViewerPage = async ({
           conditionSummary={evaluateEcrSummaryCondition(
             fhirBundle,
             fhirIndex,
-            snomedCode
+            snomedCode,
           )}
           snomed={snomedCode}
         />

--- a/containers/ecr-viewer/src/app/view-data/services/ecrMetadataService.ts
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrMetadataService.ts
@@ -25,8 +25,11 @@ import {
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { DisplayDataProps } from "@/app/view-data/components/DataDisplay";
 
-import { evaluatePractitionerRoleReference } from "./evaluateFhirDataService";
-import { evaluateRRInfo, ReportableConditions } from "./reportabilityService";
+import { evaluatePractitionerRoleReference } from "@/app/view-data/services/encounterInfoService";
+import {
+  evaluateRRInfo,
+  ReportableConditions,
+} from "@/app/view-data/services/reportabilityService";
 
 interface EcrMetadata {
   eicrDetails: CompleteData;

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -10,10 +10,7 @@ import {
   Organization,
 } from "fhir/r4";
 
-import {
-  formatDate,
-  formatStartEndDateTime,
-} from "@/app/services/formatDateService";
+import { formatStartEndDateTime } from "@/app/services/formatDateService";
 import {
   formatCodeableConcept,
   formatCoding,
@@ -41,7 +38,7 @@ import {
 import {
   evaluateEncounterDiagnosis,
   getLocationName,
-} from "./evaluateFhirDataService";
+} from "@/app/view-data/services/encounterInfoService";
 import {
   evaluatePatientName,
   evaluatePatientRace,
@@ -58,16 +55,16 @@ import { FhirIndex, getResourcesByType } from "./fhirResourcesIndexService";
 /**
  * Evaluates and retrieves patient details from the FHIR bundle using the provided path mappings.
  * @param fhirBundle - The FHIR bundle containing patient data.
- * @returns An array of patient details objects containing title and value pairs.
+ * @returns An array of patient summary objects containing title and value pairs.
  */
-export const evaluateEcrSummaryPatientDetails = (
+export const evaluateEcrSummaryPatient = (
   fhirBundle: Bundle,
-  fhirIndex: FhirIndex,
+  fhirIndex: FhirIndex
 ) => {
   const patient = getPatient(fhirIndex);
 
   const patientSex = toTitleCase(
-    evaluateOne(patient, fhirPathMappings.patientGender),
+    evaluateOne(patient, fhirPathMappings.patientGender)
   );
   const age = calculatePatientAge(patient);
   const parentGuardian =
@@ -77,7 +74,7 @@ export const evaluateEcrSummaryPatientDetails = (
             title: "Parent/Guardian",
             value:
               formatPatientContactList(
-                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
+                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian)
               ) || noDataSummary,
           },
         ]
@@ -109,14 +106,14 @@ export const evaluateEcrSummaryPatientDetails = (
       title: "Patient Address",
       value:
         formatCurrentAddress(
-          evaluateAll(patient, fhirPathMappings.patientAddressList),
+          evaluateAll(patient, fhirPathMappings.patientAddressList)
         ) || noDataSummary,
     },
     {
       title: "Patient Contact",
       value:
         formatContactPoint(
-          evaluateAll(patient, fhirPathMappings.patientTelecom),
+          evaluateAll(patient, fhirPathMappings.patientTelecom)
         ) || noDataSummary,
     },
     ...parentGuardian,
@@ -126,12 +123,12 @@ export const evaluateEcrSummaryPatientDetails = (
 /**
  * Evaluates and retrieves encounter details from the FHIR bundle using the provided path mappings.
  * @param fhirBundle - The FHIR bundle containing patient data.
- * @returns An array of encounter details objects containing title and value pairs.
+ * @returns An array of encounter summary objects containing title and value pairs.
  */
-export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
+export const evaluateEcrSummaryEncounter = (fhirBundle: Bundle) => {
   const encounter = evaluateOneReference<Encounter>(
     fhirBundle,
-    fhirPathMappings.compositionEncounterRef,
+    fhirPathMappings.compositionEncounterRef
   );
 
   const orgRef = evaluateOne(encounter, fhirPathMappings.facilityOrgRef);
@@ -168,10 +165,10 @@ export const evaluateEcrSummaryEncounterDetails = (fhirBundle: Bundle) => {
  * @param snomedCode - (Optional) The SNOMED code identifying the main snomed code.
  * @returns An array of condition summary objects.
  */
-export const evaluateEcrSummaryConditionSummary = (
+export const evaluateEcrSummaryCondition = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
-  snomedCode?: string,
+  snomedCode?: string
 ): ConditionSummary[] => {
   const rrConditions = evaluateAll(fhirBundle, fhirPathMappings.rrConditions);
   const conditionsList: {
@@ -179,7 +176,7 @@ export const evaluateEcrSummaryConditionSummary = (
   } = {};
   for (const observation of rrConditions) {
     const coding = observation?.valueCodeableConcept?.coding?.find(
-      (coding) => coding.system === "http://snomed.info/sct",
+      (coding) => coding.system === "http://snomed.info/sct"
     );
 
     const displayText =
@@ -198,12 +195,12 @@ export const evaluateEcrSummaryConditionSummary = (
     observation?.hasMember?.forEach((ref) => {
       const rrInfoObs: Observation | undefined = evaluateReference(
         fhirBundle,
-        ref.reference,
+        ref.reference
       );
       const { rules } = getReportabilityRulesReasons(rrInfoObs);
 
       rules.forEach((rule: string) =>
-        conditionsList[conditionListKey].ruleSummaries.add(rule),
+        conditionsList[conditionListKey].ruleSummaries.add(rule)
       );
     });
   }
@@ -223,7 +220,7 @@ export const evaluateEcrSummaryConditionSummary = (
               {[...conditionsList[conditionsListKey].ruleSummaries].map(
                 (summary) => (
                   <p key={summary}>{summary}</p>
-                ),
+                )
               )}
             </div>
           ),
@@ -231,18 +228,18 @@ export const evaluateEcrSummaryConditionSummary = (
       ],
       immunizationDetails: evaluateEcrSummaryRelevantImmunizations(
         fhirBundle,
-        conditionsListKey,
+        conditionsListKey
       ),
       clinicalDetails: evaluateEcrSummaryRelevantClinicalDetails(
         fhirBundle,
         fhirIndex,
-        conditionsListKey,
+        conditionsListKey
       ),
       labDetails: evaluateEcrSummaryRelevantLabResults(
         fhirBundle,
         fhirIndex,
         conditionsListKey,
-        false,
+        false
       ),
     };
 

--- a/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/ecrSummaryService.tsx
@@ -59,12 +59,12 @@ import { FhirIndex, getResourcesByType } from "./fhirResourcesIndexService";
  */
 export const evaluateEcrSummaryPatient = (
   fhirBundle: Bundle,
-  fhirIndex: FhirIndex
+  fhirIndex: FhirIndex,
 ) => {
   const patient = getPatient(fhirIndex);
 
   const patientSex = toTitleCase(
-    evaluateOne(patient, fhirPathMappings.patientGender)
+    evaluateOne(patient, fhirPathMappings.patientGender),
   );
   const age = calculatePatientAge(patient);
   const parentGuardian =
@@ -74,7 +74,7 @@ export const evaluateEcrSummaryPatient = (
             title: "Parent/Guardian",
             value:
               formatPatientContactList(
-                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian)
+                evaluateAll(fhirBundle, fhirPathMappings.patientGuardian),
               ) || noDataSummary,
           },
         ]
@@ -106,14 +106,14 @@ export const evaluateEcrSummaryPatient = (
       title: "Patient Address",
       value:
         formatCurrentAddress(
-          evaluateAll(patient, fhirPathMappings.patientAddressList)
+          evaluateAll(patient, fhirPathMappings.patientAddressList),
         ) || noDataSummary,
     },
     {
       title: "Patient Contact",
       value:
         formatContactPoint(
-          evaluateAll(patient, fhirPathMappings.patientTelecom)
+          evaluateAll(patient, fhirPathMappings.patientTelecom),
         ) || noDataSummary,
     },
     ...parentGuardian,
@@ -128,7 +128,7 @@ export const evaluateEcrSummaryPatient = (
 export const evaluateEcrSummaryEncounter = (fhirBundle: Bundle) => {
   const encounter = evaluateOneReference<Encounter>(
     fhirBundle,
-    fhirPathMappings.compositionEncounterRef
+    fhirPathMappings.compositionEncounterRef,
   );
 
   const orgRef = evaluateOne(encounter, fhirPathMappings.facilityOrgRef);
@@ -168,7 +168,7 @@ export const evaluateEcrSummaryEncounter = (fhirBundle: Bundle) => {
 export const evaluateEcrSummaryCondition = (
   fhirBundle: Bundle,
   fhirIndex: FhirIndex,
-  snomedCode?: string
+  snomedCode?: string,
 ): ConditionSummary[] => {
   const rrConditions = evaluateAll(fhirBundle, fhirPathMappings.rrConditions);
   const conditionsList: {
@@ -176,7 +176,7 @@ export const evaluateEcrSummaryCondition = (
   } = {};
   for (const observation of rrConditions) {
     const coding = observation?.valueCodeableConcept?.coding?.find(
-      (coding) => coding.system === "http://snomed.info/sct"
+      (coding) => coding.system === "http://snomed.info/sct",
     );
 
     const displayText =
@@ -195,12 +195,12 @@ export const evaluateEcrSummaryCondition = (
     observation?.hasMember?.forEach((ref) => {
       const rrInfoObs: Observation | undefined = evaluateReference(
         fhirBundle,
-        ref.reference
+        ref.reference,
       );
       const { rules } = getReportabilityRulesReasons(rrInfoObs);
 
       rules.forEach((rule: string) =>
-        conditionsList[conditionListKey].ruleSummaries.add(rule)
+        conditionsList[conditionListKey].ruleSummaries.add(rule),
       );
     });
   }
@@ -220,7 +220,7 @@ export const evaluateEcrSummaryCondition = (
               {[...conditionsList[conditionsListKey].ruleSummaries].map(
                 (summary) => (
                   <p key={summary}>{summary}</p>
-                )
+                ),
               )}
             </div>
           ),
@@ -228,18 +228,18 @@ export const evaluateEcrSummaryCondition = (
       ],
       immunizationDetails: evaluateEcrSummaryRelevantImmunizations(
         fhirBundle,
-        conditionsListKey
+        conditionsListKey,
       ),
       clinicalDetails: evaluateEcrSummaryRelevantClinicalDetails(
         fhirBundle,
         fhirIndex,
-        conditionsListKey
+        conditionsListKey,
       ),
       labDetails: evaluateEcrSummaryRelevantLabResults(
         fhirBundle,
         fhirIndex,
         conditionsListKey,
-        false
+        false,
       ),
     };
 

--- a/containers/ecr-viewer/src/app/view-data/services/encounterInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/encounterInfoService.tsx
@@ -12,7 +12,6 @@ import {
   PractitionerRole,
 } from "fhir/r4";
 
-import { ExpandCollapseAccordion } from "@/app/components/ExpandCollapseAccordion";
 import {
   formatDateTime,
   formatStartEndDate,

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrSummary.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrSummary.test.tsx
@@ -119,7 +119,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />
+        />,
       );
 
       expect(container).toMatchSnapshot();
@@ -130,7 +130,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />
+        />,
       );
 
       expect(await axe(container)).toHaveNoViolations();
@@ -141,7 +141,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />
+        />,
       );
 
       expect(screen.getByText("covid summary")).toBeVisible();
@@ -153,7 +153,7 @@ describe("EcrSummary tests", () => {
           encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
           snomed="test-snomed-456"
-        />
+        />,
       );
 
       expect(screen.getByText("hep c summary")).toBeVisible();
@@ -164,7 +164,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
-        />
+        />,
       );
 
       expect(screen.getByText("hep c summary")).not.toBeVisible();
@@ -176,7 +176,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={[]}
-        />
+        />,
       );
 
       expect(screen.getByText("0 CONDITIONS FOUND"));
@@ -187,7 +187,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />
+        />,
       );
 
       expect(screen.getByText("1 CONDITION FOUND"));
@@ -198,7 +198,7 @@ describe("EcrSummary tests", () => {
           patientSummary={patientSummary}
           encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
-        />
+        />,
       );
 
       expect(screen.getByText("2 CONDITIONS FOUND"));

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrSummary.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrSummary.test.tsx
@@ -7,7 +7,7 @@ import EcrSummary, {
 
 describe("EcrSummary tests", () => {
   describe("EcrSummary", () => {
-    const patientDetails = [
+    const patientSummary = [
       {
         title: "Patient Name",
         value: "Han Solo",
@@ -37,7 +37,7 @@ describe("EcrSummary tests", () => {
         value: "Home 555-555-55555\nHANSOLOFAKEEMAIL@EXAMPLE.COM",
       },
     ];
-    const encounterDetails = [
+    const encounterSummary = [
       {
         title: "Facility Name",
         value: "Millennium Falcon Med Bay",
@@ -116,10 +116,10 @@ describe("EcrSummary tests", () => {
     it("should match snapshot", () => {
       const { container } = render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />,
+        />
       );
 
       expect(container).toMatchSnapshot();
@@ -127,10 +127,10 @@ describe("EcrSummary tests", () => {
     it("should pass accessibility test", async () => {
       const { container } = render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />,
+        />
       );
 
       expect(await axe(container)).toHaveNoViolations();
@@ -138,10 +138,10 @@ describe("EcrSummary tests", () => {
     it("should open the condition details when there is one", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />,
+        />
       );
 
       expect(screen.getByText("covid summary")).toBeVisible();
@@ -149,11 +149,11 @@ describe("EcrSummary tests", () => {
     it("should open the condition when the snomed matches", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
           snomed="test-snomed-456"
-        />,
+        />
       );
 
       expect(screen.getByText("hep c summary")).toBeVisible();
@@ -161,10 +161,10 @@ describe("EcrSummary tests", () => {
     it("should open no condition details when there is many and no match", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
-        />,
+        />
       );
 
       expect(screen.getByText("hep c summary")).not.toBeVisible();
@@ -173,10 +173,10 @@ describe("EcrSummary tests", () => {
     it("should show 0 reportable conditions tag", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={[]}
-        />,
+        />
       );
 
       expect(screen.getByText("0 CONDITIONS FOUND"));
@@ -184,10 +184,10 @@ describe("EcrSummary tests", () => {
     it("should show 1 reportable condition tag", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={covidConditionDetails}
-        />,
+        />
       );
 
       expect(screen.getByText("1 CONDITION FOUND"));
@@ -195,10 +195,10 @@ describe("EcrSummary tests", () => {
     it("should show 2 reportable conditions tag", () => {
       render(
         <EcrSummary
-          patientDetails={patientDetails}
-          encounterDetails={encounterDetails}
+          patientSummary={patientSummary}
+          encounterSummary={encounterSummary}
           conditionSummary={[...covidConditionDetails, ...hepConditionDetails]}
-        />,
+        />
       );
 
       expect(screen.getByText("2 CONDITIONS FOUND"));

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EncounterInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EncounterInfo.test.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
 
-import EncounterDetails from "@/app/view-data/components/Encounter";
+import EncounterInfo from "@/app/view-data/components/EncounterInfo";
 
-describe("Encounter", () => {
+describe("Encounter Info section", () => {
   let container: HTMLElement;
   beforeAll(() => {
     const mockChildMethod = jest.fn();
@@ -128,7 +128,7 @@ describe("Encounter", () => {
       },
     ];
     container = render(
-      <EncounterDetails
+      <EncounterInfo
         encounterData={encounterData}
         hospitalEncounterData={hospitalEncounterData}
         facilityData={facilityData}

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/EncounterInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/EncounterInfo.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Encounter should match snapshot 1`] = `
+exports[`Encounter Info section should match snapshot 1`] = `
 <div>
   <div
     class="margin-top-0"

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/encounterInfoService.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/encounterInfoService.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Encounter Details Evaluate Encounter Care Team should return the correct Encounter care team 1`] = `
+exports[`Encounter Info service tests Evaluate Encounter Info: Encounter Details Evaluate Encounter Care Team should return the correct Encounter care team 1`] = `
 <JsonTable
   className="caption-data-title margin-y-0"
   jsonTableData={
@@ -34,9 +34,9 @@ exports[`evaluateFhirDataService tests Evaluate Encounter Info: Encounter Detail
 />
 `;
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Encounter Details Evaluate Encounter Diagnoses should return the correct diagnoses given an Encounter 1`] = `"OTHER MUSCLE SPASM"`;
+exports[`Encounter Info service tests Evaluate Encounter Info: Encounter Details Evaluate Encounter Diagnoses should return the correct diagnoses given an Encounter 1`] = `"OTHER MUSCLE SPASM"`;
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Facility Details should return the correct Facility data 1`] = `
+exports[`Encounter Info service tests Evaluate Encounter Info: Facility Details should return the correct Facility data 1`] = `
 {
   "availableData": [
     {
@@ -74,7 +74,7 @@ US",
 }
 `;
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Hospital Encounter Details A bundle with only Discharge Diagnosis returns that data and matches snapshot 1`] = `
+exports[`Encounter Info service tests Evaluate Encounter Info: Hospital Encounter Details A bundle with only Discharge Diagnosis returns that data and matches snapshot 1`] = `
 {
   "availableData": [
     {
@@ -163,7 +163,7 @@ exports[`evaluateFhirDataService tests Evaluate Encounter Info: Hospital Encount
 }
 `;
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Hospital Encounter Details should return Admission Medication data when present and match snapshot 1`] = `
+exports[`Encounter Info service tests Evaluate Encounter Info: Hospital Encounter Details should return Admission Medication data when present and match snapshot 1`] = `
 {
   "availableData": [
     {
@@ -410,7 +410,7 @@ exports[`evaluateFhirDataService tests Evaluate Encounter Info: Hospital Encount
 }
 `;
 
-exports[`evaluateFhirDataService tests Evaluate Encounter Info: Hospital Encounter Details should return Hospital Encounter Data for Admission and Discharge Diagnosis when present and match snapshot 1`] = `
+exports[`Encounter Info service tests Evaluate Encounter Info: Hospital Encounter Details should return Hospital Encounter Data for Admission and Discharge Diagnosis when present and match snapshot 1`] = `
 {
   "availableData": [
     {

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -142,7 +142,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return titles based on snomed code, and return human-readable name if available", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       expect(actual[0].title).toEqual("Hepatitis C");
@@ -153,7 +153,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return human-readable name if available", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleRRConditionValueString,
-        fhirIndexBundleRRConditionValueString
+        fhirIndexBundleRRConditionValueString,
       );
 
       expect(actual[0].title).toEqual("COVID");
@@ -161,7 +161,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return summaries based on snomed code", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
       render(
         actual[1].conditionDetails.map((detail, i) => (
@@ -186,7 +186,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return clinical details based on snomed code", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       render(
@@ -200,7 +200,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return lab details based on snomed code", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       render(
@@ -217,7 +217,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return immunization details based on snomed code", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -265,7 +265,7 @@ describe("ecrSummaryService Tests", () => {
       );
       const actual = evaluateEcrSummaryCondition(
         BundleNonRelatedImmuns,
-        fhirIndexBundleNonRelatedImmuns
+        fhirIndexBundleNonRelatedImmuns,
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -284,7 +284,7 @@ describe("ecrSummaryService Tests", () => {
     it("should return the the requested snomed first", () => {
       const verifyNotFirst = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary
+        fhirIndexBundleEcrSummary,
       );
 
       expect(verifyNotFirst[0].title).not.toEqual(
@@ -294,7 +294,7 @@ describe("ecrSummaryService Tests", () => {
       const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
         fhirIndexBundleEcrSummary,
-        "840539006"
+        "840539006",
       );
       expect(actual[0].title).toEqual(
         "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)",
@@ -306,7 +306,7 @@ describe("ecrSummaryService Tests", () => {
     it("should get all relevant patient details", () => {
       const actual = evaluateEcrSummaryPatient(
         BundlePatient,
-        fhirIndexBundlePatient
+        fhirIndexBundlePatient,
       );
 
       expect(evaluateData(actual).unavailableData).toBeEmpty();
@@ -315,7 +315,7 @@ describe("ecrSummaryService Tests", () => {
     it("should not show parent/guardian info if adult", () => {
       const actual = evaluateEcrSummaryPatient(
         BundlePatient,
-        fhirIndexBundlePatient
+        fhirIndexBundlePatient,
       );
 
       const guardian = actual.find((d) => d.title === "Parent/Guardian");
@@ -377,7 +377,7 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexPatientEmpty = getFhirIndex(BundlePatientEmpty);
       const actual = evaluateEcrSummaryPatient(
         BundlePatientEmpty,
-        fhirIndexPatientEmpty
+        fhirIndexPatientEmpty,
       );
       actual.forEach((a) => {
         expect(a.value).toEqual(noDataSummary);

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/ecrSummaryService.test.tsx
@@ -10,9 +10,9 @@ import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundlePatient from "../../../../../../../test-data/fhir/BundlePatient.json";
 import _BundleRRConditionValueString from "../../../../../../../test-data/fhir/BundleRRConditionValueString.json";
 import {
-  evaluateEcrSummaryConditionSummary,
-  evaluateEcrSummaryEncounterDetails,
-  evaluateEcrSummaryPatientDetails,
+  evaluateEcrSummaryPatient,
+  evaluateEcrSummaryEncounter,
+  evaluateEcrSummaryCondition,
   evaluateEcrSummaryRelevantClinicalDetails,
   evaluateEcrSummaryRelevantLabResults,
 } from "@/app/view-data/services/ecrSummaryService";
@@ -140,9 +140,9 @@ describe("ecrSummaryService Tests", () => {
 
   describe("Evaluate eCR Summary Condition Summary", () => {
     it("should return titles based on snomed code, and return human-readable name if available", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       expect(actual[0].title).toEqual("Hepatitis C");
@@ -151,17 +151,17 @@ describe("ecrSummaryService Tests", () => {
       );
     });
     it("should return human-readable name if available", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleRRConditionValueString,
-        fhirIndexBundleRRConditionValueString,
+        fhirIndexBundleRRConditionValueString
       );
 
       expect(actual[0].title).toEqual("COVID");
     });
     it("should return summaries based on snomed code", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
       render(
         actual[1].conditionDetails.map((detail, i) => (
@@ -184,9 +184,9 @@ describe("ecrSummaryService Tests", () => {
       ).toBeInTheDocument();
     });
     it("should return clinical details based on snomed code", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       render(
@@ -198,9 +198,9 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.getByText("COVID toes")).toBeInTheDocument();
     });
     it("should return lab details based on snomed code", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       render(
@@ -215,9 +215,9 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.getByText("SARS-CoV-2 PCR")).toBeInTheDocument();
     });
     it("should return immunization details based on snomed code", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -263,9 +263,9 @@ describe("ecrSummaryService Tests", () => {
       const fhirIndexBundleNonRelatedImmuns = getFhirIndex(
         BundleNonRelatedImmuns,
       );
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleNonRelatedImmuns,
-        fhirIndexBundleNonRelatedImmuns,
+        fhirIndexBundleNonRelatedImmuns
       );
       render(
         actual[1].immunizationDetails.map((detail) => (
@@ -277,27 +277,24 @@ describe("ecrSummaryService Tests", () => {
       expect(screen.queryByText("anthrax")).not.toBeInTheDocument();
     });
     it("should return empty array if none found", () => {
-      const actual = evaluateEcrSummaryConditionSummary(
-        {} as Bundle,
-        {} as FhirIndex,
-      );
+      const actual = evaluateEcrSummaryCondition({} as Bundle, {} as FhirIndex);
 
       expect(actual).toBeEmpty();
     });
     it("should return the the requested snomed first", () => {
-      const verifyNotFirst = evaluateEcrSummaryConditionSummary(
+      const verifyNotFirst = evaluateEcrSummaryCondition(
         BundleEcrSummary,
-        fhirIndexBundleEcrSummary,
+        fhirIndexBundleEcrSummary
       );
 
       expect(verifyNotFirst[0].title).not.toEqual(
         "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)",
       );
 
-      const actual = evaluateEcrSummaryConditionSummary(
+      const actual = evaluateEcrSummaryCondition(
         BundleEcrSummary,
         fhirIndexBundleEcrSummary,
-        "840539006",
+        "840539006"
       );
       expect(actual[0].title).toEqual(
         "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)",
@@ -307,18 +304,18 @@ describe("ecrSummaryService Tests", () => {
 
   describe("Evaluate eCR Summary Patient Details", () => {
     it("should get all relevant patient details", () => {
-      const actual = evaluateEcrSummaryPatientDetails(
+      const actual = evaluateEcrSummaryPatient(
         BundlePatient,
-        fhirIndexBundlePatient,
+        fhirIndexBundlePatient
       );
 
       expect(evaluateData(actual).unavailableData).toBeEmpty();
     });
 
     it("should not show parent/guardian info if adult", () => {
-      const actual = evaluateEcrSummaryPatientDetails(
+      const actual = evaluateEcrSummaryPatient(
         BundlePatient,
-        fhirIndexBundlePatient,
+        fhirIndexBundlePatient
       );
 
       const guardian = actual.find((d) => d.title === "Parent/Guardian");
@@ -342,7 +339,7 @@ describe("ecrSummaryService Tests", () => {
         ],
       } as unknown as Bundle;
       const fhirIndexBundle = getFhirIndex(bundle);
-      const actual = evaluateEcrSummaryPatientDetails(bundle, fhirIndexBundle);
+      const actual = evaluateEcrSummaryPatient(bundle, fhirIndexBundle);
 
       const guardian = actual.find((d) => d.title === "Parent/Guardian");
 
@@ -378,9 +375,9 @@ describe("ecrSummaryService Tests", () => {
         ],
       } as unknown as Bundle;
       const fhirIndexPatientEmpty = getFhirIndex(BundlePatientEmpty);
-      const actual = evaluateEcrSummaryPatientDetails(
+      const actual = evaluateEcrSummaryPatient(
         BundlePatientEmpty,
-        fhirIndexPatientEmpty,
+        fhirIndexPatientEmpty
       );
       actual.forEach((a) => {
         expect(a.value).toEqual(noDataSummary);
@@ -390,7 +387,7 @@ describe("ecrSummaryService Tests", () => {
 
   describe("Evaluate eCR Summary Encounter Details", () => {
     it("should get all relevant encounter details", () => {
-      const actual = evaluateEcrSummaryEncounterDetails(BundleEcrMetadata);
+      const actual = evaluateEcrSummaryEncounter(BundleEcrMetadata);
       expect(evaluateData(actual).unavailableData).toBeEmpty();
     });
 
@@ -420,7 +417,7 @@ describe("ecrSummaryService Tests", () => {
           },
         ],
       } as unknown as Bundle;
-      const actual = evaluateEcrSummaryEncounterDetails(BundleEncounterEmpty);
+      const actual = evaluateEcrSummaryEncounter(BundleEncounterEmpty);
       actual.forEach((a) => {
         expect(a.value).toEqual(noDataSummary);
       });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/encounterInfoService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/encounterInfoService.test.tsx
@@ -22,14 +22,14 @@ import {
   getLocationName,
   evaluateEncounterDiagnosis,
   evaluateFacilityData,
-} from "@/app/view-data/services/evaluateFhirDataService";
+} from "@/app/view-data/services/encounterInfoService";
 
 const BundleEcrMetadata = _BundleEcrMetadata as Bundle;
 const BundleWithAdmissionMedications = _BundleAdmissionMedications as Bundle;
 const BundlePatientWithCovid = _BundlePatientWithCovid as Bundle;
 const BundlePractitionerRole = _BundlePractitionerRole as Bundle;
 
-describe("evaluateFhirDataService tests", () => {
+describe("Encounter Info service tests", () => {
   describe("Evaluate Encounter Info: Encounter Details", () => {
     describe("Evaluate Encounter Care Team", () => {
       it("should return the correct Encounter care team", () => {


### PR DESCRIPTION
# PULL REQUEST

## Summary

evaluateFhirDataService now only has encounter service functions, so:
- `renamed:    src/app/view-data/services/evaluateFhirDataService.tsx -> src/app/view-data/services/encounterInfoService.tsx`
- `renamed:    tests/unit/app/view-data/services/evaluateFhirDataServices.test.tsx -> tests/unit/app/view-data/services/encounterInfoService.test.tsx`

Also standardized naming in some functions/files to match content in Viewer:
- `renamed:    src/app/view-data/components/Encounter.tsx -> src/app/view-data/components/EncounterInfo.tsx`
- `renamed:    tests/unit/app/view-data/components/Encounter.test.tsx -> tests/unit/app/view-data/components/EncounterInfo.test.tsx`
- Also in eCR Summary and eCR Summary Service functions for consistency.

This should be a maintenance-focused cleanup and should not introduce any user-facing changes.

## Related Issue

Fixes # See below (this is part 5)
https://github.com/CDCgov/dibbs-ecr-viewer/issues/1574

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
