### PR TITLE
fix: update batching to be based off of max number of parameters

### DIFF
--- a/containers/ecr-viewer/src/app/api/save-fhir-data/service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/service.ts
@@ -315,8 +315,8 @@ const saveExtendedMetadata = async (
 
       const numColumns = Object.keys(record).length;
 
-      // SQL Server allows a maximum of 4096 columns inserted at once which is the lower number of the two databases we support
-      const maxRowsPerBatch = Math.floor(4096 / numColumns);
+      // SQL Server has a limit of 2100 parameters per query which is the lower number of the two databases we support
+      const maxRowsPerBatch = Math.floor(2099 / numColumns);
 
       if (
         batchToInsert.length === maxRowsPerBatch ||

--- a/containers/ecr-viewer/tests/unit/app/api/save-fhir-data/service.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/api/save-fhir-data/service.test.ts
@@ -312,7 +312,7 @@ describe("saveFhirMetadata", () => {
       eicr_id: ecrId,
       specimen_collection_date: new Date(firstLab.specimen_collection_date),
     }).length;
-    const maxLabBatchSize = Math.floor(4096 / labColumnCount);
+    const maxLabBatchSize = Math.floor(2099 / labColumnCount);
     const labs = Array.from({ length: maxLabBatchSize + 1 }, (_, index) =>
       makeLabMetadata(index),
     );


### PR DESCRIPTION
# PULL REQUEST

## Summary

Updates lab insert batching logic to calculate batch size based on SQL Server's max number of parameters rather than max number of columns. This is needed because each column of each record is parameterized in the query generated by kysely. The 2100 parameter limit is exclusive which is why the maximum is now 2099.

## Related Issue

Fixes #NA

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
