### PR TITLE
fix: Changing vitals signs to be collapsible

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -128,15 +128,13 @@ const VitalDetails = ({ details }: { details: DisplayDataProps[] }) => {
     return (
       <AccordionSubSection title="Diagnostics and Vital Signs">
         <Accordion
-          className="accordion-rr margin-top-0"
+          className="accordion-rr vital-signs-accordion margin-top-0"
           items={[
             {
               title: "Vital Signs",
-              content: (
-                <div data-testid="vital-signs">
-                  <TableDetails details={details} />
-                </div>
-              ),
+              content: details.map((item, index) => (
+                <React.Fragment key={index}>{item.value}</React.Fragment>
+              )),
               expanded: false,
               headingLevel: "h5",
               id: "vital-signs-content",

--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Accordion } from "@trussworks/react-uswds";
 import classNames from "classnames";
 
 import {
@@ -126,9 +127,22 @@ const VitalDetails = ({ details }: { details: DisplayDataProps[] }) => {
   if (details.length > 0) {
     return (
       <AccordionSubSection title="Diagnostics and Vital Signs">
-        <div data-testid="vital-signs">
-          <TableDetails details={details} />
-        </div>
+        <Accordion
+          className="accordion-rr margin-top-0"
+          items={[
+            {
+              title: "Vital Signs",
+              content: (
+                <div data-testid="vital-signs">
+                  <TableDetails details={details} />
+                </div>
+              ),
+              expanded: false,
+              headingLevel: "h5",
+              id: "vital-signs-content",
+            },
+          ]}
+        />
       </AccordionSubSection>
     );
   }

--- a/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
@@ -1024,6 +1024,7 @@ export const returnVitalsTable = (fhirBundle: Bundle) => {
       columns={columns}
       className="margin-y-0"
       fixed={false}
+      outerBorder={false}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
@@ -1022,7 +1022,6 @@ export const returnVitalsTable = (fhirBundle: Bundle) => {
     <EvaluateTable
       resources={vitals}
       columns={columns}
-      caption="Vital Signs"
       className="margin-y-0"
       fixed={false}
     />

--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -304,6 +304,18 @@ main {
   }
 }
 
+.vital-signs-accordion {
+  > .usa-accordion__content {
+    overflow: hidden;
+    padding-bottom: 0;
+  }
+
+  .usa-prose > table {
+    border-bottom: 0;
+    margin-bottom: 0;
+  }
+}
+
 .table-clinical-problems {
   tbody td:nth-child(2) {
     min-width: 130px;

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
@@ -1167,9 +1167,11 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
       />,
     );
 
-    const expectedVitalSignsElement = clinicalInfo.getByTestId("vital-signs");
-    expect(expectedVitalSignsElement).toBeInTheDocument();
-    expect(expectedVitalSignsElement).not.toBeVisible();
+    const vitalSignsContent = clinicalInfo.getByTestId(
+      "accordionItem_vital-signs-content",
+    );
+    expect(vitalSignsContent).toBeInTheDocument();
+    expect(vitalSignsContent).not.toBeVisible();
 
     const vitalSignsButton = clinicalInfo.getByRole("button", {
       name: "Vital Signs",
@@ -1179,12 +1181,18 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
     await user.click(vitalSignsButton);
 
     expect(vitalSignsButton).toHaveAttribute("aria-expanded", "true");
-    expect(expectedVitalSignsElement).toBeVisible();
+    expect(vitalSignsContent).toBeVisible();
 
     // Ensure only one table (Vital Signs) is rendering
     const expectedTable = clinicalInfo.getAllByTestId("table");
     expect(expectedTable.length).toEqual(1);
     expect(expectedTable[0]).toBeInTheDocument();
+    expect(expectedTable[0].parentElement).toBe(vitalSignsContent);
+    expect(expectedTable[0]).not.toHaveClass(
+      "border-top",
+      "border-left",
+      "border-right",
+    );
 
     // Check Vital Signs table contents
     const expectedValues = [
@@ -1295,8 +1303,9 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
     expect(expectedTable[0]).toBeInTheDocument();
     expect(expectedTable.length).toEqual(6);
 
-    const expectedVitalSignsElement = clinicalInfo.getByTestId("vital-signs");
-    expect(expectedVitalSignsElement).toBeInTheDocument();
+    expect(
+      clinicalInfo.getByTestId("accordionItem_vital-signs-content"),
+    ).toBeInTheDocument();
 
     const expectedReasonForVisitElement =
       clinicalInfo.getByTestId("reason-for-visit");

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Bundle, Condition, Immunization } from "fhir/r4";
 import { axe } from "jest-axe";
 
@@ -1152,7 +1153,8 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
     expect(clinicalInfo.getAllByText("Recurrence")).toHaveLength(1);
   });
 
-  it("eCR Viewer renders vital signs given FHIR bundle with vital signs info", () => {
+  it("eCR Viewer renders vital signs collapsed by default and expands them", async () => {
+    const user = userEvent.setup();
     const clinicalInfo = render(
       <ClinicalInfo
         immunizationsDetails={[]}
@@ -1167,6 +1169,17 @@ describe("Check that Clinical Info components render given FHIR bundle", () => {
 
     const expectedVitalSignsElement = clinicalInfo.getByTestId("vital-signs");
     expect(expectedVitalSignsElement).toBeInTheDocument();
+    expect(expectedVitalSignsElement).not.toBeVisible();
+
+    const vitalSignsButton = clinicalInfo.getByRole("button", {
+      name: "Vital Signs",
+    });
+    expect(vitalSignsButton).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(vitalSignsButton);
+
+    expect(vitalSignsButton).toHaveAttribute("aria-expanded", "true");
+    expect(expectedVitalSignsElement).toBeVisible();
 
     // Ensure only one table (Vital Signs) is rendering
     const expectedTable = clinicalInfo.getAllByTestId("table");

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
@@ -2107,134 +2107,156 @@ Result: 2 m
             class="usa-summary-box__text"
           >
             <div
-              data-testid="vital-signs"
+              class="usa-accordion accordion-rr margin-top-0"
+              data-testid="accordion"
             >
-              <div>
-                <div>
-                  <div
-                    class="grid-col-auto text-pre-line"
-                  >
-                    <table
-                      class="usa-table usa-table--borderless width-full table-caption-margin margin-y-0 border-top border-left border-right"
-                      data-testid="table"
-                    >
-                      <caption>
-                        Vital Signs
-                      </caption>
-                      <thead>
-                        <tr>
-                          <th
-                            class="table-header"
-                            scope="col"
-                          >
-                            Vital Reading
-                          </th>
-                          <th
-                            class="table-header"
-                            scope="col"
-                          >
-                            Result
-                          </th>
-                          <th
-                            class="table-header"
-                            scope="col"
-                          >
-                            Date/Time
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            Weight
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            140 lb
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            02/04/2025 12:48 PM EST
-                          </td>
-                        </tr>
-                        <tr>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            Weight
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            63.5 kg
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            02/04/2025 12:48 PM EST
-                          </td>
-                        </tr>
-                        <tr>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            Bmi (body mass index)
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            20 kg/m2
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            02/04/2025 12:48 PM EST
-                          </td>
-                        </tr>
-                        <tr>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            Height
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            60 in
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            02/04/2025 12:48 PM EST
-                          </td>
-                        </tr>
-                        <tr>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            Height
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            152.4 cm
-                          </td>
-                          <td
-                            class="text-top text-pre-line"
-                          >
-                            02/04/2025 12:48 PM EST
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
+              <h5
+                class="usa-accordion__heading"
+              >
+                <button
+                  aria-controls="vital-signs-content"
+                  aria-expanded="false"
+                  class="usa-accordion__button"
+                  data-testid="accordionButton_vital-signs-content"
+                  type="button"
+                >
+                  Vital Signs
+                </button>
+              </h5>
+              <div
+                class="usa-accordion__content usa-prose"
+                data-testid="accordionItem_vital-signs-content"
+                hidden=""
+                id="vital-signs-content"
+              >
+                <div
+                  data-testid="vital-signs"
+                >
+                  <div>
+                    <div>
+                      <div
+                        class="grid-col-auto text-pre-line"
+                      >
+                        <table
+                          class="usa-table usa-table--borderless width-full table-caption-margin margin-y-0 border-top border-left border-right"
+                          data-testid="table"
+                        >
+                          <thead>
+                            <tr>
+                              <th
+                                class="table-header"
+                                scope="col"
+                              >
+                                Vital Reading
+                              </th>
+                              <th
+                                class="table-header"
+                                scope="col"
+                              >
+                                Result
+                              </th>
+                              <th
+                                class="table-header"
+                                scope="col"
+                              >
+                                Date/Time
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                Weight
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                140 lb
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                02/04/2025 12:48 PM EST
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                Weight
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                63.5 kg
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                02/04/2025 12:48 PM EST
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                Bmi (body mass index)
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                20 kg/m2
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                02/04/2025 12:48 PM EST
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                Height
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                60 in
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                02/04/2025 12:48 PM EST
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                Height
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                152.4 cm
+                              </td>
+                              <td
+                                class="text-top text-pre-line"
+                              >
+                                02/04/2025 12:48 PM EST
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div
+                        class="section__line_gray"
+                      />
+                    </div>
                   </div>
-                  <div
-                    class="section__line_gray"
-                  />
                 </div>
               </div>
             </div>

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
@@ -2107,7 +2107,7 @@ Result: 2 m
             class="usa-summary-box__text"
           >
             <div
-              class="usa-accordion accordion-rr margin-top-0"
+              class="usa-accordion accordion-rr vital-signs-accordion margin-top-0"
               data-testid="accordion"
             >
               <h5
@@ -2129,135 +2129,120 @@ Result: 2 m
                 hidden=""
                 id="vital-signs-content"
               >
-                <div
-                  data-testid="vital-signs"
+                <table
+                  class="usa-table usa-table--borderless width-full table-caption-margin margin-y-0"
+                  data-testid="table"
                 >
-                  <div>
-                    <div>
-                      <div
-                        class="grid-col-auto text-pre-line"
+                  <thead>
+                    <tr>
+                      <th
+                        class="table-header"
+                        scope="col"
                       >
-                        <table
-                          class="usa-table usa-table--borderless width-full table-caption-margin margin-y-0 border-top border-left border-right"
-                          data-testid="table"
-                        >
-                          <thead>
-                            <tr>
-                              <th
-                                class="table-header"
-                                scope="col"
-                              >
-                                Vital Reading
-                              </th>
-                              <th
-                                class="table-header"
-                                scope="col"
-                              >
-                                Result
-                              </th>
-                              <th
-                                class="table-header"
-                                scope="col"
-                              >
-                                Date/Time
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <tr>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                Weight
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                140 lb
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                02/04/2025 12:48 PM EST
-                              </td>
-                            </tr>
-                            <tr>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                Weight
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                63.5 kg
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                02/04/2025 12:48 PM EST
-                              </td>
-                            </tr>
-                            <tr>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                Bmi (body mass index)
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                20 kg/m2
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                02/04/2025 12:48 PM EST
-                              </td>
-                            </tr>
-                            <tr>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                Height
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                60 in
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                02/04/2025 12:48 PM EST
-                              </td>
-                            </tr>
-                            <tr>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                Height
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                152.4 cm
-                              </td>
-                              <td
-                                class="text-top text-pre-line"
-                              >
-                                02/04/2025 12:48 PM EST
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
-                      <div
-                        class="section__line_gray"
-                      />
-                    </div>
-                  </div>
-                </div>
+                        Vital Reading
+                      </th>
+                      <th
+                        class="table-header"
+                        scope="col"
+                      >
+                        Result
+                      </th>
+                      <th
+                        class="table-header"
+                        scope="col"
+                      >
+                        Date/Time
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        Weight
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        140 lb
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        02/04/2025 12:48 PM EST
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        Weight
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        63.5 kg
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        02/04/2025 12:48 PM EST
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        Bmi (body mass index)
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        20 kg/m2
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        02/04/2025 12:48 PM EST
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        Height
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        60 in
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        02/04/2025 12:48 PM EST
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        Height
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        152.4 cm
+                      </td>
+                      <td
+                        class="text-top text-pre-line"
+                      >
+                        02/04/2025 12:48 PM EST
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

UI updates to change vitals signs section to be collapsible and collapsed by default.

Before changes (got this from the Demo site so contents might be slightly different):
<img width="2472" height="1266" alt="image" src="https://github.com/user-attachments/assets/32c548ad-c440-4ff5-938c-b1526c0fd64f" />

After changes (on load - collapsed by default):
<img width="2450" height="290" alt="image" src="https://github.com/user-attachments/assets/f904eb67-a703-4418-b5dc-96f116a3e24e" />

After changes (after expanding):
<img width="2428" height="1120" alt="image" src="https://github.com/user-attachments/assets/206c6d51-c8b2-448e-ac65-9bfdbcacdf1d" />

## Related Issue

Fixes #1451 

## Acceptance Criteria

- [x]  Make Vital Signs collapsible, and collapsed by default
- [x]  Add any relevant tests
- [x]  Add Chinelo for design review

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
