### PR TITLE
chore: Removing rxnorm download from Dockerfile

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -14,13 +14,7 @@ RUN dotnet publish \
   --self-contained true \
   -o output
 
-RUN apt-get update && apt-get install -y curl jq
-
-# Get an up to date copy of active rxnorm codes and names
-RUN rm output/rxnorm.csv
-RUN curl 'https://rxnav.nlm.nih.gov/REST/allstatus.json?status=active' \
-  | jq --raw-output '[["code", "name"]] + [.minConceptGroup.minConcept[] | [.rxcui, .name]] | .[] | @csv' \
-  > output/rxnorm.csv
+RUN apt-get update && apt-get install -y curl
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /App


### PR DESCRIPTION
## Summary

Part of the terminology automation in PR https://github.com/CDCgov/dibbs-FHIR-Converter/pull/152, it is no longer necessary to download the rxnorm csv in the Dockerfile. 

## Related Issue

Same ticket as PR linked above.

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
