### PR TITLE
fix: multiple notes for active problems and multiple travel locations

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -825,7 +825,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "TimeX",
     path: "effective",
   },
-  noteText: { type: "string", path: "note.text" },
+  noteText: { type: "string", path: "note.text.join('<br />')" },
   valueX: {
     type: "ValueX",
     path: "value",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -739,7 +739,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   travelHistoryLocation: {
     type: "ValueX",
-    path: "iif(component.where(code.coding.code = 'LOC').value.exists(), component.where(code.coding.code = 'LOC').value, component.where(code.coding.code = 'LOC').extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension').value)",
+    path: "iif(component.where(code.coding.code = 'LOC').value.exists(), component.where(code.coding.code = 'LOC').value.coding.display.join(', '), component.where(code.coding.code = 'LOC').extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension').value)",
   },
   travelHistoryPurpose: {
     type: "ValueX",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -30,6 +30,7 @@ export type ValueX =
   | boolean
   | number
   | string
+  | Address
   | CodeableConcept
   | Coding
   | Quantity
@@ -174,7 +175,7 @@ export type PathTypes = {
   observationInterpretation: Coding;
   organizationType: ValueX;
   patientTravelHistory: Observation;
-  travelHistoryLocation: string;
+  travelHistoryLocation: ValueX;
   travelHistoryPurpose: ValueX;
   hasMember: Reference;
   exposureObservations: Observation;
@@ -739,7 +740,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   },
   travelHistoryLocation: {
     type: "ValueX",
-    path: "iif(component.where(code.coding.code = 'LOC').value.exists(), component.where(code.coding.code = 'LOC').value.coding.display.join(', '), component.where(code.coding.code = 'LOC').extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension').value)",
+    path: "iif(component.where(code.coding.code = 'LOC').value.exists(), component.where(code.coding.code = 'LOC').value, component.where(code.coding.code = 'LOC').extension('http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension').value)",
   },
   travelHistoryPurpose: {
     type: "ValueX",

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -826,7 +826,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     type: "TimeX",
     path: "effective",
   },
-  noteText: { type: "string", path: "note.text.join('<br />')" },
+  noteText: { type: "string", path: "note.text" },
   valueX: {
     type: "ValueX",
     path: "value",

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -248,7 +248,13 @@ export const evaluateValue = (
     typeof path === "string" ? [path, "ValueX"] : [path.path, path.type];
 
   const originalValue =
-    evaluateOneAndCheck<ValueX>(entry, fhirPath, type, undefined, base) ?? "";
+    evaluateOneAndCheck<ValueX | Period>(
+      entry,
+      fhirPath,
+      type,
+      undefined,
+      base,
+    ) ?? "";
 
   if (
     typeof originalValue === "string" &&

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -248,13 +248,7 @@ export const evaluateValue = (
     typeof path === "string" ? [path, "ValueX"] : [path.path, path.type];
 
   const originalValue =
-    evaluateOneAndCheck<ValueX>(
-      entry,
-      fhirPath,
-      type,
-      undefined,
-      base,
-    ) ?? "";
+    evaluateOneAndCheck<ValueX>(entry, fhirPath, type, undefined, base) ?? "";
 
   if (
     typeof originalValue === "string" &&

--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -248,7 +248,7 @@ export const evaluateValue = (
     typeof path === "string" ? [path, "ValueX"] : [path.path, path.type];
 
   const originalValue =
-    evaluateOneAndCheck<ValueX | Period>(
+    evaluateOneAndCheck<ValueX>(
       entry,
       fhirPath,
       type,
@@ -287,12 +287,12 @@ export const evaluateValue = (
     value = range || originalValue.text || "";
   } else if (isReference(originalValue, originalValuePath)) {
     value = formatReference(originalValue) || "";
+  } else if (isAddress(originalValue, originalValuePath)) {
+    value = formatAddress(originalValue);
   } else if (isPeriod(originalValue, originalValuePath)) {
     // Note: there are two period formatters, start/end is more commonly used, but
     // we may need to think in the future about making this more flexible
     value = formatStartEndDateTime(originalValue);
-  } else if (isAddress(originalValue, originalValuePath)) {
-    value = formatAddress(originalValue);
   } else if (typeof originalValue === "object") {
     console.error(`Not implemented for ${originalValuePath}`);
   }

--- a/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
@@ -259,8 +259,7 @@ export const returnProblemsTable = (
     { columnName: "Onset Age", infoPath: "activeProblemsOnsetAge" },
     {
       columnName: "Comments",
-      infoPath: "noteText",
-      applyToValue: (v) => <FieldValue>{safeParse(v)}</FieldValue>,
+      evaluateEntry: evaluateCommentNotes,
       hiddenBaseText: "comment",
     },
   ];
@@ -288,6 +287,13 @@ export const returnProblemsTable = (
       fixed={false}
     />
   );
+};
+
+const evaluateCommentNotes = (entry: Element) => {
+  const notes = evaluateAll(entry, fhirPathMappings.noteText);
+  if (notes.length === 0) return "";
+
+  return <FieldValue>{safeParse(notes.join("<br />"))}</FieldValue>;
 };
 
 type ConditionWithFormattedOnsetAge = Omit<Condition, "onsetAge"> & {
@@ -692,7 +698,9 @@ export const returnMedicationsTable = (fhirBundle: Bundle) => {
           {
             title: "Text",
             value:
-              evaluateValue(medicationStatement, fhirPathMappings.noteText) ||
+              evaluateAll(medicationStatement, fhirPathMappings.noteText).join(
+                "\n",
+              ) ||
               noData,
           },
         ];

--- a/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/clinicalInfoService.tsx
@@ -700,8 +700,7 @@ export const returnMedicationsTable = (fhirBundle: Bundle) => {
             value:
               evaluateAll(medicationStatement, fhirPathMappings.noteText).join(
                 "\n",
-              ) ||
-              noData,
+              ) || noData,
           },
         ];
 

--- a/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/labsService.tsx
@@ -7,6 +7,7 @@ import {
   Composition,
   Device,
   DiagnosticReport,
+  Element,
   Observation,
   Organization,
   Specimen,
@@ -487,9 +488,8 @@ export const evaluateDiagnosticReportData = (
     },
     {
       columnName: "Lab Comment",
-      infoPath: "noteText",
+      evaluateEntry: evaluateLabCommentNotes,
       hiddenBaseText: "comment",
-      applyToValue: (v) => <FieldValue>{safeParse(v)}</FieldValue>,
       className: "minw-10 width-20",
     },
   ];
@@ -513,6 +513,13 @@ export const evaluateDiagnosticReportData = (
       />
     );
   }
+};
+
+const evaluateLabCommentNotes = (entry: Element) => {
+  const notes = evaluateAll(entry, fhirPathMappings.noteText);
+  if (notes.length === 0) return "";
+
+  return <FieldValue>{safeParse(notes.join("<br />"))}</FieldValue>;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/services/socialHistoryService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/socialHistoryService.tsx
@@ -1,5 +1,8 @@
 import {
+  Address,
   Bundle,
+  CodeableConcept,
+  Coding,
   Element,
   Observation,
   RelatedPerson,
@@ -11,6 +14,8 @@ import { HtmlTableJsonRow } from "@/app/services/htmlTableService";
 import { JsonTable } from "@/app/view-data/components/JsonTable";
 
 import {
+  formatAddress,
+  formatCoding,
   formatCodeableConcept,
   formatCurrentAddress,
   formatPatientContactList,
@@ -22,7 +27,7 @@ import {
   evaluateReference,
   evaluateValue,
 } from "@/app/utils/evaluate";
-import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
+import fhirPathMappings, { ValueX } from "@/app/utils/evaluate/fhir-paths";
 import { toSentenceCase } from "@/app/utils/format-utils";
 import {
   DataDisplay,
@@ -363,7 +368,7 @@ export const evaluateTravelHistoryTable = (fhirBundle: Bundle) => {
   const columns: ColumnInfoInput[] = [
     {
       columnName: "Location",
-      infoPath: "travelHistoryLocation",
+      evaluateEntry: evaluateTravelHistoryLocation,
     },
     {
       columnName: "Date",
@@ -383,6 +388,52 @@ export const evaluateTravelHistoryTable = (fhirBundle: Bundle) => {
   return (
     <EvaluateTable resources={travelHistoryObservations} columns={columns} />
   );
+};
+
+const evaluateTravelHistoryLocation = (travelObs: Element): string => {
+  return evaluateAll(travelObs, fhirPathMappings.travelHistoryLocation)
+    .map(formatTravelHistoryLocation)
+    .map((location) => location.trim())
+    .filter(Boolean)
+    .join(", ");
+};
+
+const formatTravelHistoryLocation = (location: ValueX): string => {
+  if (
+    typeof location === "string" ||
+    typeof location === "number" ||
+    typeof location === "boolean"
+  ) {
+    return location.toString();
+  }
+
+  if (isAddress(location)) {
+    return formatAddress(location);
+  }
+
+  if (isCodeableConcept(location)) {
+    return formatCodeableConcept(location) ?? "";
+  }
+
+  if (isCoding(location)) {
+    return formatCoding(location) ?? "";
+  }
+
+  return "";
+};
+
+const isAddress = (value: object): value is Address => {
+  return ["line", "city", "state", "postalCode", "district", "country"].some(
+    (key) => key in value,
+  );
+};
+
+const isCodeableConcept = (value: object): value is CodeableConcept => {
+  return "text" in value || ("coding" in value && Array.isArray(value.coding));
+};
+
+const isCoding = (value: object): value is Coding => {
+  return ["code", "display", "system"].some((key) => key in value);
 };
 
 const evaluateTravelHistoryDetails = (

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
@@ -166,6 +166,8 @@ describe("Render Medications table", () => {
     );
 
     expect(medicationDetails).toBeVisible();
-    expect(medicationDetails?.textContent).toContain("First medication note\nSecond medication note");
+    expect(medicationDetails?.textContent).toContain(
+      "First medication note\nSecond medication note",
+    );
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
@@ -3,7 +3,10 @@ import { Bundle } from "fhir/r4";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
 import { evaluateAll } from "@/app/utils/evaluate";
-import { returnProblemsTable } from "@/app/view-data/services/clinicalInfoService";
+import {
+  returnMedicationsTable,
+  returnProblemsTable,
+} from "@/app/view-data/services/clinicalInfoService";
 import BundleNoActiveProblems from "@/../../../test-data/fhir/BundleNoActiveProblems.json";
 
 describe("Render Active Problem table", () => {
@@ -92,5 +95,77 @@ describe("Render Active Problem table", () => {
 
     expect(comments?.textContent).toContain("First active problem note");
     expect(comments?.textContent).toContain("Second active problem note");
+    expect(comments?.querySelectorAll("br")).toHaveLength(1);
+  });
+});
+
+describe("Render Medications table", () => {
+  it("should display multiple notes for a medication", () => {
+    const bundleWithMultipleNotes: Bundle = {
+      resourceType: "Bundle",
+      type: "document",
+      entry: [
+        {
+          resource: {
+            resourceType: "Composition",
+            id: "composition-with-medication",
+            status: "final",
+            type: {
+              coding: [{ code: "34133-9", system: "http://loinc.org" }],
+            },
+            date: "2026-01-01",
+            author: [{ reference: "Practitioner/example" }],
+            title: "Test composition",
+            section: [
+              {
+                code: {
+                  coding: [{ code: "10160-0", system: "http://loinc.org" }],
+                },
+                entry: [
+                  { reference: "MedicationStatement/medication-with-notes" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          resource: {
+            resourceType: "MedicationStatement",
+            id: "medication-with-notes",
+            status: "active",
+            medicationReference: { reference: "Medication/test-medication" },
+            subject: {
+              reference: "Patient/example",
+            },
+            note: [
+              { text: "First medication note" },
+              { text: "Second medication note" },
+            ],
+          },
+        },
+        {
+          resource: {
+            resourceType: "Medication",
+            id: "test-medication",
+            code: { text: "Test medication" },
+          },
+        },
+      ],
+    };
+
+    render(returnMedicationsTable(bundleWithMultipleNotes));
+
+    const medicationButton = screen.getByRole("button", {
+      name: /test medication/i,
+    });
+
+    fireEvent.click(medicationButton);
+
+    const medicationDetails = document.getElementById(
+      medicationButton.getAttribute("aria-controls") ?? "",
+    );
+
+    expect(medicationDetails).toBeVisible();
+    expect(medicationDetails?.textContent).toContain("First medication note\nSecond medication note");
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/clinicalInfoService.test.ts
@@ -1,3 +1,4 @@
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Bundle } from "fhir/r4";
 import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
@@ -17,5 +18,79 @@ describe("Render Active Problem table", () => {
       ),
     );
     expect(actual).toBeUndefined();
+  });
+
+  it("should display multiple notes for an active problem", () => {
+    const bundleWithMultipleNotes: Bundle = {
+      resourceType: "Bundle",
+      type: "document",
+      entry: [
+        {
+          resource: {
+            resourceType: "Condition",
+            id: "active-problem-with-notes",
+            category: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+                    code: "problem-item-list",
+                  },
+                ],
+              },
+            ],
+            code: {
+              coding: [
+                {
+                  system: "http://snomed.info/sct",
+                  code: "386661006",
+                  display: "Fever",
+                },
+              ],
+            },
+            clinicalStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                  code: "active",
+                  display: "Active",
+                },
+              ],
+            },
+            subject: {
+              reference: "Patient/example",
+            },
+            note: [
+              { text: "First active problem note" },
+              { text: "Second active problem note" },
+            ],
+          },
+        },
+      ],
+    };
+    const fhirIndex = getFhirIndex(bundleWithMultipleNotes);
+
+    render(
+      returnProblemsTable(
+        bundleWithMultipleNotes,
+        fhirIndex,
+        evaluateAll(bundleWithMultipleNotes, fhirPathMappings.activeProblems),
+      ),
+    );
+
+    const commentButton = screen.getByRole("button", {
+      name: /view comment/i,
+    });
+
+    fireEvent.click(commentButton);
+
+    const comments = document.getElementById(
+      commentButton.getAttribute("aria-controls") ?? "",
+    );
+
+    expect(comments?.textContent).toContain("First active problem note");
+    expect(comments?.textContent).toContain("Second active problem note");
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
@@ -110,11 +110,7 @@ describe("Travel History", () => {
 
     render(evaluateTravelHistoryTable(bundleWithMultipleTravelLocations));
 
-    expect(
-      screen.getByText(
-        "Argentina, Brazil",
-      ),
-    ).toBeTruthy();
+    expect(screen.getByText("Argentina, Brazil")).toBeTruthy();
   });
   it("should display nothing when no travel history is available", () => {
     expect(evaluateTravelHistoryTable({} as Bundle)).toBeUndefined();

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
@@ -39,6 +39,83 @@ describe("Travel History", () => {
     );
     expect(container).toMatchSnapshot();
   });
+  it("should join multiple locations on a travel observation", () => {
+    const bundleWithMultipleTravelLocations: Bundle = {
+      resourceType: "Bundle",
+      type: "document",
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "multi-location-travel",
+            code: {
+              coding: [
+                {
+                  system: "http://snomed.info/sct",
+                  code: "420008001",
+                  display: "Travel",
+                },
+              ],
+              text: "Travel History",
+            },
+            status: "final",
+            component: [
+              {
+                code: {
+                  coding: [
+                    {
+                      system:
+                        "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      code: "LOC",
+                      display: "Location",
+                    },
+                  ],
+                },
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: "urn:oid:1.0.3166.1",
+                      code: "AR",
+                      display: "Argentina",
+                    },
+                  ],
+                },
+              },
+              {
+                code: {
+                  coding: [
+                    {
+                      system:
+                        "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      code: "LOC",
+                      display: "Location",
+                    },
+                  ],
+                },
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: "urn:oid:1.0.3166.1",
+                      code: "BRA",
+                      display: "Brazil",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    render(evaluateTravelHistoryTable(bundleWithMultipleTravelLocations));
+
+    expect(
+      screen.getByText(
+        "Argentina, Brazil",
+      ),
+    ).toBeTruthy();
+  });
   it("should display nothing when no travel history is available", () => {
     expect(evaluateTravelHistoryTable({} as Bundle)).toBeUndefined();
   });


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Fixes error if there are multiple notes for an active problem or multiple locations in one travel history observation. Previously anything beyond the first instance was not displayed. Active problem notes are now delimited by newline and travel history locations are delimited by a comma.

## Related Issue

Fixes #1627

## Acceptance Criteria

- [ ] All notes should be displayed in the Active Problems Table
- [ ] All locations should appear in travel history table
- [ ] No more console errors will appear
- [ ] Add any relevant unit/snapshot tests

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
