### PR TITLE
fix: route notes with only unavailable terms to Unavailable Info

### DIFF
--- a/containers/ecr-viewer/src/app/utils/data-utils.tsx
+++ b/containers/ecr-viewer/src/app/utils/data-utils.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import parse from "html-react-parser";
 import sanitizeHtml from "sanitize-html";
@@ -59,8 +60,29 @@ export const isDataAvailable = (item: DisplayDataProps): Boolean => {
     "no information available",
     "no information",
   ];
-  const valStr = removeHtmlElements(`${item.value}`).trim().toLowerCase();
+  const valStr = removeHtmlElements(renderValueToString(item.value))
+    .trim()
+    .toLowerCase();
   return !unavailableTerms.some((t) => t === valStr);
+};
+
+/**
+ * Renders a display value to a plain string so its text can be inspected.
+ * `evaluateNotes` stores already-parsed React nodes as the value, so a bare
+ * template-string coercion yields "[object Object]" and hides the real text.
+ * Rendering the node first lets the unavailable-term check see through it.
+ * @param value - The DisplayDataProps value, which may be a string or React node.
+ * @returns - The value's text as a string.
+ */
+export const renderValueToString = (
+  value: DisplayDataProps["value"],
+): string => {
+  if (typeof value === "string") return value;
+  try {
+    return renderToStaticMarkup(value);
+  } catch {
+    return `${value}`;
+  }
 };
 
 /**

--- a/containers/ecr-viewer/tests/unit/app/utils/data-utils.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/utils/data-utils.test.tsx
@@ -30,9 +30,23 @@ describe("Utils", () => {
       const result = isDataAvailable(input);
       expect(result).toEqual(false);
     });
+    it("given an item whose parsed HTML value renders only an unavailable term, it should return false", () => {
+      const input: DisplayDataProps = {
+        value: safeParse("<paragraph>No information</paragraph>"),
+      };
+      const result = isDataAvailable(input);
+      expect(result).toEqual(false);
+    });
     it("given an item with available info, it should return true", () => {
       const input: DisplayDataProps = {
         value: "01/01/1970",
+      };
+      const result = isDataAvailable(input);
+      expect(result).toEqual(true);
+    });
+    it("given an item whose parsed HTML value renders real content, it should return true", () => {
+      const input: DisplayDataProps = {
+        value: safeParse("<paragraph>Patient reports chest pain</paragraph>"),
       };
       const result = isDataAvailable(input);
       expect(result).toEqual(true);


### PR DESCRIPTION
## Summary

Reason for Visit and Clinical Notes that contain only unavailable terms were still showing up under Clinical Info (rendering "No information") instead of moving to the Unavailable Info section. The cause is the mismatch the ticket points at: evaluateNotes stores the value as an already-parsed React node, but isDataAvailable decided availability by coercing that value into a template string, which gives "[object Object]" and never matches the unavailable-term list. I made the availability check render the value to its text first, so it can see through parsed nodes before stripping HTML.

## Related Issue

Fixes #1467

## Acceptance Criteria

- [x] If Reason for Visit contains only unavailable terms, it is displayed under Unavailable Info instead of Clinical Info.
- [x] If Clinical Notes contains only unavailable terms, it is displayed under Unavailable Info instead of Clinical Info.
- [x] All other sub-sections containing valid content continue to appear as normal.
- [x] Any relevant tests are added/updated.

## Additional Information

I added two isDataAvailable cases covering parsed-HTML values (an unavailable term and real content). Verified with the ecr-viewer test suite for data-utils, clinicalInfoService, and Unavailable (16 tests passing), plus tsc, eslint, and prettier all clean.