### PR TITLE
fix: SideNav highlights multiple active sections

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -185,7 +185,7 @@ export const getEcrDocumentAccordionItems = (
     {
       title: "Clinical Info",
       content: Object.values(clinicalData).some(
-        (section) => section.availableData.length > 0
+        (section) => section.availableData.length > 0,
       ) ? (
         <ClinicalInfo
           historyOfPresentIllness={
@@ -231,7 +231,7 @@ export const getEcrDocumentAccordionItems = (
           ecrMetadata.eRSDProcessingInfo ||
           ecrMetadata.eicrDetails.availableData.length > 0 ||
           ecrMetadata.eicrAuthorDetails.find(
-            (authorDetails) => authorDetails.availableData.length > 0
+            (authorDetails) => authorDetails.availableData.length > 0,
           ) ||
           ecrMetadata.ecrCustodianDetails.availableData.length > 0 ? (
             <EcrMetadata
@@ -292,7 +292,7 @@ export const getEcrDocumentAccordionItems = (
                 ...ecrMetadata.ecrCustodianDetails.unavailableData,
               ]}
               eicrAuthorUnavailableData={ecrMetadata.eicrAuthorDetails.map(
-                (authorDetails) => authorDetails.unavailableData
+                (authorDetails) => authorDetails.unavailableData,
               )}
             />
           ) : (

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -8,11 +8,7 @@ import ClinicalInfo from "@/app/view-data/components/ClinicalInfo";
 import Demographics from "@/app/view-data/components/Demographics";
 import EcrMetadata from "@/app/view-data/components/EcrMetadata";
 import EncounterInfo from "@/app/view-data/components/EncounterInfo";
-import {
-  LabInfo,
-  LabNavItem,
-  createLabSectionId,
-} from "@/app/view-data/components/LabInfo";
+import { LabInfo, LabNavItem } from "@/app/view-data/components/LabInfo";
 import PregnancyInfo from "@/app/view-data/components/PregnancyInfo";
 import SocialHistory from "@/app/view-data/components/SocialHistory";
 import UnavailableInfo from "@/app/view-data/components/UnavailableInfo";
@@ -132,14 +128,10 @@ export const getEcrDocumentAccordionItems = (
     ecrMetadata.ecrCustodianDetails.availableData.length > 0 &&
       "eICR Custodian Details",
   );
-  const usedLabSectionIds = new Set<string>();
-  const subNavLabs = labInfoData.map((labResult) => {
-    const organizationName =
-      (labResult.organizationDisplayDataProps[0].value as string) || undefined;
-    const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+  const subNavLabs = labInfoData.map(({subNavMetadata}) => {
     return {
-      title: labName,
-      id: createLabSectionId(organizationName, usedLabSectionIds),
+      title: subNavMetadata.title,
+      id: subNavMetadata.id
     };
   }) as LabNavItem[];
 

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -185,7 +185,7 @@ export const getEcrDocumentAccordionItems = (
     {
       title: "Clinical Info",
       content: Object.values(clinicalData).some(
-        (section) => section.availableData.length > 0,
+        (section) => section.availableData.length > 0
       ) ? (
         <ClinicalInfo
           historyOfPresentIllness={
@@ -215,10 +215,7 @@ export const getEcrDocumentAccordionItems = (
       title: "Lab Info",
       content:
         labInfoData.length > 0 ? (
-          <LabInfo
-            labResults={labInfoData}
-            sectionIds={subNavLabs.map((lab) => lab.id)}
-          />
+          <LabInfo labResults={labInfoData} />
         ) : (
           <p className="text-italic padding-bottom-05">
             No lab information was found in this eCR.
@@ -234,7 +231,7 @@ export const getEcrDocumentAccordionItems = (
           ecrMetadata.eRSDProcessingInfo ||
           ecrMetadata.eicrDetails.availableData.length > 0 ||
           ecrMetadata.eicrAuthorDetails.find(
-            (authorDetails) => authorDetails.availableData.length > 0,
+            (authorDetails) => authorDetails.availableData.length > 0
           ) ||
           ecrMetadata.ecrCustodianDetails.availableData.length > 0 ? (
             <EcrMetadata
@@ -295,7 +292,7 @@ export const getEcrDocumentAccordionItems = (
                 ...ecrMetadata.ecrCustodianDetails.unavailableData,
               ]}
               eicrAuthorUnavailableData={ecrMetadata.eicrAuthorDetails.map(
-                (authorDetails) => authorDetails.unavailableData,
+                (authorDetails) => authorDetails.unavailableData
               )}
             />
           ) : (

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -8,7 +8,11 @@ import ClinicalInfo from "@/app/view-data/components/ClinicalInfo";
 import Demographics from "@/app/view-data/components/Demographics";
 import EcrMetadata from "@/app/view-data/components/EcrMetadata";
 import EncounterInfo from "@/app/view-data/components/EncounterInfo";
-import { LabInfo, LabNavItem, createLabSectionId } from "@/app/view-data/components/LabInfo";
+import {
+  LabInfo,
+  LabNavItem,
+  createLabSectionId,
+} from "@/app/view-data/components/LabInfo";
 import PregnancyInfo from "@/app/view-data/components/PregnancyInfo";
 import SocialHistory from "@/app/view-data/components/SocialHistory";
 import UnavailableInfo from "@/app/view-data/components/UnavailableInfo";

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -8,7 +8,7 @@ import ClinicalInfo from "@/app/view-data/components/ClinicalInfo";
 import Demographics from "@/app/view-data/components/Demographics";
 import EcrMetadata from "@/app/view-data/components/EcrMetadata";
 import EncounterInfo from "@/app/view-data/components/EncounterInfo";
-import LabInfo from "@/app/view-data/components/LabInfo";
+import { LabInfo, LabNavItem, createLabSectionId } from "@/app/view-data/components/LabInfo";
 import PregnancyInfo from "@/app/view-data/components/PregnancyInfo";
 import SocialHistory from "@/app/view-data/components/SocialHistory";
 import UnavailableInfo from "@/app/view-data/components/UnavailableInfo";
@@ -32,7 +32,7 @@ import { evaluateClinicalData } from "@/app/view-data/services/clinicalInfoServi
 
 export type EcrDocumentNavConfig = {
   title: string;
-  subNavItems: string[];
+  subNavItems: Array<string | LabNavItem>;
 };
 
 /**
@@ -128,13 +128,16 @@ export const getEcrDocumentAccordionItems = (
     ecrMetadata.ecrCustodianDetails.availableData.length > 0 &&
       "eICR Custodian Details",
   );
+  const usedLabSectionIds = new Set<string>();
   const subNavLabs = labInfoData.map((labResult) => {
-    const labName = `Lab Results from ${
-      labResult?.organizationDisplayDataProps?.[0]?.value ||
-      "Unknown Organization"
-    }`;
-    return labName;
-  }) as string[];
+    const organizationName =
+      (labResult.organizationDisplayDataProps[0].value as string) || undefined;
+    const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+    return {
+      title: labName,
+      id: createLabSectionId(organizationName, usedLabSectionIds),
+    };
+  }) as LabNavItem[];
 
   const sections = [
     {
@@ -216,7 +219,10 @@ export const getEcrDocumentAccordionItems = (
       title: "Lab Info",
       content:
         labInfoData.length > 0 ? (
-          <LabInfo labResults={labInfoData} />
+          <LabInfo
+            labResults={labInfoData}
+            sectionIds={subNavLabs.map((lab) => lab.id)}
+          />
         ) : (
           <p className="text-italic padding-bottom-05">
             No lab information was found in this eCR.

--- a/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrDocument/accordion-items.tsx
@@ -128,10 +128,10 @@ export const getEcrDocumentAccordionItems = (
     ecrMetadata.ecrCustodianDetails.availableData.length > 0 &&
       "eICR Custodian Details",
   );
-  const subNavLabs = labInfoData.map(({subNavMetadata}) => {
+  const subNavLabs = labInfoData.map(({ subNavMetadata }) => {
     return {
       title: subNavMetadata.title,
-      id: subNavMetadata.id
+      id: subNavMetadata.id,
     };
   }) as LabNavItem[];
 

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -11,7 +11,6 @@ import { DataDisplay } from "./DataDisplay";
 
 interface LabInfoProps {
   labResults: LabReportElementData[];
-  sectionIds: string[];
 }
 
 /**
@@ -20,11 +19,11 @@ interface LabInfoProps {
  * @param props.labResults - some props
  * @returns The JSX element representing the lab information.
  */
-export const LabInfo = ({ labResults, sectionIds = [] }: LabInfoProps) => {
+export const LabInfo = ({ labResults}: LabInfoProps) => {
   return (
     <AccordionSection>
       {labResults.map((res, i) => (
-        <LabResultDetail key={i} labResult={res} sectionId={sectionIds[i]} />
+        <LabResultDetail key={i} labResult={res} sectionId={res.subNavMetadata.id} />
       ))}
     </AccordionSection>
   );

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -66,8 +66,19 @@ export type LabNavItem = {
   id: string;
 };
 
-// TODO ANGELA: Add JSDoc
-// Creates unique lab section ID for SideNav (avoid duplicate IDs)
+/**
+ * Creates a unique lab section ID for the SideNav.
+ *
+ * The generated ID is based on the lab organization's name and converted to kebab-case.
+ * If an ID with the same org name has already been used, a numeric suffix is added
+ * to ensure uniqueness.
+ *
+ * @param organizationName - The name of the lab organization.
+ * If undefined, defaults to "Unknown Organization".
+ * @param usedIds - A set of IDs that already generated. The newly created ID
+ * is added to this set before being returned.
+ * @returns A unique lab section ID string.
+ */
 export const createLabSectionId = (
   organizationName: string | undefined,
   usedIds: Set<string>,

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -19,11 +19,15 @@ interface LabInfoProps {
  * @param props.labResults - some props
  * @returns The JSX element representing the lab information.
  */
-export const LabInfo = ({ labResults}: LabInfoProps) => {
+export const LabInfo = ({ labResults }: LabInfoProps) => {
   return (
     <AccordionSection>
       {labResults.map((res, i) => (
-        <LabResultDetail key={i} labResult={res} sectionId={res.subNavMetadata.id} />
+        <LabResultDetail
+          key={i}
+          labResult={res}
+          sectionId={res.subNavMetadata.id}
+        />
       ))}
     </AccordionSection>
   );

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -8,9 +8,11 @@ import {
 } from "@/app/view-data/utils/component-utils";
 
 import { DataDisplay } from "./DataDisplay";
+import { toKebabCase } from "@/app/utils/format-utils";
 
 interface LabInfoProps {
   labResults: LabReportElementData[];
+  sectionIds: string[];
 }
 
 /**
@@ -19,11 +21,15 @@ interface LabInfoProps {
  * @param props.labResults - some props
  * @returns The JSX element representing the lab information.
  */
-export const LabInfo = ({ labResults }: LabInfoProps) => {
+export const LabInfo = ({ labResults, sectionIds = [] }: LabInfoProps) => {
   return (
     <AccordionSection>
       {labResults.map((res, i) => (
-        <LabResultDetail key={i} labResult={res} />
+        <LabResultDetail
+          key={i}
+          labResult={res}
+          sectionId={sectionIds[i]}
+        />
       ))}
     </AccordionSection>
   );
@@ -31,8 +37,10 @@ export const LabInfo = ({ labResults }: LabInfoProps) => {
 
 const LabResultDetail = ({
   labResult,
+  sectionId,
 }: {
   labResult: LabReportElementData;
+  sectionId: string;
 }) => {
   const labName = `Lab Results from ${
     labResult?.organizationDisplayDataProps?.[0]?.value ||
@@ -40,7 +48,7 @@ const LabResultDetail = ({
   }`;
 
   return (
-    <AccordionSubSection title={labName}>
+    <AccordionSubSection title={labName} id={sectionId}>
       {labResult?.organizationDisplayDataProps?.map((item, index) => {
         if (item.value) return <DataDisplay item={item} key={index} />;
       })}
@@ -51,6 +59,31 @@ const LabResultDetail = ({
       />
     </AccordionSubSection>
   );
+};
+
+export type LabNavItem = {
+  title: string;
+  id: string;
+};
+
+// TODO ANGELA: Add JSDoc
+// Creates unique lab section ID for SideNav (avoid duplicate IDs)
+export const createLabSectionId = (
+  organizationName: string | undefined,
+  usedIds: Set<string>,
+) => {
+  const baseName = (organizationName || "Unknown Organization").trim();
+  const baseId = `lab-results-from-${toKebabCase(baseName)}`;
+  let candidateId = baseId;
+  let suffix = 2;
+
+  while (usedIds.has(candidateId)) {
+    candidateId = `${baseId}-${suffix}`;
+    suffix += 1;
+  }
+
+  usedIds.add(candidateId);
+  return candidateId;
 };
 
 export default LabInfo;

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -25,11 +25,7 @@ export const LabInfo = ({ labResults, sectionIds = [] }: LabInfoProps) => {
   return (
     <AccordionSection>
       {labResults.map((res, i) => (
-        <LabResultDetail
-          key={i}
-          labResult={res}
-          sectionId={sectionIds[i]}
-        />
+        <LabResultDetail key={i} labResult={res} sectionId={sectionIds[i]} />
       ))}
     </AccordionSection>
   );

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/app/view-data/utils/component-utils";
 
 import { DataDisplay } from "./DataDisplay";
-import { toKebabCase } from "@/app/utils/format-utils";
 
 interface LabInfoProps {
   labResults: LabReportElementData[];
@@ -38,13 +37,8 @@ const LabResultDetail = ({
   labResult: LabReportElementData;
   sectionId: string;
 }) => {
-  const labName = `Lab Results from ${
-    labResult?.organizationDisplayDataProps?.[0]?.value ||
-    "Unknown Organization"
-  }`;
-
   return (
-    <AccordionSubSection title={labName} id={sectionId}>
+    <AccordionSubSection title={labResult.subNavMetadata.title} id={sectionId}>
       {labResult?.organizationDisplayDataProps?.map((item, index) => {
         if (item.value) return <DataDisplay item={item} key={index} />;
       })}
@@ -61,36 +55,3 @@ export type LabNavItem = {
   title: string;
   id: string;
 };
-
-/**
- * Creates a unique lab section ID for the SideNav.
- *
- * The generated ID is based on the lab organization's name and converted to kebab-case.
- * If an ID with the same org name has already been used, a numeric suffix is added
- * to ensure uniqueness.
- *
- * @param organizationName - The name of the lab organization.
- * If undefined, defaults to "Unknown Organization".
- * @param usedIds - A set of IDs that already generated. The newly created ID
- * is added to this set before being returned.
- * @returns A unique lab section ID string.
- */
-export const createLabSectionId = (
-  organizationName: string | undefined,
-  usedIds: Set<string>,
-) => {
-  const baseName = (organizationName || "Unknown Organization").trim();
-  const baseId = `lab-results-from-${toKebabCase(baseName)}`;
-  let candidateId = baseId;
-  let suffix = 2;
-
-  while (usedIds.has(candidateId)) {
-    candidateId = `${baseId}-${suffix}`;
-    suffix += 1;
-  }
-
-  usedIds.add(candidateId);
-  return candidateId;
-};
-
-export default LabInfo;

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -16,13 +16,9 @@ export class SectionConfig {
   id: string;
   subNavItems?: SectionConfig[];
 
-  constructor(
-    title: string,
-    subNavItems?: SectionNavInput[],
-    id?: string,
-  ) {
+  constructor(title: string, subNavItems?: SectionNavInput[], id?: string) {
     this.title = title;
-    this.id = id ?? toKebabCase(title); 
+    this.id = id ?? toKebabCase(title);
 
     if (subNavItems) {
       this.subNavItems = subNavItems.map((item) => {

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -9,22 +9,34 @@ import { toKebabCase } from "@/app/utils/format-utils";
 import { SideNavLoadingSkeleton } from "./LoadingComponent";
 import { EcrDocumentNavConfig } from "./EcrDocument/accordion-items";
 
+type SectionNavInput = string | SectionConfig | { title: string; id?: string };
+
 export class SectionConfig {
   title: string;
   id: string;
   subNavItems?: SectionConfig[];
 
-  constructor(title: string, subNavItems?: string[] | SectionConfig[]) {
+  constructor(
+    title: string,
+    subNavItems?: SectionNavInput[],
+    id?: string,
+  ) {
     this.title = title;
-    this.id = toKebabCase(title);
+    this.id = id ?? toKebabCase(title); 
 
     if (subNavItems) {
       this.subNavItems = subNavItems.map((item) => {
         if (typeof item === "string") {
-          return new SectionConfig(item);
-        } else {
+          return new SectionConfig(item, undefined, toKebabCase(item));
+        } else if (item instanceof SectionConfig) {
           return item;
         }
+
+        return new SectionConfig(
+          item.title,
+          undefined,
+          item.id ?? toKebabCase(item.title),
+        );
       });
     }
   }
@@ -295,8 +307,9 @@ const SideNav: React.FC<{
       ) as HTMLElement[];
 
       headingElements.forEach((heading) => {
+        const idAttribute = heading.getAttribute("id");
         const text = heading.textContent;
-        const sectionId = text ? toKebabCase(text) : null;
+        const sectionId = idAttribute || (text ? toKebabCase(text) : null);
 
         if (sectionId && validIds.has(sectionId)) {
           heading.setAttribute("data-sectionid", sectionId);

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -69,9 +69,9 @@ export interface LabReportElementData {
   diagnosticReportDataItems: AccordionItem[];
   organizationDisplayDataProps: DisplayDataProps[];
   subNavMetadata: {
-    title: string,
-    id: string,
-  }
+    title: string;
+    id: string;
+  };
 }
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
@@ -588,13 +588,14 @@ export const combineOrgAndReportData = (
       fhirIndex,
       organizationItems[key].length,
     );
-    
+
     // Create unique IDs for Side Nav
     const orgName = (orgData[0].value as string) || undefined;
     const displayOrg = (orgName || "Unknown Organization").trim();
     const subNavTitle = `Lab Results from ${displayOrg}`;
     const subNavId = `${toKebabCase(subNavTitle)}${
-      organizationId ? `-${organizationId}` : ""}`;
+      organizationId ? `-${organizationId}` : ""
+    }`;
 
     return {
       organizationId,

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -68,6 +68,10 @@ export interface LabReportElementData {
   organizationId: string;
   diagnosticReportDataItems: AccordionItem[];
   organizationDisplayDataProps: DisplayDataProps[];
+  subNavMetadata: {
+    title: string,
+    id: string,
+  }
 }
 
 const ABNORMAL_OBSERVATION_INTERPRETATIONS: Record<string, string> = {
@@ -584,10 +588,19 @@ export const combineOrgAndReportData = (
       fhirIndex,
       organizationItems[key].length,
     );
+    
+    // Create unique IDs for Side Nav
+    const orgName = (orgData[0].value as string) || undefined;
+    const displayOrg = (orgName || "Unknown Organization").trim();
+    const subNavTitle = `Lab Results from ${displayOrg}`;
+    const subNavId = `${toKebabCase(subNavTitle)}${
+      organizationId ? `-${organizationId}` : ""}`;
+
     return {
       organizationId,
       diagnosticReportDataItems: organizationItems[key],
       organizationDisplayDataProps: orgData,
+      subNavMetadata: { title: subNavTitle, id: subNavId },
     };
   });
 };

--- a/containers/ecr-viewer/src/app/view-data/utils/component-utils.tsx
+++ b/containers/ecr-viewer/src/app/view-data/utils/component-utils.tsx
@@ -63,7 +63,9 @@ export const AccordionSubSection = ({
   return (
     <div className="gutter-3">
       <ToolTipElement toolTip={toolTip}>
-        <AccordionH4 id={id ?? idPrefix + toKebabCase(title)}>{title}</AccordionH4>
+        <AccordionH4 id={id ?? idPrefix + toKebabCase(title)}>
+          {title}
+        </AccordionH4>
       </ToolTipElement>
       <AccordionDiv className={className}>{children}</AccordionDiv>
     </div>

--- a/containers/ecr-viewer/src/app/view-data/utils/component-utils.tsx
+++ b/containers/ecr-viewer/src/app/view-data/utils/component-utils.tsx
@@ -37,6 +37,7 @@ interface AccordionSubSectionProps {
   title: string;
   className?: string;
   idPrefix?: string;
+  id?: string;
   toolTip?: string;
   children: React.ReactNode;
 }
@@ -55,13 +56,14 @@ export const AccordionSubSection = ({
   title,
   className,
   idPrefix = "",
+  id,
   toolTip,
   children,
 }: AccordionSubSectionProps) => {
   return (
     <div className="gutter-3">
       <ToolTipElement toolTip={toolTip}>
-        <AccordionH4 id={idPrefix + toKebabCase(title)}>{title}</AccordionH4>
+        <AccordionH4 id={id ?? idPrefix + toKebabCase(title)}>{title}</AccordionH4>
       </ToolTipElement>
       <AccordionDiv className={className}>{children}</AccordionDiv>
     </div>

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -118,7 +118,10 @@ describe("Tests for eCR Document", () => {
       },
       {
         title: "Lab Info",
-        subNavItems: ["Lab Results from Unknown Organization"],
+        subNavItems: [{
+          "id": "lab-results-from-unknown-organization",
+          "title": "Lab Results from Unknown Organization",
+        }],
       },
       {
         title: "eCR Metadata",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/EcrDocument.test.tsx
@@ -118,10 +118,12 @@ describe("Tests for eCR Document", () => {
       },
       {
         title: "Lab Info",
-        subNavItems: [{
-          "id": "lab-results-from-unknown-organization",
-          "title": "Lab Results from Unknown Organization",
-        }],
+        subNavItems: [
+          {
+            id: "lab-results-from-unknown-organization",
+            title: "Lab Results from Unknown Organization",
+          },
+        ],
       },
       {
         title: "eCR Metadata",

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -44,12 +44,7 @@ describe("LabInfo", () => {
         };
       }) as LabNavItem[];
 
-      labInfoJsx = (
-        <LabInfo
-          labResults={labInfoOrg}
-          sectionIds={subNavLabs.map((lab) => lab.id)}
-        />
-      );
+      labInfoJsx = <LabInfo labResults={labInfoOrg} />;
     });
     it("all should be collapsed by default", () => {
       render(labInfoJsx);
@@ -143,12 +138,7 @@ describe("LabInfo", () => {
       }) as LabNavItem[];
     });
     it("should be collapsed by default", () => {
-      render(
-        <LabInfo
-          labResults={labInfo}
-          sectionIds={subNavLabs.map((lab) => lab.id)}
-        />,
-      );
+      render(<LabInfo labResults={labInfo} />);
       screen
         .getAllByTestId("accordionButton", { exact: false })
         .forEach((button) => {
@@ -162,18 +152,13 @@ describe("LabInfo", () => {
     });
 
     it("should not render any results if no table data is present", () => {
-      render(<LabInfo labResults={[]} sectionIds={[]} />);
+      render(<LabInfo labResults={[]}/>);
       expect(screen.queryByText("Lab Results")).not.toBeInTheDocument();
       expect(screen.queryByTestId("table")).not.toBeInTheDocument();
     });
 
     it("should match snapshot test", () => {
-      const { container } = render(
-        <LabInfo
-          labResults={labInfo}
-          sectionIds={subNavLabs.map((lab) => lab.id)}
-        />,
-      );
+      const { container } = render(<LabInfo labResults={labInfo} />);
       expect(container).toMatchSnapshot();
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -6,7 +6,11 @@ import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
-import { LabInfo, createLabSectionId, LabNavItem } from "@/app/view-data/components/LabInfo";
+import {
+  LabInfo,
+  createLabSectionId,
+  LabNavItem,
+} from "@/app/view-data/components/LabInfo";
 import {
   evaluateLabInfoData,
   LabReportElementData,
@@ -40,7 +44,8 @@ describe("LabInfo", () => {
       const usedLabSectionIds = new Set<string>();
       const subNavLabs = labInfoOrg.map((labResult) => {
         const organizationName =
-          (labResult.organizationDisplayDataProps[0].value as string) || undefined;
+          (labResult.organizationDisplayDataProps[0].value as string) ||
+          undefined;
         const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
         return {
           title: labName,
@@ -150,10 +155,14 @@ describe("LabInfo", () => {
           id: createLabSectionId(organizationName, usedLabSectionIds),
         };
       });
-
     });
     it("should be collapsed by default", () => {
-      render(<LabInfo labResults={labInfo} sectionIds={subNavLabs.map((lab) => lab.id)}/>);
+      render(
+        <LabInfo
+          labResults={labInfo}
+          sectionIds={subNavLabs.map((lab) => lab.id)}
+        />,
+      );
       screen
         .getAllByTestId("accordionButton", { exact: false })
         .forEach((button) => {
@@ -167,7 +176,7 @@ describe("LabInfo", () => {
     });
 
     it("should not render any results if no table data is present", () => {
-      render(<LabInfo labResults={[]} sectionIds={[]}/>);
+      render(<LabInfo labResults={[]} sectionIds={[]} />);
       expect(screen.queryByText("Lab Results")).not.toBeInTheDocument();
       expect(screen.queryByTestId("table")).not.toBeInTheDocument();
     });
@@ -177,7 +186,7 @@ describe("LabInfo", () => {
         <LabInfo
           labResults={labInfo}
           sectionIds={subNavLabs.map((lab) => lab.id)}
-        />
+        />,
       );
       expect(container).toMatchSnapshot();
     });
@@ -185,15 +194,15 @@ describe("LabInfo", () => {
 
   describe("Lab Side Nav", () => {
     it("should produce unique IDs for side nav", () => {
-      const usedLabSectionIds = new Set<string>;
+      const usedLabSectionIds = new Set<string>();
       const labNames = ["Org A", "Org A"];
-      const expected = ['lab-results-from-org-a', 'lab-results-from-org-a-2'];
+      const expected = ["lab-results-from-org-a", "lab-results-from-org-a-2"];
 
       const actual = labNames.map((labName) =>
-        createLabSectionId(labName, usedLabSectionIds)
+        createLabSectionId(labName, usedLabSectionIds),
       );
 
       expect(actual).toEqual(expected);
-    })
+    });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -6,11 +6,7 @@ import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
-import {
-  LabInfo,
-  createLabSectionId,
-  LabNavItem,
-} from "@/app/view-data/components/LabInfo";
+import { LabInfo, LabNavItem } from "@/app/view-data/components/LabInfo";
 import {
   evaluateLabInfoData,
   LabReportElementData,
@@ -41,15 +37,10 @@ describe("LabInfo", () => {
       // Empty out one of the lab names for testing
       labInfoOrg[0].organizationDisplayDataProps[0].value = "";
 
-      const usedLabSectionIds = new Set<string>();
-      const subNavLabs = labInfoOrg.map((labResult) => {
-        const organizationName =
-          (labResult.organizationDisplayDataProps[0].value as string) ||
-          undefined;
-        const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+      const subNavLabs = labInfoOrg.map(({subNavMetadata}) => {
         return {
-          title: labName,
-          id: createLabSectionId(organizationName, usedLabSectionIds),
+          title: subNavMetadata.title,
+          id: subNavMetadata.id,
         };
       }) as LabNavItem[];
 
@@ -144,17 +135,12 @@ describe("LabInfo", () => {
         diagnosticReports,
       );
 
-      const usedLabSectionIds = new Set<string>();
-      subNavLabs = labInfo.map((labResult) => {
-        const organizationName =
-          (labResult.organizationDisplayDataProps[0].value as string) ||
-          undefined;
-        const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+      subNavLabs = labInfo.map(({ subNavMetadata }) => {
         return {
-          title: labName,
-          id: createLabSectionId(organizationName, usedLabSectionIds),
+          title: subNavMetadata.title,
+          id: subNavMetadata.id,
         };
-      });
+      }) as LabNavItem[];
     });
     it("should be collapsed by default", () => {
       render(
@@ -192,17 +178,4 @@ describe("LabInfo", () => {
     });
   });
 
-  describe("Lab Side Nav", () => {
-    it("should produce unique IDs for side nav", () => {
-      const usedLabSectionIds = new Set<string>();
-      const labNames = ["Org A", "Org A"];
-      const expected = ["lab-results-from-org-a", "lab-results-from-org-a-2"];
-
-      const actual = labNames.map((labName) =>
-        createLabSectionId(labName, usedLabSectionIds),
-      );
-
-      expect(actual).toEqual(expected);
-    });
-  });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -152,7 +152,7 @@ describe("LabInfo", () => {
     });
 
     it("should not render any results if no table data is present", () => {
-      render(<LabInfo labResults={[]}/>);
+      render(<LabInfo labResults={[]} />);
       expect(screen.queryByText("Lab Results")).not.toBeInTheDocument();
       expect(screen.queryByTestId("table")).not.toBeInTheDocument();
     });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -6,7 +6,7 @@ import { Bundle, DiagnosticReport } from "fhir/r4";
 
 import _BundleLab from "../../../../../../../test-data/fhir/BundleLab.json";
 import _BundleLabNoLabIds from "../../../../../../../test-data/fhir/BundleLabNoLabIds.json";
-import LabInfo from "@/app/view-data/components/LabInfo";
+import { LabInfo, createLabSectionId, LabNavItem } from "@/app/view-data/components/LabInfo";
 import {
   evaluateLabInfoData,
   LabReportElementData,
@@ -37,7 +37,23 @@ describe("LabInfo", () => {
       // Empty out one of the lab names for testing
       labInfoOrg[0].organizationDisplayDataProps[0].value = "";
 
-      labInfoJsx = <LabInfo labResults={labInfoOrg} />;
+      const usedLabSectionIds = new Set<string>();
+      const subNavLabs = labInfoOrg.map((labResult) => {
+        const organizationName =
+          (labResult.organizationDisplayDataProps[0].value as string) || undefined;
+        const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+        return {
+          title: labName,
+          id: createLabSectionId(organizationName, usedLabSectionIds),
+        };
+      }) as LabNavItem[];
+
+      labInfoJsx = (
+        <LabInfo
+          labResults={labInfoOrg}
+          sectionIds={subNavLabs.map((lab) => lab.id)}
+        />
+      );
     });
     it("all should be collapsed by default", () => {
       render(labInfoJsx);
@@ -112,6 +128,7 @@ describe("LabInfo", () => {
 
   describe("when labResults is DisplayDataProps[]", () => {
     let labInfo: LabReportElementData[];
+    let subNavLabs: LabNavItem[];
     beforeAll(() => {
       const diagnosticReports = getResourcesByType<DiagnosticReport>(
         fhirIndexBundleLabNoLabIds,
@@ -121,9 +138,22 @@ describe("LabInfo", () => {
         fhirIndexBundleLabNoLabIds,
         diagnosticReports,
       );
+
+      const usedLabSectionIds = new Set<string>();
+      subNavLabs = labInfo.map((labResult) => {
+        const organizationName =
+          (labResult.organizationDisplayDataProps[0].value as string) ||
+          undefined;
+        const labName = `Lab Results from ${organizationName || "Unknown Organization"}`;
+        return {
+          title: labName,
+          id: createLabSectionId(organizationName, usedLabSectionIds),
+        };
+      });
+
     });
     it("should be collapsed by default", () => {
-      render(<LabInfo labResults={labInfo} />);
+      render(<LabInfo labResults={labInfo} sectionIds={subNavLabs.map((lab) => lab.id)}/>);
       screen
         .getAllByTestId("accordionButton", { exact: false })
         .forEach((button) => {
@@ -137,14 +167,33 @@ describe("LabInfo", () => {
     });
 
     it("should not render any results if no table data is present", () => {
-      render(<LabInfo labResults={[]} />);
+      render(<LabInfo labResults={[]} sectionIds={[]}/>);
       expect(screen.queryByText("Lab Results")).not.toBeInTheDocument();
       expect(screen.queryByTestId("table")).not.toBeInTheDocument();
     });
 
     it("should match snapshot test", () => {
-      const { container } = render(<LabInfo labResults={labInfo} />);
+      const { container } = render(
+        <LabInfo
+          labResults={labInfo}
+          sectionIds={subNavLabs.map((lab) => lab.id)}
+        />
+      );
       expect(container).toMatchSnapshot();
     });
+  });
+
+  describe("Lab Side Nav", () => {
+    it("should produce unique IDs for side nav", () => {
+      const usedLabSectionIds = new Set<string>;
+      const labNames = ["Org A", "Org A"];
+      const expected = ['lab-results-from-org-a', 'lab-results-from-org-a-2'];
+
+      const actual = labNames.map((labName) =>
+        createLabSectionId(labName, usedLabSectionIds)
+      );
+
+      expect(actual).toEqual(expected);
+    })
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/LabInfo.test.tsx
@@ -37,7 +37,7 @@ describe("LabInfo", () => {
       // Empty out one of the lab names for testing
       labInfoOrg[0].organizationDisplayDataProps[0].value = "";
 
-      const subNavLabs = labInfoOrg.map(({subNavMetadata}) => {
+      const subNavLabs = labInfoOrg.map(({ subNavMetadata }) => {
         return {
           title: subNavMetadata.title,
           id: subNavMetadata.id,
@@ -177,5 +177,4 @@ describe("LabInfo", () => {
       expect(container).toMatchSnapshot();
     });
   });
-
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/LabInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/LabInfo.test.tsx.snap
@@ -406,9 +406,9 @@ exports[`LabInfo when labResults is LabReportElementData[] should match snapshot
         >
           <h4
             class="usa-summary-box__heading padding-y-105"
-            id="lab-results-from-unknown-organization"
+            id="lab-results-from-tatooine-hospital-14394818-a1e9-4882-ca8b-FAKE793bb5cc"
           >
-            Lab Results from Unknown Organization
+            Lab Results from Tatooine Hospital
           </h4>
           <div
             class="usa-summary-box__text"
@@ -1291,7 +1291,7 @@ Mos Eisley, CO 00055
         >
           <h4
             class="usa-summary-box__heading padding-y-105"
-            id="lab-results-from-coruscant-medical"
+            id="lab-results-from-coruscant-medical-3a1cb409-6f94-0231-86d6-FAKE1ecc5fda"
           >
             Lab Results from Coruscant Medical
           </h4>


### PR DESCRIPTION
# PULL REQUEST

## Summary

If there are lab sections with the same name (i.e. same Organization, but are sectioned differently because of other info i.e. address), the SideNav bar will highlight both when either of them is in view or is clicked on. 

This PR fixes so that lab sections are given unique IDs -> are therefore highlighted as unique sections (even if they have the same name).

## Related Issue

Fixes #1432 

## Acceptance Criteria

- [X] When two lab organizations have the same name (but unique info), each section is treated as a unique SideNav sub-section.
- [X] Clicking one lab section in the SideNav highlights only the matching section.
- [X] Scrolling to one lab section highlights only the matching section in the SideNav.

## Additional Information

For an eCR: change a lab organization to have the same name (but different address) as another lab organization. 

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
