### PR TITLE
fix: HTML tables with nested list items

### DIFF
--- a/containers/ecr-viewer/src/app/services/htmlTableService.ts
+++ b/containers/ecr-viewer/src/app/services/htmlTableService.ts
@@ -74,7 +74,8 @@ export function formatTablesToJSON(htmlString: string): HtmlTableJson[] {
   }
 
   // <li>{name}<table/></li> OR <list><item>{name}<table /></item></list>
-  const liArray = doc.querySelectorAll("li, list > item");
+  // Use case: each table is a list item (i.e. lab observations)
+  const liArray = doc.querySelectorAll("li:has(> table), list > item");
   if (liArray.length > 0) {
     liArray.forEach((li) => {
       const tables: HtmlTableJsonRow[][] = [];

--- a/containers/ecr-viewer/tests/unit/app/services/htmlTableService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/services/htmlTableService.test.tsx
@@ -133,30 +133,30 @@ describe("htmlTableService tests", () => {
       });
 
       it("<table><li></li></table>", () => {
-        // Should process table. Should not hit <li> case since 
+        // Should process table. Should not hit <li> case since
         // list items are in table, NOT that each table is a list item.
         const htmlString =
           "<table><tr><th>Header</th></tr><tr><td><li>Nested list item</li></td></tr></table>";
         const expectedResult: HtmlTableJson[] = [
           {
-            "resultId": undefined,
-            "resultName": "",
-            "tables": [
+            resultId: undefined,
+            resultName: "",
+            tables: [
               [
                 {
-                  "Header": {
-                    "metadata": {},
-                    "value": <li>Nested list item</li>
-                  }
-                }
-              ]
-            ]
-          }
-        ]
+                  Header: {
+                    metadata: {},
+                    value: <li>Nested list item</li>,
+                  },
+                },
+              ],
+            ],
+          },
+        ];
         const result = formatTablesToJSON(htmlString);
         console.log(result);
         expect(result).toEqual(expectedResult);
-      })
+      });
 
       it("<item data-id><table /></item>", () => {
         const htmlString =
@@ -412,7 +412,6 @@ describe("htmlTableService tests", () => {
         expect(result).toEqual(expectedResult);
       });
     });
-
 
     it("should return an empty array when HTML string input has no tables", () => {
       const htmlString =

--- a/containers/ecr-viewer/tests/unit/app/services/htmlTableService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/services/htmlTableService.test.tsx
@@ -4,6 +4,7 @@ import {
   formatTablesToJSON,
   getDataId,
   getFirstNonCommentChild,
+  HtmlTableJson,
 } from "@/app/services/htmlTableService";
 
 describe("htmlTableService tests", () => {
@@ -130,6 +131,32 @@ describe("htmlTableService tests", () => {
 
         expect(result).toEqual(expectedResult);
       });
+
+      it("<table><li></li></table>", () => {
+        // Should process table. Should not hit <li> case since 
+        // list items are in table, NOT that each table is a list item.
+        const htmlString =
+          "<table><tr><th>Header</th></tr><tr><td><li>Nested list item</li></td></tr></table>";
+        const expectedResult: HtmlTableJson[] = [
+          {
+            "resultId": undefined,
+            "resultName": "",
+            "tables": [
+              [
+                {
+                  "Header": {
+                    "metadata": {},
+                    "value": <li>Nested list item</li>
+                  }
+                }
+              ]
+            ]
+          }
+        ]
+        const result = formatTablesToJSON(htmlString);
+        console.log(result);
+        expect(result).toEqual(expectedResult);
+      })
 
       it("<item data-id><table /></item>", () => {
         const htmlString =
@@ -288,103 +315,104 @@ describe("htmlTableService tests", () => {
 
         expect(result).toEqual(expectedResult);
       });
-    });
 
-    it("<content>{name}</content><br/><table/>", () => {
-      const tableString =
-        '<content>Empty Header</content><br /><content>Future Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test1</td></tr></tbody></table><content>Pending Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test2</td></tr></tbody></table>< /br><content>Text Header</content><br/>No table here<content styleCode="Bold" xmlns="urn:hl7-org:v3">Patient Instructions</content><br xmlns="urn:hl7-org:v3" /><table xmlns="urn:hl7-org:v3"><tbody><tr><td ID="potpatinstr-1">instruction</td></tr></tbody></table>';
-      const expectedResult = [
-        {
-          resultName: "Future Tests",
-          tables: [[{ Name: { metadata: {}, value: "test1" } }]],
-        },
-        {
-          resultName: "Pending Tests",
-          tables: [[{ Name: { metadata: {}, value: "test2" } }]],
-        },
-        {
-          resultName: "Patient Instructions",
-          tables: [
-            [
-              {
-                "Unknown Header": {
-                  metadata: { id: "potpatinstr-1" },
-                  value: "instruction",
+      it("<content>{name}</content><br/><table/>", () => {
+        const tableString =
+          '<content>Empty Header</content><br /><content>Future Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test1</td></tr></tbody></table><content>Pending Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test2</td></tr></tbody></table>< /br><content>Text Header</content><br/>No table here<content styleCode="Bold" xmlns="urn:hl7-org:v3">Patient Instructions</content><br xmlns="urn:hl7-org:v3" /><table xmlns="urn:hl7-org:v3"><tbody><tr><td ID="potpatinstr-1">instruction</td></tr></tbody></table>';
+        const expectedResult = [
+          {
+            resultName: "Future Tests",
+            tables: [[{ Name: { metadata: {}, value: "test1" } }]],
+          },
+          {
+            resultName: "Pending Tests",
+            tables: [[{ Name: { metadata: {}, value: "test2" } }]],
+          },
+          {
+            resultName: "Patient Instructions",
+            tables: [
+              [
+                {
+                  "Unknown Header": {
+                    metadata: { id: "potpatinstr-1" },
+                    value: "instruction",
+                  },
                 },
-              },
+              ],
             ],
-          ],
-        },
-      ];
-      const result = formatTablesToJSON(tableString);
+          },
+        ];
+        const result = formatTablesToJSON(tableString);
 
-      expect(result).toEqual(expectedResult);
-    });
+        expect(result).toEqual(expectedResult);
+      });
 
-    it("<content>{name}</content><br/><table/>", () => {
-      const tableString =
-        '<content>Empty Header</content><br /><content>Future Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test1</td></tr></tbody></table><content>Pending Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test2</td></tr></tbody></table>< /br><content>Text Header</content><br/>No table here<content styleCode="Bold" xmlns="urn:hl7-org:v3">Patient Instructions</content><br xmlns="urn:hl7-org:v3" /><table xmlns="urn:hl7-org:v3"><tbody><tr><td ID="potpatinstr-1">instruction</td></tr></tbody></table>';
-      const expectedResult = [
-        {
-          resultName: "Future Tests",
-          tables: [[{ Name: { metadata: {}, value: "test1" } }]],
-        },
-        {
-          resultName: "Pending Tests",
-          tables: [[{ Name: { metadata: {}, value: "test2" } }]],
-        },
-        {
-          resultName: "Patient Instructions",
-          tables: [
-            [
-              {
-                "Unknown Header": {
-                  metadata: { id: "potpatinstr-1" },
-                  value: "instruction",
+      it("<content>{name}</content><br/><table/>", () => {
+        const tableString =
+          '<content>Empty Header</content><br /><content>Future Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test1</td></tr></tbody></table><content>Pending Tests</content><br /><table><thead><tr><th>Name</th></tr></thead><tbody><tr data-id=\'procedure9\'><td>test2</td></tr></tbody></table>< /br><content>Text Header</content><br/>No table here<content styleCode="Bold" xmlns="urn:hl7-org:v3">Patient Instructions</content><br xmlns="urn:hl7-org:v3" /><table xmlns="urn:hl7-org:v3"><tbody><tr><td ID="potpatinstr-1">instruction</td></tr></tbody></table>';
+        const expectedResult = [
+          {
+            resultName: "Future Tests",
+            tables: [[{ Name: { metadata: {}, value: "test1" } }]],
+          },
+          {
+            resultName: "Pending Tests",
+            tables: [[{ Name: { metadata: {}, value: "test2" } }]],
+          },
+          {
+            resultName: "Patient Instructions",
+            tables: [
+              [
+                {
+                  "Unknown Header": {
+                    metadata: { id: "potpatinstr-1" },
+                    value: "instruction",
+                  },
                 },
-              },
+              ],
             ],
-          ],
-        },
-      ];
-      const result = formatTablesToJSON(tableString);
+          },
+        ];
+        const result = formatTablesToJSON(tableString);
 
-      expect(result).toEqual(expectedResult);
-    });
+        expect(result).toEqual(expectedResult);
+      });
 
-    it("<table/>", () => {
-      const tableString =
-        "<table><thead><tr><th>Name</th></tr></thead><tbody><tr ID='lab9'><td>test1</td></tr></tbody></table><table><thead><tr><th>Name</th></tr></thead><tbody><tr ID='lab9'><td>test2</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><tbody><tr><td ID=\"potpatinstr-1\">instruction</td></tr></tbody></table>";
-      const expectedResult = [
-        {
-          resultId: undefined,
-          resultName: "",
-          tables: [[{ Name: { metadata: {}, value: "test1" } }]],
-        },
-        {
-          resultId: undefined,
-          resultName: "",
-          tables: [[{ Name: { metadata: {}, value: "test2" } }]],
-        },
-        {
-          resultId: undefined,
-          resultName: "",
-          tables: [
-            [
-              {
-                "Unknown Header": {
-                  metadata: { id: "potpatinstr-1" },
-                  value: "instruction",
+      it("<table/>", () => {
+        const tableString =
+          "<table><thead><tr><th>Name</th></tr></thead><tbody><tr ID='lab9'><td>test1</td></tr></tbody></table><table><thead><tr><th>Name</th></tr></thead><tbody><tr ID='lab9'><td>test2</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><tbody><tr><td ID=\"potpatinstr-1\">instruction</td></tr></tbody></table>";
+        const expectedResult = [
+          {
+            resultId: undefined,
+            resultName: "",
+            tables: [[{ Name: { metadata: {}, value: "test1" } }]],
+          },
+          {
+            resultId: undefined,
+            resultName: "",
+            tables: [[{ Name: { metadata: {}, value: "test2" } }]],
+          },
+          {
+            resultId: undefined,
+            resultName: "",
+            tables: [
+              [
+                {
+                  "Unknown Header": {
+                    metadata: { id: "potpatinstr-1" },
+                    value: "instruction",
+                  },
                 },
-              },
+              ],
             ],
-          ],
-        },
-      ];
-      const result = formatTablesToJSON(tableString);
+          },
+        ];
+        const result = formatTablesToJSON(tableString);
 
-      expect(result).toEqual(expectedResult);
+        expect(result).toEqual(expectedResult);
+      });
     });
+
 
     it("should return an empty array when HTML string input has no tables", () => {
       const htmlString =


### PR DESCRIPTION
# PULL REQUEST

## Summary

`Reason for Visit` and `History of Present Illness` weren't showing up due to this small issue with `formatTablesToJSON` where the example data had `<li>`s nested inside the `<table>`. Updated conditional to check for list items with nested tables (often found with labs), and not just any list items present.

Also added a unit test to ensure this structure is now processed correctly.

## Related Issue

Fixes # N/A

Found when looking at processing `bundle-eicr-document-zika` (found [here](https://www.hl7.org/fhir/us/ecr/artifacts.html)) FHIR bundle.

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
