### PR TITLE
chore: Fixing allowScripts for sharp dependency

### DIFF
--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -151,7 +151,7 @@
       "@parcel/watcher#2.5.6": true,
       "eslint-config-next>eslint-import-resolver-typescript>unrs-resolver#1.11.1": true,
       "fhirpath#4.8.5": false,
-      "next>sharp#0.34.5": true
+      "sharp#0.34.5": true
     }
   }
 }

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -151,6 +151,7 @@
       "@parcel/watcher#2.5.6": true,
       "eslint-config-next>eslint-import-resolver-typescript>unrs-resolver#1.11.1": true,
       "fhirpath#4.8.5": false,
+      "next>sharp#0.34.5": true,
       "sharp#0.34.5": true
     }
   }


### PR DESCRIPTION
## Summary

During a recent version bump for sharp, Dependabot updated our Lavamoat configuration by scoping sharp as a strictly nested dependency of Next.js ("next>sharp": true). Because in our local environments npm flattens node_modules during installation, sharp was actually installed at the root level. This mismatch caused allow-scripts to fail with a "missing configuration" error during the local build. This PR fixes this by adding support for both nested and un-nested options. 

