### PR TITLE
feat: Adding Pregnancy Summary Organizer

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -6,16 +6,13 @@ import {
   Coding,
   Condition,
   ContactPoint,
-  DiagnosticReport,
   Dosage,
   EncounterParticipant,
   Extension,
   HumanName,
   Immunization,
-  MedicationStatement,
   Observation,
   ObservationReferenceRange,
-  Organization,
   PatientCommunication,
   PatientContact,
   Period,
@@ -82,6 +79,7 @@ export type PathTypes = {
   pregnancyLastLiveBirth: Observation;
   pregnancyRhType: Observation;
   pregnancyDRhSensitized: Observation;
+  pregnancySummary: Observation;
   postpartumStatus: Observation;
   patientNationality: ValueX;
   patientCountryResidence: ValueX;
@@ -395,6 +393,10 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
   pregnancyDRhSensitized: {
     type: "Observation",
     path: "entry.resource.Observation.where(code.coding.exists(system = 'http://snomed.info/sct' and code = '55607006'))",
+  },
+  pregnancySummary: {
+    type: "Reference",
+    path: "entry.resource.Observation.where(code.coding.exists(system = 'http://loinc.org' and code = '10162-6'))",
   },
 
   // eCR Metadata

--- a/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/fhir-paths.ts
@@ -395,7 +395,7 @@ const _fhirPathMappings: { [K in FhirPathKeys]: Omit<FhirPath<K>, "name"> } = {
     path: "entry.resource.Observation.where(code.coding.exists(system = 'http://snomed.info/sct' and code = '55607006'))",
   },
   pregnancySummary: {
-    type: "Reference",
+    type: "Observation",
     path: "entry.resource.Observation.where(code.coding.exists(system = 'http://loinc.org' and code = '10162-6'))",
   },
 

--- a/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
@@ -442,11 +442,11 @@ const evaluatePregnancySummary = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
 
   const columns: ColumnInfoInput[] = [
     {
-      columnName: "Context",
+      columnName: "Outcome",
       infoPath: "code",
     },
     {
-      columnName: "Value",
+      columnName: "Count",
       infoPath: "valueX",
     },
     {

--- a/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
@@ -83,6 +83,11 @@ export const evaluatePregnancyData = (
       title: "Medications Administered",
       value: evaluatePregnancyMedicationsAdministered(fhirBundle, fhirIndex),
     },
+    {
+      title: "History of Pregnancies",
+      value: evaluatePregnancySummary(fhirBundle),
+      fullWidthContent: true,
+    },
   ];
 
   return evaluateData(data);
@@ -416,4 +421,37 @@ const evaluatePregnancyMedicationsAdministered = (
   );
 
   return entries.join("\n\n");
+};
+
+const evaluatePregnancySummary = (fhirBundle: Bundle) => {
+  const observation = evaluateOne(
+    fhirBundle,
+    fhirPathMappings.pregnancySummary,
+  );
+
+  const pregnancySummaryObs = evaluateAllReferences<Observation>(
+    observation,
+    fhirPathMappings.hasMember,
+  );
+
+  console.log(pregnancySummaryObs);
+
+  if (!pregnancySummaryObs.length) return undefined;
+
+  const columns: ColumnInfoInput[] = [
+    {
+      columnName: "Context",
+      infoPath: "code",
+    },
+    {
+      columnName: "Value",
+      infoPath: "valueX",
+    },
+    {
+      columnName: "Date",
+      infoPath: "effectiveX",
+    },
+  ];
+
+  return <EvaluateTable resources={pregnancySummaryObs} columns={columns} />;
 };

--- a/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/pregnancyInfoService.tsx
@@ -85,7 +85,7 @@ export const evaluatePregnancyData = (
     },
     {
       title: "History of Pregnancies",
-      value: evaluatePregnancySummary(fhirBundle),
+      value: evaluatePregnancySummary(fhirBundle, fhirIndex),
       fullWidthContent: true,
     },
   ];
@@ -423,20 +423,22 @@ const evaluatePregnancyMedicationsAdministered = (
   return entries.join("\n\n");
 };
 
-const evaluatePregnancySummary = (fhirBundle: Bundle) => {
+const evaluatePregnancySummary = (fhirBundle: Bundle, fhirIndex: FhirIndex) => {
   const observation = evaluateOne(
     fhirBundle,
     fhirPathMappings.pregnancySummary,
   );
 
-  const pregnancySummaryObs = evaluateAllReferences<Observation>(
-    observation,
-    fhirPathMappings.hasMember,
-  );
+  const pregnancySummaryObs: Observation[] = [];
 
-  console.log(pregnancySummaryObs);
+  observation?.hasMember?.forEach((memberRef) => {
+    const memberObs = evaluateReference2<Observation>(fhirIndex, memberRef);
+    if (memberObs) {
+      pregnancySummaryObs.push(memberObs);
+    }
+  });
 
-  if (!pregnancySummaryObs.length) return undefined;
+  if (!pregnancySummaryObs?.length) return undefined;
 
   const columns: ColumnInfoInput[] = [
     {

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -1302,6 +1302,25 @@ exports[`Tests for eCR Document Given no data, info message for empty sections s
                         class="section__line_gray"
                       />
                     </div>
+                    <div>
+                      <div
+                        class="grid-row"
+                      >
+                        <div
+                          class="data-title padding-right-1"
+                        >
+                          History of Pregnancies
+                        </div>
+                        <div
+                          class="grid-col maxw7 text-pre-line p-list text-italic text-base"
+                        >
+                          No data
+                        </div>
+                      </div>
+                      <div
+                        class="section__line_gray"
+                      />
+                    </div>
                   </div>
                 </div>
                 <div

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/pregnancyInfoService.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/pregnancyInfoService.test.tsx.snap
@@ -532,3 +532,156 @@ exports[`Evaluate Patient Info: Pregnancy Info should display all pregnancy data
 Start: 06/18/2017
 </div>
 `;
+
+exports[`Evaluate Patient Info: Pregnancy Info should display all pregnancy data  8`] = `
+<div>
+  <table
+    class="usa-table usa-table--borderless width-full _fixed_1khz6_1 table-caption-margin border-top border-left border-right"
+    data-testid="table"
+  >
+    <thead>
+      <tr>
+        <th
+          class="table-header"
+          scope="col"
+        >
+          Context
+        </th>
+        <th
+          class="table-header"
+          scope="col"
+        >
+          Value
+        </th>
+        <th
+          class="table-header"
+          scope="col"
+        >
+          Date
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Pregnancies
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          6
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Parity
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          2
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Abortions
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          3
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Births.term
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          2
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Births.preterm
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          0
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          [#] Births.still living
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          2
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+      <tr>
+        <td
+          class="text-top text-pre-line"
+        >
+          Previous live births now dead #
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          0
+        </td>
+        <td
+          class="text-top text-pre-line"
+        >
+          01/05/2018 10:15 AM
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/pregnancyInfoService.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/pregnancyInfoService.test.tsx.snap
@@ -545,13 +545,13 @@ exports[`Evaluate Patient Info: Pregnancy Info should display all pregnancy data
           class="table-header"
           scope="col"
         >
-          Context
+          Outcome
         </th>
         <th
           class="table-header"
           scope="col"
         >
-          Value
+          Count
         </th>
         <th
           class="table-header"

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.9 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch laura/1498-pregnancy-organizer --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch laura/1498-pregnancy-organizer --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.8.0 --depth 1 /App
 
 WORKDIR /App
 

--- a/test-data/fhir/BundlePregnancyStatus.json
+++ b/test-data/fhir/BundlePregnancyStatus.json
@@ -94,6 +94,9 @@
               },
               {
                 "reference": "MedicationAdministration/ceacfcfd-ca17-208e-3425-119c3a64ce92"
+              },
+              {
+                "reference": "Observation/133a1e3c-6196-f26a-b677-408228cf6d9b"
               }
             ]
           }
@@ -915,6 +918,330 @@
         "meta": {
           "source": "ecr"
         }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:133a1e3c-6196-f26a-b677-408228cf6d9b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "133a1e3c-6196-f26a-b677-408228cf6d9b",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:0a648e8a-c61c-46dd-bd0c-3081db0a9f66"
+          }
+        ],
+        "status": "preliminary",
+        "code": {
+          "coding": [
+            {
+              "code": "10162-6",
+              "system": "http://loinc.org",
+              "display": "History of pregnancies Narrative"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "hasMember": [
+          {
+            "reference": "Observation/5f32e660-c236-709d-95e7-9885d71726ea"
+          },
+          {
+            "reference": "Observation/d3ed4b69-b29f-7ea0-fc02-ce121aec5644"
+          },
+          {
+            "reference": "Observation/ebcebb42-7f64-5d9e-5876-3d0bc0425d62"
+          },
+          {
+            "reference": "Observation/c0820644-f1cf-d7c7-8166-e564f7f09c31"
+          },
+          {
+            "reference": "Observation/89743fcb-9f3c-cddb-2651-eba9fe440560"
+          },
+          {
+            "reference": "Observation/84ae9bf5-c9bb-f29f-1294-02d97e5783c1"
+          },
+          {
+            "reference": "Observation/1bd9fc99-056d-f6f7-cce9-764ef9e36945"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5f32e660-c236-709d-95e7-9885d71726ea",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5f32e660-c236-709d-95e7-9885d71726ea",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:18701808-d4cb-4a6c-b10b-4eaeb66f1158"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11996-6",
+              "system": "http://loinc.org",
+              "display": "[#] Pregnancies"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 6
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d3ed4b69-b29f-7ea0-fc02-ce121aec5644",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "d3ed4b69-b29f-7ea0-fc02-ce121aec5644",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:789ac49c-dc03-452c-b9ca-03d3e7e47053"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11977-6",
+              "system": "http://loinc.org",
+              "display": "[#] Parity"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 2
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ebcebb42-7f64-5d9e-5876-3d0bc0425d62",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ebcebb42-7f64-5d9e-5876-3d0bc0425d62",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:24b29bc7-fb9b-4e63-8959-d11eaddd278d"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11612-9",
+              "system": "http://loinc.org",
+              "display": "[#] Abortions"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 3
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c0820644-f1cf-d7c7-8166-e564f7f09c31",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c0820644-f1cf-d7c7-8166-e564f7f09c31",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:afa83ee4-6f90-4dc1-82c7-07e76c913633"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11639-2",
+              "system": "http://loinc.org",
+              "display": "[#] Births.term"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 2
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:89743fcb-9f3c-cddb-2651-eba9fe440560",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "89743fcb-9f3c-cddb-2651-eba9fe440560",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:94fb02ab-1ea8-4931-bab3-8f976bcd776a"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11637-6",
+              "system": "http://loinc.org",
+              "display": "[#] Births.preterm"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 0
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:84ae9bf5-c9bb-f29f-1294-02d97e5783c1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "84ae9bf5-c9bb-f29f-1294-02d97e5783c1",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:ddecefa4-702b-49ab-b25b-5be78e5fc5b0"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11638-4",
+              "system": "http://loinc.org",
+              "display": "[#] Births.still living"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 2
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1bd9fc99-056d-f6f7-cce9-764ef9e36945",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1bd9fc99-056d-f6f7-cce9-764ef9e36945",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"],
+          "source": "ecr"
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:40c2a16f-8b4f-42aa-bb8e-fa96c1e5e5d3"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "68496-9",
+              "system": "http://loinc.org",
+              "display": "Previous live births now dead #"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueInteger": 0
       }
     }
   ]


### PR DESCRIPTION
## Summary

Initial draft of pregnancy organizer UI (History of Pregnancies):
<img width="3182" height="1646" alt="image" src="https://github.com/user-attachments/assets/05af2c09-30d7-4cd0-9c1b-20117b2691b5" />


## Related Issue

Fixes #1498 

## Acceptance Criteria

- [x]  Field should be converted to FHIR (PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/140)
- [x]  Field should be added to the eCR Viewer
- [x]  Any relevant unit/snapshot tests should be added

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
