### PR TITLE
feat: Add admin hierarchy Pt.2 - Create User

### DIFF
--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -14,6 +14,8 @@ on:
   push:
     branches:
       - main
+      # TODO ANGELA: Remove before merging to main
+      - angela/1636-admin-hierarchy-pt2-create-user 
     paths-ignore:
       - pyproject.toml
   workflow_dispatch:

--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -147,6 +147,8 @@ jobs:
           sed -i 's/AUTH_ISSUER=.*$/AUTH_ISSUER=${{ secrets.AZURE_AD_ISSUER }}/' .env.local
           sed -i 's/AUTH_ADMIN_USER=.*$/AUTH_ADMIN_USER=${{ secrets.AZURE_ADMIN_USER }}/' .env.local
           sed -i 's/AUTH_ADMIN_PASSWORD=.*$/AUTH_ADMIN_PASSWORD=${{ secrets.AZURE_ADMIN_PASSWORD }}/' .env.local
+          sed -i 's/AUTH_PROGRAM_ADMIN_USER=.*$/AUTH_PROGRAM_ADMIN_USER=${{ secrets.AZURE_PROGRAM_ADMIN_USER }}/' .env.local
+          sed -i 's/AUTH_PROGRAM_ADMIN_PASSWORD=.*$/AUTH_PROGRAM_ADMIN_PASSWORD=${{ secrets.AZURE_APROGRAM_DMIN_PASSWORD }}/' .env.local
           sed -i 's/AUTH_STANDARD_USER=.*$/AUTH_STANDARD_USER=${{ secrets.AZURE_STANDARD_USER }}/' .env.local
           sed -i 's/AUTH_STANDARD_PASSWORD=.*$/AUTH_STANDARD_PASSWORD=${{ secrets.AZURE_STANDARD_PASSWORD }}/' .env.local
 

--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -148,7 +148,7 @@ jobs:
           sed -i 's/AUTH_ADMIN_USER=.*$/AUTH_ADMIN_USER=${{ secrets.AZURE_ADMIN_USER }}/' .env.local
           sed -i 's/AUTH_ADMIN_PASSWORD=.*$/AUTH_ADMIN_PASSWORD=${{ secrets.AZURE_ADMIN_PASSWORD }}/' .env.local
           sed -i 's/AUTH_PROGRAM_ADMIN_USER=.*$/AUTH_PROGRAM_ADMIN_USER=${{ secrets.AZURE_PROGRAM_ADMIN_USER }}/' .env.local
-          sed -i 's/AUTH_PROGRAM_ADMIN_PASSWORD=.*$/AUTH_PROGRAM_ADMIN_PASSWORD=${{ secrets.AZURE_APROGRAM_DMIN_PASSWORD }}/' .env.local
+          sed -i 's/AUTH_PROGRAM_ADMIN_PASSWORD=.*$/AUTH_PROGRAM_ADMIN_PASSWORD=${{ secrets.AZURE_PROGRAM_ADMIN_PASSWORD }}/' .env.local
           sed -i 's/AUTH_STANDARD_USER=.*$/AUTH_STANDARD_USER=${{ secrets.AZURE_STANDARD_USER }}/' .env.local
           sed -i 's/AUTH_STANDARD_PASSWORD=.*$/AUTH_STANDARD_PASSWORD=${{ secrets.AZURE_STANDARD_PASSWORD }}/' .env.local
 

--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -211,7 +211,7 @@ jobs:
         working-directory: ./containers/${{env.CONTAINER}}
         run: npm run local-docker:silent && ./tests/e2e/waitForUrl.sh localhost:3000/ecr-viewer/api/health-check ${{ !matrix.azure_ad  && 'localhost:8071/health/ready' || '' }}
 
-      - name: Seed standard user and COVID program
+      - name: Seed standard and program admin users, and COVID program
         working-directory: ./containers/${{env.CONTAINER}}
         run: $PLAYWRIGHT_DOCKER npm run test:e2e:seed-user-prog
 

--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -15,7 +15,7 @@ on:
     branches:
       - main
       # TODO ANGELA: Remove before merging to main
-      - angela/1636-admin-hierarchy-pt2-create-user 
+      - angela/1636-admin-hierarchy-pt2-create-user
     paths-ignore:
       - pyproject.toml
   workflow_dispatch:

--- a/containers/ecr-viewer/.env.sample
+++ b/containers/ecr-viewer/.env.sample
@@ -59,6 +59,8 @@ AUTH_ISSUER=http://localhost:8070/realms/master
 # For local testing only
 AUTH_ADMIN_USER=ecr-viewer@admin.com
 AUTH_ADMIN_PASSWORD=pw
+AUTH_PROGRAM_ADMIN_USER=ecr-viewer@programadmin.com
+AUTH_PROGRAM_ADMIN_PASSWORD=pw
 AUTH_STANDARD_USER=ecr-viewer@standard.com
 AUTH_STANDARD_PASSWORD=pw
 # AUTH_SESSION_DURATION_MIN=3

--- a/containers/ecr-viewer/README.md
+++ b/containers/ecr-viewer/README.md
@@ -74,6 +74,7 @@ To run the eCR Viewer locally:
 The default IDP is keycloak for local development. The default users are (password is `pw`):
 
 - admin: `ecr-viewer-admin`
+- program admin (access to COVID eCRs): `ecr-viewer-program-admin`
 - standard (access to COVID eCRs): `ecr-viewer-standard`
 
 ### Windows Setup

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -66,7 +66,7 @@ This table stores user information.
 | `email`              | `varchar(200)` | NOT NULL    |                   | User's email address, must be unique                            |
 | `name`               | `varchar(200)` | NULL        |                   | User's full name                                                |
 | `date_of_last_login` | `datetime`     | NULL        |                   | Date and time of user's last login                              |
-| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                            |
+| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                |
 | `status`             | `varchar(12)`  | NOT NULL    | active            | User's account status                                           |
 | `date_created`       | `datetime`     | NOT NULL    | Current timestamp | Date and time when the user record was created                  |
 | `author_uuid`        | `varchar(200)` | NOT NULL    |                   | Foreign key, references `user.uuid`, creator of the user record |

--- a/containers/ecr-viewer/guides/db-documentation.md
+++ b/containers/ecr-viewer/guides/db-documentation.md
@@ -66,7 +66,7 @@ This table stores user information.
 | `email`              | `varchar(200)` | NOT NULL    |                   | User's email address, must be unique                            |
 | `name`               | `varchar(200)` | NULL        |                   | User's full name                                                |
 | `date_of_last_login` | `datetime`     | NULL        |                   | Date and time of user's last login                              |
-| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, standard)                            |
+| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                            |
 | `status`             | `varchar(12)`  | NOT NULL    | active            | User's account status                                           |
 | `date_created`       | `datetime`     | NOT NULL    | Current timestamp | Date and time when the user record was created                  |
 | `author_uuid`        | `varchar(200)` | NOT NULL    |                   | Foreign key, references `user.uuid`, creator of the user record |

--- a/containers/ecr-viewer/keycloak/realm-export.json
+++ b/containers/ecr-viewer/keycloak/realm-export.json
@@ -668,6 +668,31 @@
       "realmRoles": ["admin", "default-roles-master"],
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "id": "1c3b6114-3c12-4ef7-95ba-a0091f506ed8",
+      "username": "ecr-viewer-program-admin",
+      "firstName": "Ecr",
+      "lastName": "Program-Admin",
+      "email": "ecr-viewer@programadmin.com",
+      "emailVerified": true,
+      "createdTimestamp": 1732143781841,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "c28534a5-f006-4c8d-9b2a-d1aa9b257abg",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1732143832208,
+          "value": "pw"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": ["admin", "default-roles-master"],
+      "notBefore": 0,
+      "groups": []
     }
   ],
   "localizationTexts": {},

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -15,7 +15,7 @@ import { FormPageContent } from "@/app/components/forms/FormPageContent";
 import { ToastContext } from "@/app/components/toast/ToastProvider";
 import { ServerActionResult } from "@/app/services/errorService";
 import { ListedProgramArea } from "@/app/services/programAreaService";
-import { ListedUser } from "@/app/services/userService";
+import { UserType, ListedUser } from "@/app/services/userService";
 import { AccordionItem } from "@/app/types";
 import { notEmpty } from "@/app/utils/data-utils";
 import {
@@ -24,8 +24,6 @@ import {
   toKebabCase,
   toTitleCase,
 } from "@/app/utils/format-utils";
-
-export type UserType = "admin" | "standard";
 
 export interface FormProgram extends ListedProgramArea {
   checked?: boolean;
@@ -95,7 +93,9 @@ export const UserForm = ({
 
   const valid =
     !!email &&
-    (userType === "admin" || userType === "standard") &&
+    (userType === "admin" ||
+      userType === "standard" ||
+      userType === "prog_admin") &&
     !emailIsDupe;
   const touched =
     (email && email !== initValues.email) ||
@@ -189,26 +189,34 @@ const UserTypeFieldSet = ({
       </span>
       {[
         {
-          name: "admin",
+          label: "Admin",
+          value: "admin",
           description:
             "Admins have full access to user management, program management, and the eCR Library",
         },
         {
-          name: "standard",
+          label: "Program Admin",
+          value: "prog_admin",
+          description:
+            "Program Admins have limited access to user management, program management, and the eCR Library",
+        },
+        {
+          label: "Standard",
+          value: "standard",
           description:
             "Standard users can only use the eCR Library with limited access to program area(s)",
         },
       ].map((option) => (
         <Radio
-          key={option.name}
-          label={toTitleCase(option.name)}
+          key={option.value}
+          label={option.label}
           labelDescription={option.description}
           type="radio"
           required={true}
           name="userType"
-          id={`userType-${option.name}`}
-          value={option.name}
-          checked={userType === option.name}
+          id={`userType-${option.value}`}
+          value={option.value}
+          checked={userType === option.value}
           onChange={(e) => setUserType(e.target.value as UserType)}
         />
       ))}
@@ -231,7 +239,8 @@ export const ProgramFieldSet = ({
   const [expandedPrograms, setExpandedPrograms] = useState<
     Record<string, boolean>
   >(valsToBoolean(programs, false));
-  const isStandardUser = userType === "standard";
+  const isProgramLevelUser =
+    userType === "prog_admin" || userType === "standard";
 
   const accordionItems: AccordionItem[] = programs.map((program) => {
     const { name, conditions } = program;
@@ -253,12 +262,12 @@ export const ProgramFieldSet = ({
       checkboxGroup: "program",
       checkboxLabel: `Select ${program.name}`,
       isChecked: program.checked === true,
-      onChecked: isStandardUser
+      onChecked: isProgramLevelUser
         ? (checked: boolean) => {
             setPrograms(
               programs.map((c) =>
-                c.uuid === program.uuid ? { ...c, checked } : c,
-              ),
+                c.uuid === program.uuid ? { ...c, checked } : c
+              )
             );
           }
         : undefined,
@@ -268,14 +277,14 @@ export const ProgramFieldSet = ({
   return (
     <FieldSet legend="Program area access">
       <span>
-        {isStandardUser ? (
+        {isProgramLevelUser ? (
           <>Select one or more program areas</>
         ) : (
           <>Admins will be able to see all program areas and conditions</>
         )}
       </span>
 
-      {isStandardUser && (
+      {isProgramLevelUser && (
         <>
           <p className="text-bold font-size-md">
             {numProgramsSelected} program area{makePlural(numProgramsSelected)}{" "}
@@ -295,7 +304,7 @@ export const ProgramFieldSet = ({
                     programs.map((c) => ({
                       ...c,
                       checked,
-                    })),
+                    }))
                   )
                 }
                 aria-controls={programs

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -22,7 +22,6 @@ import {
   makePlural,
   stringSort,
   toKebabCase,
-  toTitleCase,
 } from "@/app/utils/format-utils";
 
 export interface FormProgram extends ListedProgramArea {
@@ -59,23 +58,25 @@ export const UserForm = ({
   submitAction,
   banner,
   formTouchedMsg,
+  isLoggedInUserAdmin,
 }: {
   action: string;
   initValues: FormValues;
   submitAction: (
     email: string,
     userType: UserType,
-    programs: string[],
+    programs: string[]
   ) => Promise<ServerActionResult<void>>;
   banner?: ReactNode;
   formTouchedMsg?: string;
+  isLoggedInUserAdmin: boolean;
 }) => {
   const [email, setEmail] = useState(initValues.email || "");
   const [userType, setUserType] = useState<UserType>(
-    initValues.userType || "standard",
+    initValues.userType || "standard"
   );
   const [programs, setPrograms] = useState(
-    [...initValues.programs].sort((a, b) => stringSort(a.name, b.name)),
+    [...initValues.programs].sort((a, b) => stringSort(a.name, b.name))
   );
 
   const { createToast } = React.useContext(ToastContext);
@@ -91,12 +92,11 @@ export const UserForm = ({
     .filter((e) => e !== initValues.email?.toLowerCase())
     .includes(email.toLowerCase());
 
-  const valid =
-    !!email &&
-    (userType === "admin" ||
-      userType === "standard" ||
-      userType === "prog_admin") &&
-    !emailIsDupe;
+  const isValidUserType = isLoggedInUserAdmin
+    ? ["admin", "prog_admin", "standard"].includes(userType)
+    : ["prog_admin", "standard"].includes(userType);
+  const valid = !!email && isValidUserType && !emailIsDupe;
+
   const touched =
     (email && email !== initValues.email) ||
     userType !== (initValues.userType || "standard") ||
@@ -116,7 +116,7 @@ export const UserForm = ({
         const res = await submitAction(
           email.trim(),
           userType,
-          userType === "admin" ? [] : selectedPrograms, // admins should not be saved with assigned programs
+          userType === "admin" ? [] : selectedPrograms // admins should not be saved with assigned programs
         );
         if (!res.error)
           createToast(`${email.trim()} successfully saved`, "success");
@@ -128,7 +128,11 @@ export const UserForm = ({
         setEmail={setEmail}
         emailIsDupe={emailIsDupe}
       />
-      <UserTypeFieldSet userType={userType} setUserType={setUserType} />
+      <UserTypeFieldSet
+        userType={userType}
+        setUserType={setUserType}
+        isLoggedInUserAdmin={isLoggedInUserAdmin}
+      />
       <ProgramFieldSet
         programs={programs}
         setPrograms={setPrograms}
@@ -177,9 +181,11 @@ const EmailFieldSet = ({
 const UserTypeFieldSet = ({
   userType,
   setUserType,
+  isLoggedInUserAdmin,
 }: {
   userType: UserType;
   setUserType: (n: UserType) => void;
+  isLoggedInUserAdmin: boolean;
 }) => {
   return (
     <FieldSet legend="User type">
@@ -188,12 +194,16 @@ const UserTypeFieldSet = ({
         <RequiredMarker />
       </span>
       {[
-        {
-          label: "Admin",
-          value: "admin",
-          description:
-            "Admins have full access to user management, program management, and the eCR Library",
-        },
+        ...(isLoggedInUserAdmin
+          ? [
+              {
+                label: "Admin",
+                value: "admin",
+                description:
+                  "Admins have full access to user management, program management, and the eCR Library",
+              },
+            ]
+          : []),
         {
           label: "Program Admin",
           value: "prog_admin",

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -18,11 +18,7 @@ import { ListedProgramArea } from "@/app/services/programAreaService";
 import { UserType, ListedUser } from "@/app/services/userService";
 import { AccordionItem } from "@/app/types";
 import { notEmpty } from "@/app/utils/data-utils";
-import {
-  makePlural,
-  stringSort,
-  toKebabCase,
-} from "@/app/utils/format-utils";
+import { makePlural, stringSort, toKebabCase } from "@/app/utils/format-utils";
 
 export interface FormProgram extends ListedProgramArea {
   checked?: boolean;
@@ -65,7 +61,7 @@ export const UserForm = ({
   submitAction: (
     email: string,
     userType: UserType,
-    programs: string[]
+    programs: string[],
   ) => Promise<ServerActionResult<void>>;
   banner?: ReactNode;
   formTouchedMsg?: string;
@@ -73,10 +69,10 @@ export const UserForm = ({
 }) => {
   const [email, setEmail] = useState(initValues.email || "");
   const [userType, setUserType] = useState<UserType>(
-    initValues.userType || "standard"
+    initValues.userType || "standard",
   );
   const [programs, setPrograms] = useState(
-    [...initValues.programs].sort((a, b) => stringSort(a.name, b.name))
+    [...initValues.programs].sort((a, b) => stringSort(a.name, b.name)),
   );
 
   const { createToast } = React.useContext(ToastContext);
@@ -116,7 +112,7 @@ export const UserForm = ({
         const res = await submitAction(
           email.trim(),
           userType,
-          userType === "admin" ? [] : selectedPrograms // admins should not be saved with assigned programs
+          userType === "admin" ? [] : selectedPrograms, // admins should not be saved with assigned programs
         );
         if (!res.error)
           createToast(`${email.trim()} successfully saved`, "success");
@@ -276,8 +272,8 @@ export const ProgramFieldSet = ({
         ? (checked: boolean) => {
             setPrograms(
               programs.map((c) =>
-                c.uuid === program.uuid ? { ...c, checked } : c
-              )
+                c.uuid === program.uuid ? { ...c, checked } : c,
+              ),
             );
           }
         : undefined,
@@ -314,7 +310,7 @@ export const ProgramFieldSet = ({
                     programs.map((c) => ({
                       ...c,
                       checked,
-                    }))
+                    })),
                   )
                 }
                 aria-controls={programs

--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -31,9 +31,10 @@ import {
 } from "@/app/utils/format-utils";
 import { ForceClient } from "@/app/view-data/components/ForceClient";
 
-const USER_TYPE_OPTIONS: Record<string, string> = {
+const USER_TYPE_FILTER_OPTIONS: Record<string, string> = {
   all: "All users",
   admin: "Admin",
+  prog_admin: "Program Admin",
   standard: "Standard",
 };
 const NO_PROGRAM_AREA_OPTION: string = "No program areas (Standard)";
@@ -86,8 +87,8 @@ export const UserTable = ({
       return false;
     }
 
-    // Standard users not assigned to any program areas
-    if (user_type === "standard" && program_areas.length === 0) {
+    // Standard users or program admins not assigned to any program areas
+    if ((user_type === "standard" || user_type === "prog_admin") && program_areas.length === 0) {
       return filterProgramAreas[NO_PROGRAM_AREA_OPTION];
     }
 
@@ -231,14 +232,14 @@ const FilterByUserType = ({
     <Filter
       isActive={true}
       type="user type"
-      title={USER_TYPE_OPTIONS[filterUserTypeOption]}
+      title={USER_TYPE_FILTER_OPTIONS[filterUserTypeOption]}
       resetHandler={() => {}}
       icon={Person}
     >
       <div className="display-flex flex-column">
         <RadioDateOptions
           groupName="user-type"
-          optionsMap={USER_TYPE_OPTIONS}
+          optionsMap={USER_TYPE_FILTER_OPTIONS}
           onChange={setFilterUserTypeOption}
           currentOption={filterUserTypeOption}
           classNames="padding-bottom-1"

--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -88,7 +88,10 @@ export const UserTable = ({
     }
 
     // Standard users or program admins not assigned to any program areas
-    if ((user_type === "standard" || user_type === "prog_admin") && program_areas.length === 0) {
+    if (
+      (user_type === "standard" || user_type === "prog_admin") &&
+      program_areas.length === 0
+    ) {
       return filterProgramAreas[NO_PROGRAM_AREA_OPTION];
     }
 

--- a/containers/ecr-viewer/src/app/admin/user/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/create/page.tsx
@@ -4,13 +4,15 @@ import { revalidatePath } from "next/cache";
 import { UserForm } from "@/app/admin/user/UserForm";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { createUserAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAdmin, listUsers } from "@/app/services/userService";
+import { notFoundUnlessAnyAdmin, listUsers, isAdmin } from "@/app/services/userService";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
  * @returns Page to create a new user
  */
 const CreateUserPage = async () => {
-  await notFoundUnlessAdmin();
+  await notFoundUnlessAnyAdmin();
+  const loggedInUser = await getLoggedInUser();
 
   const programs = await listProgramAreas();
   const users = await listUsers();
@@ -43,6 +45,7 @@ const CreateUserPage = async () => {
           </Alert>
         )
       }
+      isLoggedInUserAdmin={isAdmin(loggedInUser)}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/admin/user/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/create/page.tsx
@@ -4,7 +4,11 @@ import { revalidatePath } from "next/cache";
 import { UserForm } from "@/app/admin/user/UserForm";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { createUserAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAnyAdmin, listUsers, isAdmin } from "@/app/services/userService";
+import {
+  notFoundUnlessAnyAdmin,
+  listUsers,
+  isAdmin,
+} from "@/app/services/userService";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**

--- a/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
@@ -1,7 +1,8 @@
 import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 
-import { UserForm, UserType } from "@/app/admin/user/UserForm";
+import { UserForm } from "@/app/admin/user/UserForm";
+import { isAdmin, UserType } from "@/app/services/userService";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { updateUserAction } from "@/app/services/serverActionService";
 import {
@@ -11,6 +12,7 @@ import {
   notFoundUnlessAdmin,
 } from "@/app/services/userService";
 import { PageSearchParams } from "@/app/utils/search-param-utils";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
  * Edit a user
@@ -24,6 +26,7 @@ const EditUserPage = async ({
   searchParams: Promise<PageSearchParams>;
 }) => {
   await notFoundUnlessAdmin();
+  const currentUser = await getLoggedInUser();
   const { uuid } = await searchParams;
 
   // nothing to edit here
@@ -73,6 +76,7 @@ const EditUserPage = async ({
         });
         return { error: res.error };
       }}
+      isLoggedInUserAdmin={isAdmin(currentUser)}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/admin/user/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { deleteUserAction } from "@/app/services/serverActionService";
-import { listUsers, notFoundUnlessAdmin } from "@/app/services/userService";
+import { listUsers, notFoundUnlessAnyAdmin } from "@/app/services/userService";
 
 import { UserTable } from "./UserTable";
 
@@ -12,7 +12,7 @@ import { UserTable } from "./UserTable";
  * @returns user admin page
  */
 const UserAdminPage = async () => {
-  await notFoundUnlessAdmin();
+  await notFoundUnlessAnyAdmin();
 
   const users = await listUsers();
   const programAreas = await listProgramAreas();

--- a/containers/ecr-viewer/src/app/components/NavLinks.tsx
+++ b/containers/ecr-viewer/src/app/components/NavLinks.tsx
@@ -1,5 +1,5 @@
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
-import { isAdmin } from "@/app/services/userService";
+import { isAnyAdmin } from "@/app/services/userService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 import NavLink from "./NavLink";
@@ -19,7 +19,7 @@ const NavLinks = async () => {
 
   return (
     <div className="display-flex flex-row">
-      {isAdmin(dbUser) && (
+      {isAnyAdmin(dbUser) && (
         <>
           <NavLink href="/">eCR library</NavLink>
           <NavLink href="/admin/user">User management</NavLink>

--- a/containers/ecr-viewer/src/app/components/UserMenu.tsx
+++ b/containers/ecr-viewer/src/app/components/UserMenu.tsx
@@ -12,7 +12,7 @@ import { SignOutButton } from "./SignOutButton";
 export const USER_TYPE_DISPLAY: Record<string, string> = {
   admin: "Admin",
   prog_admin: "Program admin",
-  standard: "Standard",
+  standard: "Standard user",
 };
 
 /**

--- a/containers/ecr-viewer/src/app/components/UserMenu.tsx
+++ b/containers/ecr-viewer/src/app/components/UserMenu.tsx
@@ -9,6 +9,12 @@ import { toSentenceCase } from "@/app/utils/format-utils";
 import { Person } from "./Icon";
 import { SignOutButton } from "./SignOutButton";
 
+export const USER_TYPE_DISPLAY: Record<string, string> = {
+  admin: "Admin",
+  prog_admin: "Program admin",
+  standard: "Standard",
+};
+
 /**
  * User Menu component for the eCR Viewer project.
  * This component renders a dropdown menu that contains user information
@@ -73,7 +79,9 @@ const UserMenu = ({
       {showMenu && (
         <div ref={menuRef} className="user-menu">
           <p className="user-email">{user.email}</p>
-          <p className="user-role">{toSentenceCase(user.user_type)}</p>
+          <p className="user-role">
+            {user.user_type && USER_TYPE_DISPLAY[user.user_type]}
+          </p>
           <p className="version-number">version {version}</p>
           <SignOutButton />
         </div>

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -13,7 +13,7 @@ import { stringSort } from "@/app/utils/format-utils";
 
 import { audit } from "./auditLogService";
 import { UserFacingError } from "./errorService";
-import { getCheckAdmin } from "./userService";
+import { getCheckAdmin, getCheckAnyAdmin, isProgramAdmin } from "./userService";
 
 /**
  * Create a program area with the given name. The currently logged in user
@@ -208,20 +208,31 @@ export type ListedProgramArea = ProgramArea & {
 };
 
 /**
- * List program areas. The logged in user must be an admin.
+ * List program areas. The logged in user must be an admin or a program admin.
+ * If program admin, will only list program areas they have access to.
  * @returns list of all program areas
  */
 export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
-  await getCheckAdmin("list program areas");
+  const user = await getCheckAnyAdmin("list program areas");
 
   try {
     return await getDb<Core>()
       .transaction()
       .execute(async (db) => {
-        const programAreas = await db
-          .selectFrom("program_area")
-          .selectAll()
-          .execute();
+        const programAreas =
+          isProgramAdmin(user)
+            ? await db
+                .selectFrom("program_area")
+                .innerJoin(
+                  "user_program_area",
+                  "program_area.uuid",
+                  "user_program_area.program_area_uuid"
+                )
+              .selectAll("program_area")
+              .where("user_program_area.user_uuid", "=", user.uuid)
+              .execute()
+            : await db.selectFrom("program_area").selectAll().execute(); 
+        ;
         const conditionRefs = await db
           .selectFrom("condition_reference")
           .selectAll()
@@ -232,7 +243,7 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
             ...c,
             is_duplicate: conditionRefs.some(
               ({ condition_name, code }) =>
-                c.condition_name === condition_name && c.code !== code,
+                c.condition_name === condition_name && c.code !== code
             ),
           }))
           .sort((a, b) => stringSort(a.condition_name, b.condition_name));
@@ -241,7 +252,7 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
           .map((pa) => ({
             ...pa,
             conditions: conditions.filter(
-              ({ program_area_uuid }) => program_area_uuid === pa.uuid,
+              ({ program_area_uuid }) => program_area_uuid === pa.uuid
             ),
           }))
           .sort((a, b) => stringSort(a.name, b.name));

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -219,20 +219,18 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
     return await getDb<Core>()
       .transaction()
       .execute(async (db) => {
-        const programAreas =
-          isProgramAdmin(user)
-            ? await db
-                .selectFrom("program_area")
-                .innerJoin(
-                  "user_program_area",
-                  "program_area.uuid",
-                  "user_program_area.program_area_uuid"
-                )
+        const programAreas = isProgramAdmin(user)
+          ? await db
+              .selectFrom("program_area")
+              .innerJoin(
+                "user_program_area",
+                "program_area.uuid",
+                "user_program_area.program_area_uuid",
+              )
               .selectAll("program_area")
               .where("user_program_area.user_uuid", "=", user.uuid)
               .execute()
-            : await db.selectFrom("program_area").selectAll().execute(); 
-        ;
+          : await db.selectFrom("program_area").selectAll().execute();
         const conditionRefs = await db
           .selectFrom("condition_reference")
           .selectAll()
@@ -243,7 +241,7 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
             ...c,
             is_duplicate: conditionRefs.some(
               ({ condition_name, code }) =>
-                c.condition_name === condition_name && c.code !== code
+                c.condition_name === condition_name && c.code !== code,
             ),
           }))
           .sort((a, b) => stringSort(a.condition_name, b.condition_name));
@@ -252,7 +250,7 @@ export const listProgramAreas = async (): Promise<ListedProgramArea[]> => {
           .map((pa) => ({
             ...pa,
             conditions: conditions.filter(
-              ({ program_area_uuid }) => program_area_uuid === pa.uuid
+              ({ program_area_uuid }) => program_area_uuid === pa.uuid,
             ),
           }))
           .sort((a, b) => stringSort(a.name, b.name));

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -18,7 +18,6 @@ import { audit } from "./auditLogService";
 import { UserFacingError } from "./errorService";
 import { getLoggedInUser, getUserByEmail } from "./loggedInUserService";
 
-
 export type UserType = "admin" | "prog_admin" | "standard";
 
 /**
@@ -148,7 +147,7 @@ export const hasRelevantProgramAreaAccess = async (
 export async function validateAdminUserPermissions(
   loggedInUser: User,
   userType: UserType,
-  programs: string[]
+  programs: string[],
 ) {
   if (isAdmin(loggedInUser)) return;
 
@@ -160,7 +159,7 @@ export async function validateAdminUserPermissions(
     const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, program);
     if (!hasAccess) {
       throw new UserFacingError(
-        "Program admins cannot create users outside of their program areas"
+        "Program admins cannot create users outside of their program areas",
       );
     }
   }

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -18,6 +18,9 @@ import { audit } from "./auditLogService";
 import { UserFacingError } from "./errorService";
 import { getLoggedInUser, getUserByEmail } from "./loggedInUserService";
 
+
+export type UserType = "admin" | "prog_admin" | "standard";
+
 /**
  * @param user User to check is an admin
  * @returns true is the user both exists and is an admin, false otherwise
@@ -199,7 +202,7 @@ export const createUser = audit(
       programs,
     }: {
       email: string;
-      userType: "admin" | "standard";
+      userType: UserType;
       programs: string[];
     },
     trx: Transaction<Core>,
@@ -256,7 +259,7 @@ export const createInitialAdminUser = audit(
 const createUserQuery = async (
   db: Transaction<Core>,
   email: string,
-  user_type: "admin" | "standard",
+  user_type: UserType,
   uuid: string,
   author_uuid: string,
 ) => {

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -132,6 +132,41 @@ export const hasRelevantProgramAreaAccess = async (
 };
 
 /**
+ * Validates whether a user has permission to manage another user's role and
+ * program area assignments.
+ *
+ * Admin users bypass all restrictions. Program admins cannot manage admin users
+ * and can only assign users to program areas they have access to.
+ *
+ * @param loggedInUser - The user performing the user management action.
+ * @param userType - The user type being assigned to the managed user.
+ * @param programs - The program area IDs being assigned to the managed user.
+ *
+ * @throws {UserFacingError} If a program admin attempts to manage an admin user
+ * or assign a user to a program area they do not have access to.
+ */
+export async function validateAdminUserPermissions(
+  loggedInUser: User,
+  userType: UserType,
+  programs: string[]
+) {
+  if (isAdmin(loggedInUser)) return;
+
+  if (userType === "admin") {
+    throw new UserFacingError("Program admins cannot create new admins.");
+  }
+
+  for (const program of programs) {
+    const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, program);
+    if (!hasAccess) {
+      throw new UserFacingError(
+        "Program admins cannot create users outside of their program areas"
+      );
+    }
+  }
+}
+
+/**
  * Given an ecrId return not found if the user is not authorized to see it.
  * @param ecrId ID of the ecr to authorize
  * @returns whether the logged in user can see this eCR
@@ -207,7 +242,9 @@ export const createUser = audit(
     },
     trx: Transaction<Core>,
   ): Promise<string> => {
-    const creatingUser = await getCheckAdmin("create new users");
+    const creatingUser = await getCheckAnyAdmin("create new users");
+    await validateAdminUserPermissions(creatingUser, userType, programs);
+
     try {
       const uuid = await createUserQuery(
         trx,
@@ -475,7 +512,7 @@ export type ListedUser = User & { program_areas: NamedUserProgramArea[] };
  * @returns list of all active users
  */
 export const listUsers = async (): Promise<ListedUser[]> => {
-  await getCheckAdmin("list users");
+  await getCheckAnyAdmin("list users");
 
   try {
     return await getDb<Core>()

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -97,16 +97,20 @@ export const getCheckAnyAdmin = async (actionDesc: string): Promise<User> => {
  * Checks that 1) user has admin or program-level role, and
  * 2) if program-level role, checks they have access to the relevant program area.
  * @param user User to check access for (defaults to logged in user if undefined)
- * @param programAreaUuid UUID of the program area to check
- * @returns whether the user has access to the relevant program area
+ * @param programAreaUuids UUIDs of the program areas to check
+ * @returns whether the user has access to all relevant program areas
  */
 export const hasRelevantProgramAreaAccess = async (
   user: User | undefined,
-  programAreaUuid: string,
+  programAreaUuids: string[],
 ): Promise<boolean> => {
   const targetUser = user ?? (await getLoggedInUser());
   if (!targetUser || targetUser.status !== "active") {
     return false;
+  }
+
+  if (programAreaUuids.length === 0) {
+    return true;
   }
 
   if (targetUser.user_type === "admin") {
@@ -121,10 +125,14 @@ export const hasRelevantProgramAreaAccess = async (
       .selectFrom("user_program_area")
       .select("user_program_area.program_area_uuid")
       .where("user_uuid", "=", targetUser.uuid)
-      .where("program_area_uuid", "=", programAreaUuid)
-      .executeTakeFirst();
+      .where("program_area_uuid", "in", programAreaUuids)
+      .execute();
 
-    return !!res;
+    const accessibleProgramAreas = new Set(
+      res.map(({ program_area_uuid }) => program_area_uuid),
+    );
+
+    return programAreaUuids.every((uuid) => accessibleProgramAreas.has(uuid));
   }
 
   return false;
@@ -155,13 +163,11 @@ export async function validateAdminUserPermissions(
     throw new UserFacingError("Program admins cannot create new admins.");
   }
 
-  for (const program of programs) {
-    const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, program);
-    if (!hasAccess) {
-      throw new UserFacingError(
-        "Program admins cannot create users outside of their program areas",
-      );
-    }
+  const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, programs);
+  if (!hasAccess) {
+    throw new UserFacingError(
+      "Program admins cannot create users outside of their program areas",
+    );
   }
 }
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -195,7 +195,7 @@ test.describe("user management page", () => {
     // filter by user type
     await page.getByLabel("Filter by user type").click();
     await expect(page.getByText("Filter by user type")).toBeVisible();
-    await page.locator('label[for="userType-admin"]').click();
+    await page.locator('label[for="user-type-admin"]').click();
     await expect(
       page.getByRole("table").getByText("Standard"),
     ).not.toBeVisible();
@@ -366,7 +366,7 @@ const createRandomUser = async (
   await page.getByLabel("Email").fill(email);
 
   if (userType === "admin") {
-    await page.locator('label[for="userType-admin"]').click();
+    await page.locator('label[for="user-type-admin"]').click();
   }
 
   if (userType === "prog_admin" || userType === "standard") {

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -195,7 +195,7 @@ test.describe("user management page", () => {
     // filter by user type
     await page.getByLabel("Filter by user type").click();
     await expect(page.getByText("Filter by user type")).toBeVisible();
-    await page.locator('label[for="user-type-admin"]').click();
+    await page.getByLabel(/^Admin\b/).dispatchEvent("click");
     await expect(
       page.getByRole("table").getByText("Standard"),
     ).not.toBeVisible();
@@ -366,7 +366,9 @@ const createRandomUser = async (
   await page.getByLabel("Email").fill(email);
 
   if (userType === "admin") {
-    await page.locator('label[for="user-type-admin"]').click();
+    const adminRadio = page.getByLabel(/^Admin\b/);
+    await adminRadio.scrollIntoViewIfNeeded();
+    await adminRadio.dispatchEvent("click");
   }
 
   if (userType === "prog_admin" || userType === "standard") {

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -281,7 +281,52 @@ test.describe("user management page", () => {
     await expect(page.getByText(userStandard3)).toBeVisible();
   });
 
-  test("it should not show to non-admin", async ({ page }) => {
+  test("program admin: has restricted user creation permissions", async ({
+    page,
+    browserName,
+  }) => {
+    // Admin creates random program
+    await logIn(page);
+    const program1 = await getRandomProgramArea(page, ["COVID"]);
+
+    // Log in as program admin.
+    await page.context().clearCookies();
+    await logIn(page, {
+      userType: "PROGRAM_ADMIN",
+    });
+
+    await page.goto("/ecr-viewer/admin/user/create");
+    expect(page.getByRole("heading", { name: "Create user" }));
+
+    // Program admins can only create program-restricted users
+    await expect(page.locator("#userType-admin")).not.toBeVisible();
+    await expect(page.getByLabel("Program Admin")).toBeVisible();
+    await expect(page.getByLabel("Standard")).toBeVisible();
+
+    // Program admins can only create users for their program areas
+    await expect(
+      page.getByLabel(`Select ${program1}`, { exact: true })
+    ).not.toBeVisible();
+    await expect(
+      page.getByLabel(`Select COVID`, { exact: true })
+    ).toBeVisible();
+
+    // Program admin successfully creates standard user
+    const standardUser = await createRandomUser(browserName, page, "standard", [
+      "COVID",
+    ]);
+    await page.waitForURL("/ecr-viewer/admin/user");
+    await page
+      .getByRole("combobox", { name: "Users per page" })
+      .selectOption("50"); // Increase user table pagination for testing
+    const standardRow = page
+      .getByRole("row")
+      .filter({ has: page.getByRole("cell", { name: standardUser }) });
+    await expect(standardRow.getByText("Standard")).toBeVisible();
+    await expect(standardRow.getByText("COVID")).toBeVisible();
+  });
+
+  test("should not show to standard user", async ({ page }) => {
     await logIn(page, { userType: "STANDARD" });
     await page.goto("/ecr-viewer/admin/user");
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -62,7 +62,7 @@ test.describe("user management page", () => {
     expect(accessibilityScanResultsSidePanel.violations).toEqual([]);
   });
 
-  test("should create, edit, and delete a new user", async ({
+  test("admin: should create, edit, and delete a new user", async ({
     page,
     browserName,
   }) => {
@@ -157,7 +157,10 @@ test.describe("user management page", () => {
     await page.goto("/ecr-viewer/admin/program");
   });
 
-  test("filter by user type or program area", async ({ page, browserName }) => {
+  test("admin: filter by user type or program area", async ({
+    page,
+    browserName,
+  }) => {
     await logIn(page);
 
     // Create programs
@@ -192,7 +195,7 @@ test.describe("user management page", () => {
     // filter by user type
     await page.getByLabel("Filter by user type").click();
     await expect(page.getByText("Filter by user type")).toBeVisible();
-    await page.getByLabel("Admin").dispatchEvent("click");
+    await page.locator('label[for="userType-admin"]').click();
     await expect(
       page.getByRole("table").getByText("Standard"),
     ).not.toBeVisible();
@@ -348,7 +351,7 @@ const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
 const createRandomUser = async (
   browserName: string,
   page: Page,
-  userType: string = "standard",
+  userType: "admin" | "prog_admin" | "standard" = "standard",
   programAreas: string[],
 ) => {
   await page.goto("/ecr-viewer/admin/user");
@@ -363,16 +366,17 @@ const createRandomUser = async (
   await page.getByLabel("Email").fill(email);
 
   if (userType === "admin") {
-    const adminRadio = page.getByLabel("Admin");
-    await adminRadio.dispatchEvent("click");
+    await page.locator('label[for="userType-admin"]').click();
   }
 
-  if (userType === "standard") {
-    for (const program of programAreas) {
-      const standardRadio = page.getByLabel("Standard");
-      await standardRadio.scrollIntoViewIfNeeded();
-      await standardRadio.dispatchEvent("click");
+  if (userType === "prog_admin" || userType === "standard") {
+    const userTypeRadio = page.getByLabel(
+      userType === "prog_admin" ? "Program Admin" : "Standard",
+    );
+    await userTypeRadio.scrollIntoViewIfNeeded();
+    await userTypeRadio.dispatchEvent("click");
 
+    for (const program of programAreas) {
       const checkbox = page.getByLabel(`Select ${program}`, {
         exact: true,
       });

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -366,8 +366,7 @@ const createRandomUser = async (
   await page.getByLabel("Email").fill(email);
 
   if (userType === "admin") {
-    const adminRadio = page.getByLabel(/^Admin\b/);
-    await adminRadio.scrollIntoViewIfNeeded();
+    const adminRadio = page.locator("#userType-admin");
     await adminRadio.dispatchEvent("click");
   }
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -305,10 +305,10 @@ test.describe("user management page", () => {
 
     // Program admins can only create users for their program areas
     await expect(
-      page.getByLabel(`Select ${program1}`, { exact: true })
+      page.getByLabel(`Select ${program1}`, { exact: true }),
     ).not.toBeVisible();
     await expect(
-      page.getByLabel(`Select COVID`, { exact: true })
+      page.getByLabel(`Select COVID`, { exact: true }),
     ).toBeVisible();
 
     // Program admin successfully creates standard user

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -52,12 +52,11 @@ test("seed standard and program admin user. seed covid program", async ({
 
   // Seed standard user
   if (
-    (await page.getByText(process.env.AUTH_STANDARD_USER!).all())
-      .length === 0
+    (await page.getByText(process.env.AUTH_STANDARD_USER!).all()).length === 0
   ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(
-      page.getByRole("heading", { name: "Create user" })
+      page.getByRole("heading", { name: "Create user" }),
     ).toBeVisible();
 
     await page.getByLabel("Email").fill(process.env.AUTH_STANDARD_USER!);
@@ -84,7 +83,7 @@ test("seed standard and program admin user. seed covid program", async ({
   ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(
-      page.getByRole("heading", { name: "Create user" })
+      page.getByRole("heading", { name: "Create user" }),
     ).toBeVisible();
 
     await page.getByLabel("Email").fill(process.env.AUTH_PROGRAM_ADMIN_USER!);

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -91,7 +91,7 @@ test("seed standard and program admin user. seed covid program", async ({
     await adminRadio.scrollIntoViewIfNeeded();
     await adminRadio.dispatchEvent("click");
 
-    await page.getByRole("button", { name: "COVID", exact: true }).click();
+    await page.getByRole("button", { name: "Select COVID", exact: true }).click();
 
     await page.getByRole("button", { name: "Save user" }).first().click();
 

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -49,10 +49,12 @@ test("seed standard and program admin user. seed covid program", async ({
     page.getByRole("heading", { name: "User management" }),
   ).toBeVisible();
 
-  if ((await page.getByText("ecr-viewer@standard.com").all()).length === 0) {
+  if (
+    (await page.getByText(process.env.AUTH_STANDARD_USER!).all()).length === 0
+  ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(
-      page.getByRole("heading", { name: "Create user" }),
+      page.getByRole("heading", { name: "Create user" })
     ).toBeVisible();
 
     await page.getByLabel("Email").fill(process.env.AUTH_STANDARD_USER!);
@@ -73,11 +75,12 @@ test("seed standard and program admin user. seed covid program", async ({
   ).toBeVisible();
 
   if (
-    (await page.getByText("ecr-viewer@programadmin.com").all()).length === 0
+    (await page.getByText(process.env.AUTH_PROGRAM_ADMIN_USER!).all())
+      .length === 0
   ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(
-      page.getByRole("heading", { name: "Create user" }),
+      page.getByRole("heading", { name: "Create user" })
     ).toBeVisible();
 
     await page.getByLabel("Email").fill(process.env.AUTH_PROGRAM_ADMIN_USER!);

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { logIn } from "./utils";
 
 // This test is not really a test, but more of a seed script to add a
-// standard user with access to the covid program area. It is run as part of
+// standard user and a program admin with access to the covid program area. It is run as part of
 // the `convert-seed-data` npm script.
 
 test("seed standard user and covid program", async ({ page }) => {
@@ -56,6 +56,67 @@ test("seed standard user and covid program", async ({ page }) => {
     await page.getByLabel("Email").fill(process.env.AUTH_STANDARD_USER!);
 
     const adminRadio = page.getByLabel("Standard");
+    await adminRadio.scrollIntoViewIfNeeded();
+    await adminRadio.dispatchEvent("click");
+
+    await page.getByRole("button", { name: "Select all", exact: true }).click();
+
+    await page.getByRole("button", { name: "Save user" }).first().click();
+
+    await page.waitForURL("/ecr-viewer/admin/user");
+  }
+});
+
+test("seed program admin user", async ({ page }) => {
+  test.skip(
+    process.env.CONFIG_NAME.endsWith("INTEGRATED") &&
+      !process.env.CONFIG_NAME.endsWith("NON_INTEGRATED"),
+    "No seeding if no metadata db"
+  );
+  test.setTimeout(60000); // keycloak is slow
+  await logIn(page);
+
+  await page.goto("/ecr-viewer/admin/program");
+
+  await expect(
+    page.getByRole("heading", { name: "Program management" })
+  ).toBeVisible();
+
+  if ((await page.getByText("COVID").all()).length === 0) {
+    await page.goto("/ecr-viewer/admin/program/create");
+
+    await expect(
+      page.getByRole("heading", { name: "Create program area" })
+    ).toBeVisible();
+
+    await page.getByLabel("Program area name").fill("COVID");
+
+    await page.getByPlaceholder("Search condition or category").fill("covid");
+    await page.getByRole("button", { name: "Select all", exact: true }).click();
+
+    await page
+      .getByRole("button", { name: "Save program area" })
+      .first()
+      .click();
+
+    await page.waitForURL("/ecr-viewer/admin/program");
+  }
+
+  await page.goto("/ecr-viewer/admin/user");
+
+  await expect(
+    page.getByRole("heading", { name: "User management" })
+  ).toBeVisible();
+
+  if ((await page.getByText("ecr-viewer@program-admin.com").all()).length === 0) {
+    await page.goto("/ecr-viewer/admin/user/create");
+    await expect(
+      page.getByRole("heading", { name: "Create user" })
+    ).toBeVisible();
+
+    await page.getByLabel("Email").fill(process.env.AUTH_PROGRAM_ADMIN_USER!);
+
+    const adminRadio = page.getByLabel("Program Admin");
     await adminRadio.scrollIntoViewIfNeeded();
     await adminRadio.dispatchEvent("click");
 

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -6,13 +6,15 @@ import { logIn } from "./utils";
 // standard user and a program admin with access to the covid program area. It is run as part of
 // the `convert-seed-data` npm script.
 
-test("seed standard user and covid program", async ({ page }) => {
+test("seed standard and program admin user. seed covid program", async ({
+  page,
+}) => {
   test.skip(
     process.env.CONFIG_NAME.endsWith("INTEGRATED") &&
       !process.env.CONFIG_NAME.endsWith("NON_INTEGRATED"),
     "No seeding if no metadata db",
   );
-  test.setTimeout(60000); // keycloak is slow
+  test.setTimeout(120000); // keycloak is slow
   await logIn(page);
 
   await page.goto("/ecr-viewer/admin/program");
@@ -65,53 +67,17 @@ test("seed standard user and covid program", async ({ page }) => {
 
     await page.waitForURL("/ecr-viewer/admin/user");
   }
-});
-
-test("seed program admin user", async ({ page }) => {
-  test.skip(
-    process.env.CONFIG_NAME.endsWith("INTEGRATED") &&
-      !process.env.CONFIG_NAME.endsWith("NON_INTEGRATED"),
-    "No seeding if no metadata db"
-  );
-  test.setTimeout(60000); // keycloak is slow
-  await logIn(page);
-
-  await page.goto("/ecr-viewer/admin/program");
 
   await expect(
-    page.getByRole("heading", { name: "Program management" })
+    page.getByRole("heading", { name: "User management" }),
   ).toBeVisible();
 
-  if ((await page.getByText("COVID").all()).length === 0) {
-    await page.goto("/ecr-viewer/admin/program/create");
-
-    await expect(
-      page.getByRole("heading", { name: "Create program area" })
-    ).toBeVisible();
-
-    await page.getByLabel("Program area name").fill("COVID");
-
-    await page.getByPlaceholder("Search condition or category").fill("covid");
-    await page.getByRole("button", { name: "Select all", exact: true }).click();
-
-    await page
-      .getByRole("button", { name: "Save program area" })
-      .first()
-      .click();
-
-    await page.waitForURL("/ecr-viewer/admin/program");
-  }
-
-  await page.goto("/ecr-viewer/admin/user");
-
-  await expect(
-    page.getByRole("heading", { name: "User management" })
-  ).toBeVisible();
-
-  if ((await page.getByText("ecr-viewer@program-admin.com").all()).length === 0) {
+  if (
+    (await page.getByText("ecr-viewer@programadmin.com").all()).length === 0
+  ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(
-      page.getByRole("heading", { name: "Create user" })
+      page.getByRole("heading", { name: "Create user" }),
     ).toBeVisible();
 
     await page.getByLabel("Email").fill(process.env.AUTH_PROGRAM_ADMIN_USER!);

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -23,6 +23,7 @@ test("seed standard and program admin user. seed covid program", async ({
     page.getByRole("heading", { name: "Program management" }),
   ).toBeVisible();
 
+  // Seed COVID program area
   if ((await page.getByText("COVID").all()).length === 0) {
     await page.goto("/ecr-viewer/admin/program/create");
 
@@ -74,6 +75,7 @@ test("seed standard and program admin user. seed covid program", async ({
     page.getByRole("heading", { name: "User management" }),
   ).toBeVisible();
 
+  // Seed program admin (COVID)
   if (
     (await page.getByText(process.env.AUTH_PROGRAM_ADMIN_USER!).all())
       .length === 0
@@ -89,7 +91,7 @@ test("seed standard and program admin user. seed covid program", async ({
     await adminRadio.scrollIntoViewIfNeeded();
     await adminRadio.dispatchEvent("click");
 
-    await page.getByRole("button", { name: "Select all", exact: true }).click();
+    await page.getByRole("button", { name: "COVID", exact: true }).click();
 
     await page.getByRole("button", { name: "Save user" }).first().click();
 

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -50,8 +50,10 @@ test("seed standard and program admin user. seed covid program", async ({
     page.getByRole("heading", { name: "User management" }),
   ).toBeVisible();
 
+  // Seed standard user
   if (
-    (await page.getByText(process.env.AUTH_STANDARD_USER!).all()).length === 0
+    (await page.getByText(process.env.AUTH_STANDARD_USER!).all())
+      .length === 0
   ) {
     await page.goto("/ecr-viewer/admin/user/create");
     await expect(

--- a/containers/ecr-viewer/tests/e2e/seed.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/seed.spec.ts
@@ -91,7 +91,11 @@ test("seed standard and program admin user. seed covid program", async ({
     await adminRadio.scrollIntoViewIfNeeded();
     await adminRadio.dispatchEvent("click");
 
-    await page.getByRole("button", { name: "Select COVID", exact: true }).click();
+    const covidCheckbox = page.getByLabel("Select COVID", {
+      exact: true,
+    });
+    await covidCheckbox.scrollIntoViewIfNeeded();
+    await covidCheckbox.dispatchEvent("click");
 
     await page.getByRole("button", { name: "Save user" }).first().click();
 

--- a/containers/ecr-viewer/tests/e2e/utils.ts
+++ b/containers/ecr-viewer/tests/e2e/utils.ts
@@ -1,7 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { Page, expect, APIRequestContext, Cookie } from "@playwright/test";
 
-type UserType = "ADMIN" | "STANDARD";
+type UserType = "ADMIN" | "STANDARD" | "PROGRAM_ADMIN";
 
 // Instead of going to IDP to log in on every page, store the cookies
 // globally and re-use once logged in

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -13,12 +13,14 @@ import {
 } from "@/app/services/programAreaService";
 import {
   createInitialAdminUser,
+  createUser,
   listUserProgramAreas,
   updateUser,
 } from "@/app/services/userService";
 
 import { getLastAuditLog } from "./helpers/core";
 import { buildCore, dropExisting } from "./helpers/ddl";
+import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 const cond123 = {
   code: "123",
@@ -63,14 +65,23 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 jest.mock("@/app/utils/auth-utils", () => ({
-  getLoggedInUserSession: jest
-    .fn()
-    .mockResolvedValue({ name: "Adam Admin", email: "admin@admin.com" }),
+  getLoggedInUserSession: jest.fn()
 }));
 
+const mockedGetLoggedInUserSession = getLoggedInUserSession as jest.Mock;
+
 describe("program area service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   let progId;
+
   it("should create a program area", async () => {
+    mockedGetLoggedInUserSession.mockResolvedValue({
+      name: "Adam Admin",
+      email: "admin@admin.com",
+    });
     const progName = "Fun Times";
     const conditionCodes = ["123", "456"];
     progId = await createProgramArea({
@@ -131,6 +142,10 @@ describe("program area service", () => {
   });
 
   it("should update a program area name", async () => {
+    mockedGetLoggedInUserSession.mockResolvedValue({
+      name: "Adam Admin",
+      email: "admin@admin.com",
+    });
     const progName = "Sad Times";
     const id = await createProgramArea({ name: progName, conditions: ["123"] });
 
@@ -169,6 +184,10 @@ describe("program area service", () => {
   });
 
   it("should update a program area conditions", async () => {
+    mockedGetLoggedInUserSession.mockResolvedValue({
+      name: "Adam Admin",
+      email: "admin@admin.com",
+    });
     const progName = "Sad Times";
     const id = await createProgramArea({ name: progName, conditions: ["123"] });
 
@@ -197,6 +216,10 @@ describe("program area service", () => {
   });
 
   it("should delete a program area", async () => {
+    mockedGetLoggedInUserSession.mockResolvedValue({
+      name: "Adam Admin",
+      email: "admin@admin.com",
+    });
     const beforeCreate = await listProgramAreas();
     const id = await createProgramArea({ name: "test", conditions: ["123"] });
     const afterCreate = await listProgramAreas();
@@ -229,5 +252,34 @@ describe("program area service", () => {
     expect(
       afterUserProgramAreas.filter((p) => p.uuid === progId!),
     ).toBeArrayOfSize(1);
+  });
+
+  it("should only return program areas a program admin has access to", async () => {
+    const accessibleProgramId = await createProgramArea({
+      name: "Accessible Program",
+      conditions: ["123"],
+    });
+    const restrictedProgramId = await createProgramArea({
+      name: "Restricted Program",
+      conditions: ["456"],
+    });
+
+    const programAdminEmail = "programadmin@programadmin.com";
+    await createUser({
+      email: programAdminEmail,
+      userType: "prog_admin",
+      programs: [accessibleProgramId],
+    });
+
+    mockedGetLoggedInUserSession.mockResolvedValue({
+      name: "Philip Program-Admin",
+      email: "programadmin@programadmin.com",
+    });
+
+    const programAreas = await listProgramAreas();
+    const programAreaIds = programAreas.map(({ uuid }) => uuid);
+
+    expect(programAreaIds).toStrictEqual([accessibleProgramId]);
+    expect(programAreaIds).not.toContain(restrictedProgramId);
   });
 });

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -65,7 +65,7 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 jest.mock("@/app/utils/auth-utils", () => ({
-  getLoggedInUserSession: jest.fn()
+  getLoggedInUserSession: jest.fn(),
 }));
 
 const mockedGetLoggedInUserSession = getLoggedInUserSession as jest.Mock;

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -517,10 +517,9 @@ describe("User Service", () => {
   describe("hasRelevantProgramAreaAccess", () => {
     it("should return true for admin user", async () => {
       const adminUser = await getCheckAdmin("check");
-      const res = await hasRelevantProgramAreaAccess(
-        adminUser,
+      const res = await hasRelevantProgramAreaAccess(adminUser, [
         "some-prog-uuid",
-      );
+      ]);
       expect(res).toBeTrue();
     });
 
@@ -528,14 +527,14 @@ describe("User Service", () => {
       const adminUser = await getCheckAdmin("check");
       const inactiveUser = { ...adminUser, status: "inactive" as const };
       expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(inactiveUser, ["some-prog-uuid"]),
       ).toBeFalse();
     });
 
     it("should return false when no user is passed and none is logged in", async () => {
       (getLoggedInUserSession as jest.Mock).mockResolvedValue(undefined);
       expect(
-        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(undefined, ["some-prog-uuid"]),
       ).toBeFalse();
     });
   });

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -17,28 +17,31 @@ import {
   getCheckAdmin,
   getCheckAnyAdmin,
   hasRelevantProgramAreaAccess,
-  isAnyAdmin,
   isLoggedInUserEcrAuthed,
-  isProgramAdmin,
   isUserEcrAuthed,
+  ListedUser,
+  listLoggedInUserProgramAreas,
   listUserProgramAreas,
   listUsers,
   notFoundUnlessAdmin,
   notFoundUnlessAnyAdmin,
   updateUser,
+  validateAdminUserPermissions,
 } from "@/app/services/userService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 import { getLastAuditLog } from "./helpers/core";
 import { buildCore, dropExisting } from "./helpers/ddl";
+import { UserFacingError } from "@/app/services/errorService";
 
 export const makePromiseResolveWithStatus = (
   status: number,
 ): Promise<BlobResponse> =>
   new Promise((resolve) => resolve({ message: "hi there", status }));
 
-const adminEmail = "admin@admin.com";
-const userEmail = "standard@user.com";
+const adminUserEmail = "admin@admin.com";
+const standardUserEmail = "standard@standard.com";
+const programAdminEmail = "programadmin@programadmin.com";
 
 const cond123 = {
   code: "123",
@@ -51,6 +54,14 @@ const cond456 = {
   concept_name: "condition 2 (disease)",
   condition_name: "condition 2",
   condition_category: "category",
+};
+const programArea123 = {
+  name: "Program Area 123",
+  conditions: ["123"],
+};
+const programArea456 = {
+  name: "Program Area 456",
+  conditions: ["456"],
 };
 
 const ecrId = "1-2-3-4";
@@ -110,44 +121,53 @@ afterAll(async () => {
   await dropExisting();
 });
 
-describe("user service", () => {
-  let adminId;
-  let userId;
+describe("User Service", () => {
+  let adminUserId;
+  let standardUserId;
+  let programAdminUserId;
+
+  let programArea123Id;
+  let programArea456Id;
+
+  let expectedAdminUser: ListedUser;
+  let expectedStandardUser: ListedUser;
+  let expectedProgramAdminUser: ListedUser;
+
   it("should create initial admin user", async () => {
     let warning: string[] = [];
     jest.spyOn(console, "warn").mockImplementation((...args) => {
       warning = args;
     });
-    adminId = await createInitialAdminUser({ email: adminEmail });
-    expect(adminId).toMatch(UUID_REGEX);
+    adminUserId = await createInitialAdminUser({ email: adminUserEmail });
+    expect(adminUserId).toMatch(UUID_REGEX);
+
+    expectedAdminUser = {
+      uuid: adminUserId!,
+      email: adminUserEmail,
+      name: null,
+      date_of_last_login: null,
+      user_type: "admin",
+      status: "active",
+      author_uuid: adminUserId!,
+      date_created: expect.any(Date),
+      program_areas: [],
+    };
 
     const createLog = await getLastAuditLog();
     expect(createLog.subject).toEqual("user");
     expect(createLog.action).toEqual("create");
     expect(JSON.parse(createLog.parameter_json)).toStrictEqual({
-      email: adminEmail,
-      uuid: adminId,
+      email: adminUserEmail,
+      uuid: adminUserId,
     });
 
     // see admin listed
     const users = await listUsers();
     expect(users).toBeArrayOfSize(1);
-    expect(users).toStrictEqual([
-      {
-        uuid: adminId,
-        email: adminEmail,
-        name: null,
-        date_of_last_login: null,
-        user_type: "admin",
-        status: "active",
-        author_uuid: adminId,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-    ]);
+    expect(users).toStrictEqual([expectedAdminUser]);
 
     // adding again with same email should do nothing
-    const notId = await createInitialAdminUser({ email: adminEmail });
+    const notId = await createInitialAdminUser({ email: adminUserEmail });
     expect(notId).toBeUndefined();
     expect(warning[0]).toContain("Active admin user already exists");
     warning = [];
@@ -160,220 +180,282 @@ describe("user service", () => {
     expect(warning[0]).toContain("Active admin user already exists");
 
     // admin deletes themself
-    await deleteUser({ uuid: adminId! });
+    await deleteUser({ uuid: adminUserId! });
 
     // Current user isn't an admin any more!
     await expect(listUsers()).rejects.toThrow();
 
     //admin re-adds themself, gets same id
-    const newId = await createInitialAdminUser({ email: adminEmail });
-    expect(newId).toBe(adminId);
+    const newId = await createInitialAdminUser({ email: adminUserEmail });
+    expect(newId).toBe(adminUserId);
 
     // see admin listed
     const afterUsers = await listUsers();
     expect(afterUsers).toBeArrayOfSize(1);
-    expect(afterUsers).toStrictEqual([
-      {
-        uuid: adminId,
-        email: adminEmail,
-        name: null,
-        date_of_last_login: null,
-        user_type: "admin",
-        status: "active",
-        author_uuid: adminId,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-    ]);
+    expect(afterUsers).toStrictEqual([expectedAdminUser]);
   });
 
-  it("admin should be authed to see ecr", async () => {
+  it("isLoggedInUserEcrAuthed: admin should be authed to see ecr", async () => {
     const res = await isLoggedInUserEcrAuthed(ecrId);
     expect(res).toBeTrue();
   });
 
-  it("should create a standard user", async () => {
-    // admin created in prior test
-    userId = await createUser({
-      email: userEmail,
-      userType: "standard",
-      programs: [],
-    });
-    expect(userId).toMatch(UUID_REGEX);
+  describe("createUser", () => {
+    it("as an admin, should create a standard user", async () => {
+      // admin created in prior test
+      standardUserId = await createUser({
+        email: standardUserEmail,
+        userType: "standard",
+        programs: [],
+      });
+      expect(standardUserId).toMatch(UUID_REGEX);
 
-    // check audit log
-    const createLog = await getLastAuditLog();
-    expect(createLog.actor).toEqual(adminId!);
-    expect(createLog.subject).toEqual("user");
-    expect(createLog.action).toEqual("create");
-    expect(JSON.parse(createLog.parameter_json)).toStrictEqual({
-      email: userEmail,
-      userType: "standard",
-      programs: [],
-      uuid: userId,
-    });
-
-    // see standard user listed
-    const users = await listUsers();
-    expect(users).toBeArrayOfSize(2);
-    expect(users).toStrictEqual([
-      {
-        uuid: expect.any(String),
-        email: adminEmail,
-        name: null,
-        date_of_last_login: null,
-        user_type: "admin",
-        status: "active",
-        author_uuid: adminId!,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-      {
-        uuid: userId,
-        email: userEmail,
+      expectedStandardUser = {
+        uuid: standardUserId,
+        email: standardUserEmail,
         name: null,
         date_of_last_login: null,
         user_type: "standard",
         status: "active",
-        author_uuid: adminId!,
+        author_uuid: adminUserId!,
         date_created: expect.any(Date),
         program_areas: [],
-      },
-    ]);
+      };
+
+      // check audit log
+      const createLog = await getLastAuditLog();
+      expect(createLog.actor).toEqual(adminUserId!);
+      expect(createLog.subject).toEqual("user");
+      expect(createLog.action).toEqual("create");
+      expect(JSON.parse(createLog.parameter_json)).toStrictEqual({
+        email: standardUserEmail,
+        userType: "standard",
+        programs: [],
+        uuid: standardUserId,
+      });
+
+      // see standard user listed
+      const users = await listUsers();
+      expect(users).toBeArrayOfSize(2); // admin + standard
+      expect(users).toStrictEqual([expectedAdminUser, expectedStandardUser]);
+    });
+
+    it("as an admin, should create a program admin user", async () => {
+      // Create program area
+      programArea123Id = await createProgramArea(programArea123);
+      expect(programArea123Id).toMatch(UUID_REGEX);
+
+      // Create program admin
+      programAdminUserId = await createUser({
+        email: programAdminEmail,
+        userType: "prog_admin",
+        programs: [programArea123Id],
+      });
+      expect(programAdminUserId).toMatch(UUID_REGEX);
+      expectedProgramAdminUser = {
+        uuid: programAdminUserId,
+        email: programAdminEmail,
+        name: null,
+        date_of_last_login: null,
+        user_type: "prog_admin",
+        status: "active",
+        author_uuid: adminUserId!,
+        date_created: expect.any(Date),
+        program_areas: [
+          {
+            name: "Program Area 123",
+            program_area_uuid: programArea123Id,
+            user_uuid: programAdminUserId,
+          },
+        ],
+      };
+
+      // Check audit log
+      const createLog = await getLastAuditLog();
+      expect(createLog.actor).toEqual(adminUserId!);
+      expect(createLog.subject).toEqual("user");
+      expect(createLog.action).toEqual("create");
+      expect(JSON.parse(createLog.parameter_json)).toStrictEqual({
+        email: programAdminEmail,
+        userType: "prog_admin",
+        programs: [programArea123Id],
+        uuid: programAdminUserId,
+      });
+
+      // Program admin should be listed
+      const users = await listUsers();
+      expect(users).toBeArrayOfSize(3); // admin + standard + program admin
+      expect(users).toStrictEqual([
+        expectedAdminUser,
+        expectedProgramAdminUser,
+        expectedStandardUser,
+      ]);
+    });
+
+    it("as a program admin, should not create an admin user", async () => {
+      // Log in as Program Admin
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin 1",
+        email: programAdminEmail,
+      });
+
+      // Program admin should not be able to create admin
+      await expect(
+        createUser({
+          email: "new-admin@admin.com",
+          userType: "admin",
+          programs: [],
+        })
+      ).rejects.toThrow("Program admins cannot create new admins");
+    });
+
+    it("as a program admin, should not create a user for an unauthorized program area", async () => {
+      // Create program area 456
+      programArea456Id = await createProgramArea(programArea456);
+      expect(programArea456Id).toMatch(UUID_REGEX);
+
+      // Ensure logged in user is program admin with access to Program Area 123
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin 1",
+        email: programAdminEmail,
+      });
+
+      // Program areas of program admin should be listed
+      const progAreas = await listLoggedInUserProgramAreas();
+      expect(progAreas).toStrictEqual([
+        {
+          uuid: programArea123Id!,
+          author_uuid: adminUserId!,
+          name: "Program Area 123",
+          date_created: expect.any(Date),
+        },
+      ]);
+
+      // Attempt to create standard user with access to Program Area 456
+      await expect(
+        createUser({
+          email: "new-user@standard.com",
+          userType: "standard",
+          programs: [programArea456Id],
+        })
+      ).rejects.toThrow(
+        "Program admins cannot create users outside of their program areas"
+      );
+    });
   });
 
-  it("user should not yet be authed to see ecr", async () => {
-    const res = await isUserEcrAuthed(userId!, ecrId);
+  it("isUserEcrAuthed: standard user should not yet be authed to see ecr", async () => {
+    const res = await isUserEcrAuthed(standardUserId!, ecrId);
     expect(res).toBeFalse();
   });
 
-  it("should update a user", async () => {
-    // standard user created in prior test
-    await updateUser({
-      uuid: userId!,
-      updates: { name: "Olga Nunes" },
-      programs: [],
-    });
+  describe("updateUser", () => {
+    it("as an admin, should update a user", async () => {
+      // standard user created in prior test
+      await updateUser({
+        uuid: standardUserId!,
+        updates: { name: "Olga Nunes" },
+        programs: [],
+      });
 
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("user");
-    expect(log.action).toEqual("update");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      updates: { name: "Olga Nunes" },
-      programs: [],
-      uuid: userId!,
-    });
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminUserId!);
+      expect(log.subject).toEqual("user");
+      expect(log.action).toEqual("update");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        updates: { name: "Olga Nunes" },
+        programs: [],
+        uuid: standardUserId!,
+      });
 
-    // see standard user listed with name
-    const users = await listUsers();
-    expect(users).toBeArrayOfSize(2);
-    expect(users).toStrictEqual([
-      {
-        uuid: adminId!,
-        email: adminEmail,
-        name: null,
-        date_of_last_login: null,
-        user_type: "admin",
-        status: "active",
-        author_uuid: adminId!,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-      {
-        uuid: userId!,
-        email: userEmail,
+      expectedStandardUser = {
+        ...expectedStandardUser,
         name: "Olga Nunes",
-        date_of_last_login: null,
-        user_type: "standard",
-        status: "active",
-        author_uuid: adminId!,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-    ]);
+      };
+
+      // see standard user listed with name
+      const users = await listUsers();
+      expect(users).toBeArrayOfSize(3);
+      expect(users).toStrictEqual([
+        expectedAdminUser,
+        expectedProgramAdminUser,
+        expectedStandardUser,
+      ]);
+    });
+
+    it("as an admin, should update a user's program areas", async () => {
+      // standard user created in prior test
+      await updateUser({
+        uuid: standardUserId!,
+        updates: { name: "Olga Nunes" },
+        programs: [programArea123Id!],
+      });
+
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminUserId!);
+      expect(log.subject).toEqual("user");
+      expect(log.action).toEqual("update");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        updates: { name: "Olga Nunes" },
+        programs: [programArea123Id!],
+        uuid: standardUserId!,
+      });
+
+      const progAreas = await listUserProgramAreas(standardUserId!);
+
+      expect(progAreas).toStrictEqual([
+        {
+          uuid: programArea123Id!,
+          author_uuid: adminUserId!,
+          name: "Program Area 123",
+          date_created: expect.any(Date),
+        },
+      ]);
+    });
   });
 
-  it("should update a user's program areas", async () => {
-    // standard user created in prior test
-    const progId = await createProgramArea({
-      name: "Disease",
-      conditions: ["123"],
-    });
-    await updateUser({
-      uuid: userId!,
-      updates: { name: "Olga Nunes" },
-      programs: [progId],
-    });
-
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("user");
-    expect(log.action).toEqual("update");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      updates: { name: "Olga Nunes" },
-      programs: [progId],
-      uuid: userId!,
-    });
-
-    const progAreas = await listUserProgramAreas(userId!);
-
-    expect(progAreas).toStrictEqual([
-      {
-        uuid: progId,
-        author_uuid: adminId!,
-        name: "Disease",
-        date_created: expect.any(Date),
-      },
-    ]);
-  });
-
-  it("user should now be authed to see ecr", async () => {
-    const res = await isUserEcrAuthed(userId!, ecrId);
+  it("isUserEcrAuthed: standard user should now be authed to see ecr", async () => {
+    const res = await isUserEcrAuthed(standardUserId!, ecrId);
     expect(res).toBeTrue();
   });
 
-  it("should delete a user", async () => {
-    // standard user created in prior test
-    await deleteUser({ uuid: userId! });
+  describe("deleteUser", () => {
+    it("as an admin, should delete a user", async () => {
+      const beforeUsers = await listUsers();
+      expect(beforeUsers).toBeArrayOfSize(3); // admin + program admin + standard
 
-    // check audit log
-    const deleteLog = await getLastAuditLog();
-    expect(deleteLog.actor).toEqual(adminId!);
-    expect(deleteLog.subject).toEqual("user");
-    expect(deleteLog.action).toEqual("delete");
-    expect(JSON.parse(deleteLog.parameter_json)).toStrictEqual({
-      uuid: userId!,
+      // standard user created in prior test
+      await deleteUser({ uuid: standardUserId! });
+
+      // check audit log
+      const deleteLog = await getLastAuditLog();
+      expect(deleteLog.actor).toEqual(adminUserId!);
+      expect(deleteLog.subject).toEqual("user");
+      expect(deleteLog.action).toEqual("delete");
+      expect(JSON.parse(deleteLog.parameter_json)).toStrictEqual({
+        uuid: standardUserId!,
+      });
+
+      // see only admin + program admin listed
+      const users = await listUsers();
+      expect(users).toBeArrayOfSize(2); // admin + program admin
+      expect(users).toStrictEqual([
+        expectedAdminUser,
+        expectedProgramAdminUser,
+      ]);
+
+      // should also delete standard user program area assignments
+      const progAreas = await listUserProgramAreas(standardUserId!);
+      expect(progAreas).toStrictEqual([]);
     });
-
-    // see only admin user listed
-    const users = await listUsers();
-    expect(users).toBeArrayOfSize(1);
-    expect(users).toStrictEqual([
-      {
-        uuid: adminId!,
-        email: adminEmail,
-        name: null,
-        date_of_last_login: null,
-        user_type: "admin",
-        status: "active",
-        author_uuid: adminId!,
-        date_created: expect.any(Date),
-        program_areas: [],
-      },
-    ]);
-
-    // should also delete program area assignments
-    const progAreas = await listUserProgramAreas(userId!);
-    expect(progAreas).toStrictEqual([]);
   });
 
   describe("getCheckAdmin", () => {
     it("should return admin if user is an admin", async () => {
       const admin = await getCheckAdmin("do a thing");
-      expect(admin.email).toBe(adminEmail);
+      expect(admin.email).toBe(adminUserEmail);
     });
 
     it("should error if user is not an admin", async () => {
@@ -404,7 +486,7 @@ describe("user service", () => {
   describe("getCheckAnyAdmin", () => {
     it("should return admin if user is an admin", async () => {
       const admin = await getCheckAnyAdmin("do a thing");
-      expect(admin.email).toBe(adminEmail);
+      expect(admin.email).toBe(adminUserEmail);
     });
 
     it("should error if user is a standard user", async () => {
@@ -437,7 +519,7 @@ describe("user service", () => {
       const adminUser = await getCheckAdmin("check");
       const res = await hasRelevantProgramAreaAccess(
         adminUser,
-        "some-prog-uuid",
+        "some-prog-uuid"
       );
       expect(res).toBeTrue();
     });
@@ -446,15 +528,58 @@ describe("user service", () => {
       const adminUser = await getCheckAdmin("check");
       const inactiveUser = { ...adminUser, status: "inactive" as const };
       expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid")
       ).toBeFalse();
     });
 
     it("should return false when no user is passed and none is logged in", async () => {
       (getLoggedInUserSession as jest.Mock).mockResolvedValue(undefined);
       expect(
-        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid")
       ).toBeFalse();
+    });
+  });
+
+  // TODO ANGELA: Should this really be an integration test? Should this (and others be moved to unit tests)
+  describe("validateAdminUserPermissions", () => {
+    it("should allow admins to manage users of any type", async () => {
+      await expect(
+        validateAdminUserPermissions(expectedAdminUser, "admin", [])
+      ).resolves.toBeUndefined();
+    });
+    it("should allow program admins to manage standard users and program admins within their accessible program areas", async () => {
+      await expect(
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "standard",
+          [programArea123Id!]
+        )
+      ).resolves.toBeUndefined();
+      await expect(
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "prog_admin",
+          [programArea123Id!]
+        )
+      ).resolves.toBeUndefined();
+    });
+    it("should prevent program admins from managing admin users", async () => {
+      await expect(
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "admin",
+          []
+        )
+      ).rejects.toThrow(UserFacingError);
+    });
+    it("should prevent program admins from managing users outside of their accessible program areas", async () => {
+      await expect(
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "standard",
+          [programArea456Id!]
+        )
+      ).rejects.toThrow(UserFacingError);
     });
   });
 });

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -305,7 +305,7 @@ describe("User Service", () => {
           email: "new-admin@admin.com",
           userType: "admin",
           programs: [],
-        })
+        }),
       ).rejects.toThrow("Program admins cannot create new admins");
     });
 
@@ -337,9 +337,9 @@ describe("User Service", () => {
           email: "new-user@standard.com",
           userType: "standard",
           programs: [programArea456Id],
-        })
+        }),
       ).rejects.toThrow(
-        "Program admins cannot create users outside of their program areas"
+        "Program admins cannot create users outside of their program areas",
       );
     });
   });
@@ -519,7 +519,7 @@ describe("User Service", () => {
       const adminUser = await getCheckAdmin("check");
       const res = await hasRelevantProgramAreaAccess(
         adminUser,
-        "some-prog-uuid"
+        "some-prog-uuid",
       );
       expect(res).toBeTrue();
     });
@@ -528,14 +528,14 @@ describe("User Service", () => {
       const adminUser = await getCheckAdmin("check");
       const inactiveUser = { ...adminUser, status: "inactive" as const };
       expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid")
+        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid"),
       ).toBeFalse();
     });
 
     it("should return false when no user is passed and none is logged in", async () => {
       (getLoggedInUserSession as jest.Mock).mockResolvedValue(undefined);
       expect(
-        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid")
+        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid"),
       ).toBeFalse();
     });
   });
@@ -544,41 +544,31 @@ describe("User Service", () => {
   describe("validateAdminUserPermissions", () => {
     it("should allow admins to manage users of any type", async () => {
       await expect(
-        validateAdminUserPermissions(expectedAdminUser, "admin", [])
+        validateAdminUserPermissions(expectedAdminUser, "admin", []),
       ).resolves.toBeUndefined();
     });
     it("should allow program admins to manage standard users and program admins within their accessible program areas", async () => {
       await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "standard",
-          [programArea123Id!]
-        )
+        validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
+          programArea123Id!,
+        ]),
       ).resolves.toBeUndefined();
       await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "prog_admin",
-          [programArea123Id!]
-        )
+        validateAdminUserPermissions(expectedProgramAdminUser, "prog_admin", [
+          programArea123Id!,
+        ]),
       ).resolves.toBeUndefined();
     });
     it("should prevent program admins from managing admin users", async () => {
       await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "admin",
-          []
-        )
+        validateAdminUserPermissions(expectedProgramAdminUser, "admin", []),
       ).rejects.toThrow(UserFacingError);
     });
     it("should prevent program admins from managing users outside of their accessible program areas", async () => {
       await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "standard",
-          [programArea456Id!]
-        )
+        validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
+          programArea456Id!,
+        ]),
       ).rejects.toThrow(UserFacingError);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -10,8 +10,9 @@ import {
   isAdmin,
   ListedUser,
   listUsers,
-  notFoundUnlessAdmin,
+  notFoundUnlessAnyAdmin,
 } from "@/app/services/userService";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 jest.mock("@/app/data/metadataDb/database");
 jest.mock("@/app/utils/auth-utils", () => ({
@@ -27,18 +28,39 @@ jest.mock("@/app/services/listConditionsService", () => ({
   listConditionReferences: jest.fn().mockResolvedValue([]),
 }));
 
-const mockUsers: ListedUser[] = [
+const mockAdmin: ListedUser = 
   {
     uuid: "123",
     email: "admin@admin.com",
     name: "Adam Admin",
     date_of_last_login: new Date("2025-04-15T10:30:00Z"),
     user_type: "admin",
-    status: "Active",
+    status: "active",
     date_created: new Date("2025-01-01T09:00:00Z"),
     author_uuid: "123",
     program_areas: [],
-  },
+  };
+const mocKProgramAdmin: ListedUser =
+  {
+    uuid: "456",
+    email: "programadmin@programadmin.com",
+    name: "Peter Program-Admin",
+    date_of_last_login: new Date("2025-04-15T10:30:00Z"),
+    user_type: "prog_admin",
+    status: "active",
+    date_created: new Date("2025-01-01T09:00:00Z"),
+    author_uuid: "123",
+    program_areas: [
+      {
+        program_area_uuid: "222",
+        user_uuid: "456",
+        name: "Program Area Two",
+      },
+    ],
+  };
+const mockUsers: ListedUser[] = [
+  mockAdmin,
+  mocKProgramAdmin,
   {
     uuid: "234",
     email: "sallystandard@standard.com",
@@ -50,12 +72,12 @@ const mockUsers: ListedUser[] = [
     author_uuid: "123",
     program_areas: [
       {
-        program_area_uuid: "456",
+        program_area_uuid: "222",
         user_uuid: "234",
         name: "Program Area Two",
       },
       {
-        program_area_uuid: "789",
+        program_area_uuid: "333",
         user_uuid: "234",
         name: "Program Area Three",
       },
@@ -72,7 +94,7 @@ const mockUsers: ListedUser[] = [
     author_uuid: "123",
     program_areas: [
       {
-        program_area_uuid: "789",
+        program_area_uuid: "333",
         user_uuid: "345",
         name: "Program Area Three",
       },
@@ -83,12 +105,12 @@ const mockUsers: ListedUser[] = [
 const mockPrograms: FormProgram[] = [
   {
     name: "Program Area Two",
-    uuid: "456",
+    uuid: "222",
     date_created: new Date("2025-01-05"),
     author_uuid: "abc",
     conditions: [
       {
-        code: "123",
+        code: "cond0",
         concept_name: "condition (disease)",
         condition_name: "condition",
         condition_category: "category",
@@ -99,24 +121,24 @@ const mockPrograms: FormProgram[] = [
   },
   {
     name: "Program Area Three",
-    uuid: "789",
+    uuid: "333",
     date_created: new Date("2025-01-09"),
     author_uuid: "abc",
     conditions: [
       {
-        code: "456",
+        code: "cond1",
         concept_name: "condition 1 (disease)",
         condition_name: "condition",
         condition_category: "category",
-        program_area_uuid: "789",
+        program_area_uuid: "333",
         is_duplicate: false,
       },
       {
-        code: "789",
+        code: "cond2",
         concept_name: "condition 2 (disease)",
         condition_name: "condition",
         condition_category: "category",
-        program_area_uuid: "789",
+        program_area_uuid: "333",
         is_duplicate: false,
       },
     ],
@@ -129,16 +151,15 @@ describe("User Admin Page", () => {
   });
 
   it("should check user is an admin", async () => {
-    (isAdmin as unknown as jest.Mock).mockReturnValue(false);
     (listUsers as jest.Mock).mockResolvedValue([]);
     (listProgramAreas as jest.Mock).mockResolvedValue([]);
 
     render(await UserAdminPage());
-    expect(notFoundUnlessAdmin).toHaveBeenCalled();
+    expect(notFoundUnlessAnyAdmin).toHaveBeenCalled();
   });
 
   it("should list users when available", async () => {
-    (notFoundUnlessAdmin as unknown as jest.Mock).mockReturnValue(true);
+    (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockReturnValue(true);
     (listUsers as jest.Mock).mockResolvedValue(mockUsers);
     (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
 
@@ -149,7 +170,9 @@ describe("User Admin Page", () => {
 
   describe("Creating users", () => {
     it("should render a create user page", async () => {
+      (isAdmin as unknown as jest.Mock).mockReturnValue(true);
       (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
+
       const { container } = render(await CreateUserPage());
       expect(container).toMatchSnapshot();
       let results;
@@ -160,6 +183,7 @@ describe("User Admin Page", () => {
     });
 
     it("should render a create user page with no programs", async () => {
+      (isAdmin as unknown as jest.Mock).mockReturnValue(true);
       (listProgramAreas as jest.Mock).mockResolvedValue([]);
       const { container } = render(await CreateUserPage());
       expect(container).toMatchSnapshot();
@@ -194,6 +218,39 @@ describe("User Admin Page", () => {
       });
       expect(selectAll).not.toBeInTheDocument();
       expect(deselectAll).not.toBeInTheDocument();
+    });
+
+    it("As a program admin, can only create other program admins or standard users", async () => {
+      (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockResolvedValue(true);
+      (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
+      (getLoggedInUser as jest.Mock).mockResolvedValue(mocKProgramAdmin);
+
+      render(await CreateUserPage());
+
+      expect(screen.getByRole("radio", { name: /Program Admin/i })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: /Standard/i })).toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: /^Admin$/i })).not.toBeInTheDocument();
+    });
+
+    it("As a program admin, can only create users in their program areas", async () => {
+      (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockResolvedValue(true);
+      (listProgramAreas as jest.Mock).mockResolvedValue([mockPrograms[0]]);
+      (getLoggedInUser as jest.Mock).mockResolvedValue(mocKProgramAdmin);
+
+      render(await CreateUserPage());
+
+      expect(screen.getByRole("checkbox", { name: /Select Program Area Two/i })).toBeInTheDocument();
+      expect(screen.queryByRole("checkbox", { name: /Select Program Area Three/i })).not.toBeInTheDocument();
+    });
+
+    it("As a standard user, cannot access the Create User page", async () => {
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockImplementation(() => {
+        throw new Error("Not found");
+      });
+
+      await expect(CreateUserPage()).rejects.toThrow("Not found");
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -28,36 +28,34 @@ jest.mock("@/app/services/listConditionsService", () => ({
   listConditionReferences: jest.fn().mockResolvedValue([]),
 }));
 
-const mockAdmin: ListedUser = 
-  {
-    uuid: "123",
-    email: "admin@admin.com",
-    name: "Adam Admin",
-    date_of_last_login: new Date("2025-04-15T10:30:00Z"),
-    user_type: "admin",
-    status: "active",
-    date_created: new Date("2025-01-01T09:00:00Z"),
-    author_uuid: "123",
-    program_areas: [],
-  };
-const mocKProgramAdmin: ListedUser =
-  {
-    uuid: "456",
-    email: "programadmin@programadmin.com",
-    name: "Peter Program-Admin",
-    date_of_last_login: new Date("2025-04-15T10:30:00Z"),
-    user_type: "prog_admin",
-    status: "active",
-    date_created: new Date("2025-01-01T09:00:00Z"),
-    author_uuid: "123",
-    program_areas: [
-      {
-        program_area_uuid: "222",
-        user_uuid: "456",
-        name: "Program Area Two",
-      },
-    ],
-  };
+const mockAdmin: ListedUser = {
+  uuid: "123",
+  email: "admin@admin.com",
+  name: "Adam Admin",
+  date_of_last_login: new Date("2025-04-15T10:30:00Z"),
+  user_type: "admin",
+  status: "active",
+  date_created: new Date("2025-01-01T09:00:00Z"),
+  author_uuid: "123",
+  program_areas: [],
+};
+const mocKProgramAdmin: ListedUser = {
+  uuid: "456",
+  email: "programadmin@programadmin.com",
+  name: "Peter Program-Admin",
+  date_of_last_login: new Date("2025-04-15T10:30:00Z"),
+  user_type: "prog_admin",
+  status: "active",
+  date_created: new Date("2025-01-01T09:00:00Z"),
+  author_uuid: "123",
+  program_areas: [
+    {
+      program_area_uuid: "222",
+      user_uuid: "456",
+      name: "Program Area Two",
+    },
+  ],
+};
 const mockUsers: ListedUser[] = [
   mockAdmin,
   mocKProgramAdmin,
@@ -228,9 +226,15 @@ describe("User Admin Page", () => {
 
       render(await CreateUserPage());
 
-      expect(screen.getByRole("radio", { name: /Program Admin/i })).toBeInTheDocument();
-      expect(screen.getByRole("radio", { name: /Standard/i })).toBeInTheDocument();
-      expect(screen.queryByRole("radio", { name: /^Admin$/i })).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: /Program Admin/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: /Standard/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radio", { name: /^Admin$/i }),
+      ).not.toBeInTheDocument();
     });
 
     it("As a program admin, can only create users in their program areas", async () => {
@@ -241,14 +245,20 @@ describe("User Admin Page", () => {
 
       render(await CreateUserPage());
 
-      expect(screen.getByRole("checkbox", { name: /Select Program Area Two/i })).toBeInTheDocument();
-      expect(screen.queryByRole("checkbox", { name: /Select Program Area Three/i })).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("checkbox", { name: /Select Program Area Two/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("checkbox", { name: /Select Program Area Three/i }),
+      ).not.toBeInTheDocument();
     });
 
     it("As a standard user, cannot access the Create User page", async () => {
-      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockImplementation(() => {
-        throw new Error("Not found");
-      });
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockImplementation(
+        () => {
+          throw new Error("Not found");
+        },
+      );
 
       await expect(CreateUserPage()).rejects.toThrow("Not found");
     });

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -145,6 +145,30 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
             data-testid="radio"
           >
             <input
+              class="usa-radio__input"
+              id="userType-prog_admin"
+              name="userType"
+              required=""
+              type="radio"
+              value="prog_admin"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-prog_admin"
+            >
+              Program Admin
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Program Admins have limited access to user management, program management, and the eCR Library
+              </span>
+            </label>
+          </div>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
               checked=""
               class="usa-radio__input"
               id="userType-standard"
@@ -535,6 +559,30 @@ exports[`User Admin Page Creating users should render a create user page with no
                 class="usa-checkbox__label-description"
               >
                 Admins have full access to user management, program management, and the eCR Library
+              </span>
+            </label>
+          </div>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
+              class="usa-radio__input"
+              id="userType-prog_admin"
+              name="userType"
+              required=""
+              type="radio"
+              value="prog_admin"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-prog_admin"
+            >
+              Program Admin
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Program Admins have limited access to user management, program management, and the eCR Library
               </span>
             </label>
           </div>
@@ -938,6 +986,28 @@ exports[`User Admin Page should list users when available 1`] = `
                     data-testid="button"
                     type="button"
                   >
+                    programadmin@programadmin.com
+                  </button>
+                </td>
+                <td>
+                  Prog_admin
+                </td>
+                <td>
+                  Program Area Two
+                </td>
+                <td>
+                  04/15/2025 6:30 AM EDT
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <button
+                    class="usa-button usa-button--unstyled action-text"
+                    data-close-modal="true"
+                    data-open-modal="true"
+                    data-testid="button"
+                    type="button"
+                  >
                     sallystandard@standard.com
                   </button>
                 </td>
@@ -982,9 +1052,9 @@ exports[`User Admin Page should list users when available 1`] = `
               Showing 
               1
               -
-              3
+              4
                of 
-              3
+              4
                
               users
             </div>

--- a/containers/ecr-viewer/tests/unit/app/admin/components/UserForm.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/components/UserForm.test.tsx
@@ -82,6 +82,7 @@ describe("UserForm", () => {
           users: mockUsers,
         }}
         submitAction={async () => ({})}
+        isLoggedInUserAdmin={true}
       />,
     );
 
@@ -167,6 +168,7 @@ describe("UserForm", () => {
           users: [],
         }}
         submitAction={mockSubmitAction}
+        isLoggedInUserAdmin={true}
       />,
     );
 

--- a/containers/ecr-viewer/tests/unit/app/components/NavLinks.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/NavLinks.test.tsx
@@ -7,7 +7,7 @@ import { usePathname } from "next/navigation";
 import NavLinks from "@/app/components/NavLinks";
 import { User } from "@/app/data/metadataDb/types/core";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
-import { isAdmin } from "@/app/services/userService";
+import { isAnyAdmin } from "@/app/services/userService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 jest.mock("@/app/utils/auth-utils", () => ({
@@ -15,7 +15,7 @@ jest.mock("@/app/utils/auth-utils", () => ({
 }));
 
 jest.mock("@/app/services/userService", () => ({
-  isAdmin: jest.fn(),
+  isAnyAdmin: jest.fn()
 }));
 jest.mock("@/app/services/loggedInUserService", () => ({
   getLoggedInUser: jest.fn(),
@@ -38,6 +38,17 @@ const mockAdminUser: User = {
   author_uuid: "",
 };
 
+const mockProgramAdminUser: User = {
+  status: "",
+  uuid: "",
+  email: "",
+  date_of_last_login: new Date(),
+  name: "Phillip Phillip",
+  user_type: "prog_admin",
+  date_created: new Date(),
+  author_uuid: "",
+};
+
 const mockStandardUser: User = {
   status: "",
   uuid: "",
@@ -54,7 +65,7 @@ describe("NavLinks component", () => {
     (usePathname as jest.Mock).mockReturnValue("/admin/user");
     (getLoggedInUserSession as jest.Mock).mockResolvedValue(mockAdminUser);
     (getLoggedInUser as jest.Mock).mockResolvedValue(mockAdminUser);
-    (isAdmin as unknown as jest.Mock).mockReturnValue(true);
+    (isAnyAdmin as unknown as jest.Mock).mockReturnValue(true);
 
     render(await NavLinks());
 
@@ -73,10 +84,36 @@ describe("NavLinks component", () => {
     expect(screen.getByTestId("user-menu")).toHaveTextContent("Admin");
   });
 
+  it("renders admin navigation links and user menu for a program admin user", async () => {
+    (usePathname as jest.Mock).mockReturnValue("/admin/user");
+    (getLoggedInUserSession as jest.Mock).mockResolvedValue(
+      mockProgramAdminUser
+    );
+    (getLoggedInUser as jest.Mock).mockResolvedValue(mockProgramAdminUser);
+    (isAnyAdmin as unknown as jest.Mock).mockReturnValue(true);
+
+    render(await NavLinks());
+
+    // Navigation links
+    expect(screen.getByText("eCR library")).toBeInTheDocument();
+    expect(screen.getByText("eCR library")).not.toHaveClass("active-page");
+    expect(screen.getByText("User management")).toBeInTheDocument();
+    expect(screen.getByText("User management")).toHaveClass("active-page");
+    expect(screen.getByText("Program management")).toBeInTheDocument();
+    expect(screen.getByText("Program management")).not.toHaveClass(
+      "active-page"
+    );
+
+    // User menu
+    const userMenu = screen.getByTestId("user-menu");
+    expect(userMenu).toHaveTextContent("Phillip Phillip");
+    expect(userMenu).toHaveTextContent("prog_admin");
+  });
+
   it("Does not render links for a standard user but does render menu", async () => {
     (getLoggedInUserSession as jest.Mock).mockResolvedValue(mockStandardUser);
     (getLoggedInUser as jest.Mock).mockResolvedValue(mockStandardUser);
-    (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+    (isAnyAdmin as unknown as jest.Mock).mockReturnValue(false);
 
     render(await NavLinks());
 

--- a/containers/ecr-viewer/tests/unit/app/components/NavLinks.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/NavLinks.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@/app/utils/auth-utils", () => ({
 }));
 
 jest.mock("@/app/services/userService", () => ({
-  isAnyAdmin: jest.fn()
+  isAnyAdmin: jest.fn(),
 }));
 jest.mock("@/app/services/loggedInUserService", () => ({
   getLoggedInUser: jest.fn(),
@@ -87,7 +87,7 @@ describe("NavLinks component", () => {
   it("renders admin navigation links and user menu for a program admin user", async () => {
     (usePathname as jest.Mock).mockReturnValue("/admin/user");
     (getLoggedInUserSession as jest.Mock).mockResolvedValue(
-      mockProgramAdminUser
+      mockProgramAdminUser,
     );
     (getLoggedInUser as jest.Mock).mockResolvedValue(mockProgramAdminUser);
     (isAnyAdmin as unknown as jest.Mock).mockReturnValue(true);
@@ -101,7 +101,7 @@ describe("NavLinks component", () => {
     expect(screen.getByText("User management")).toHaveClass("active-page");
     expect(screen.getByText("Program management")).toBeInTheDocument();
     expect(screen.getByText("Program management")).not.toHaveClass(
-      "active-page"
+      "active-page",
     );
 
     // User menu

--- a/containers/ecr-viewer/tests/unit/app/components/UserMenu.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/UserMenu.test.tsx
@@ -56,7 +56,7 @@ describe("UserMenu component", () => {
     fireEvent.click(button);
 
     expect(
-      screen.getByText("phillip.phillip@fakestarwarsemail.bananas.com")
+      screen.getByText("phillip.phillip@fakestarwarsemail.bananas.com"),
     ).toBeInTheDocument();
     expect(screen.getByText("Program admin")).toBeInTheDocument();
   });

--- a/containers/ecr-viewer/tests/unit/app/components/UserMenu.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/UserMenu.test.tsx
@@ -7,7 +7,7 @@ import UserMenu from "@/app/components/UserMenu";
 import { User } from "@/app/data/metadataDb/types/core";
 
 describe("UserMenu component", () => {
-  const mockUser: User = {
+  const mockAdminUser: User = {
     status: "",
     uuid: "",
     email: "kyle.katarn@fakestarwarsemail.bananas.com",
@@ -17,20 +17,30 @@ describe("UserMenu component", () => {
     date_created: new Date(),
     author_uuid: "",
   };
+  const mockProgramAdminUser: User = {
+    status: "",
+    uuid: "",
+    email: "phillip.phillip@fakestarwarsemail.bananas.com",
+    date_of_last_login: new Date(),
+    name: "Phillip Phillip",
+    user_type: "prog_admin",
+    date_created: new Date(),
+    author_uuid: "",
+  };
 
   function renderWithSession(ui: React.ReactNode) {
     return render(<SessionProvider session={null}>{ui}</SessionProvider>);
   }
 
   it("renders the profile image with correct alt text", () => {
-    renderWithSession(<UserMenu user={mockUser} version="vTest" />);
+    renderWithSession(<UserMenu user={mockAdminUser} version="vTest" />);
     const profileImage = screen.getByRole("img");
     expect(profileImage).toBeInTheDocument();
     expect(profileImage.getAttribute("aria-label")).toContain("User Menu");
   });
 
   it("toggles the menu when button is clicked and displays user info", () => {
-    renderWithSession(<UserMenu user={mockUser} version="vTest" />);
+    renderWithSession(<UserMenu user={mockAdminUser} version="vTest" />);
     const button = screen.getByRole("button");
     fireEvent.click(button);
     expect(
@@ -38,5 +48,16 @@ describe("UserMenu component", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Admin")).toBeInTheDocument();
     expect(screen.getByText(/vTest/i)).toBeInTheDocument();
+  });
+
+  it("shows Program admin in the user menu when the current user is a program admin", () => {
+    renderWithSession(<UserMenu user={mockProgramAdminUser} version="vTest" />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(
+      screen.getByText("phillip.phillip@fakestarwarsemail.bananas.com")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Program admin")).toBeInTheDocument();
   });
 });

--- a/documentation-hub/it-staff/Database Documentation.md
+++ b/documentation-hub/it-staff/Database Documentation.md
@@ -66,7 +66,7 @@ This table stores user information.
 | `email`              | `varchar(200)` | NOT NULL    |                   | User's email address, must be unique                            |
 | `name`               | `varchar(200)` | NULL        |                   | User's full name                                                |
 | `date_of_last_login` | `datetime`     | NULL        |                   | Date and time of user's last login                              |
-| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                            |
+| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                |
 | `status`             | `varchar(12)`  | NOT NULL    | active            | User's account status                                           |
 | `date_created`       | `datetime`     | NOT NULL    | Current timestamp | Date and time when the user record was created                  |
 | `author_uuid`        | `varchar(200)` | NOT NULL    |                   | Foreign key, references `user.uuid`, creator of the user record |

--- a/documentation-hub/it-staff/Database Documentation.md
+++ b/documentation-hub/it-staff/Database Documentation.md
@@ -66,7 +66,7 @@ This table stores user information.
 | `email`              | `varchar(200)` | NOT NULL    |                   | User's email address, must be unique                            |
 | `name`               | `varchar(200)` | NULL        |                   | User's full name                                                |
 | `date_of_last_login` | `datetime`     | NULL        |                   | Date and time of user's last login                              |
-| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, standard)                            |
+| `user_type`          | `varchar(12)`  | NOT NULL    |                   | Type of user (e.g., admin, prog_admin, standard)                            |
 | `status`             | `varchar(12)`  | NOT NULL    | active            | User's account status                                           |
 | `date_created`       | `datetime`     | NOT NULL    | Current timestamp | Date and time when the user record was created                  |
 | `author_uuid`        | `varchar(200)` | NOT NULL    |                   | Foreign key, references `user.uuid`, creator of the user record |


### PR DESCRIPTION
# PULL REQUEST

## Summary

Create user functionality
- Admin user can now create program admins
- Program admins can create other program admins/standard users. They can only assign these users to their program area(s)

User menu & NavLinks
- Reflects new `Program admin` user type
- Also fixes #967 
- Program admin user can view all NavLinks.

Testing
- Add/update unit & snapshot tests
- Add integration tests for program admin restrictions
- Add e2e tests. Seeds program admin user (& added program admin user to Azure AD account). Add tests for program admin having limited create user permissions.

Documentation / Local development.
- Add program admin user to Keycloak for local dev. Update README to list all 3 local dev users.
- Update DB documentation to list all 3 `user_type`s

## Screenshots

Screenshots, but please pull the branch and interact with the new `Create user` flow!

**`Create user` as an admin:**
<img width="1361" height="626" alt="Screenshot 2026-08-04 at 12 34 38" src="https://github.com/user-attachments/assets/9dfe63f0-5ea8-4d8f-a805-de58760dc14e" />

**`Create user` as a program admin with only COVID access**
<img width="1094" height="801" alt="Screenshot 2026-08-04 at 12 36 09" src="https://github.com/user-attachments/assets/fb2accc1-e2cd-48d2-915d-129f40292e0a" />

**User menu**
<img width="247" height="137" alt="Screenshot 2026-08-04 at 12 36 26" src="https://github.com/user-attachments/assets/f23bf145-c108-43e1-b1be-1ec18b4c211d" />

## Related Issue

Fixes #1636 

## Acceptance Criteria

- [ ] On the Create User page, an admin (super) can create a user of any user role: 1) Admin, 2) Program Admin, and 3) Standard
- [ ] On the Create user page, a program admin can only create a user of 1) Program Admin or 2) Standard. Existing program admin user can only assign user to their own program area(s). The program area(s) listed should be limited only to the ones they have access to.
- [ ] Standard users can not see the create user page.
- [ ] DB: Program admins are now saved to the user table as program_admin (snake case). If assigned any program areas, they will also be added to user_program_area table.
- [ ] Database documentation and all relevant functions are updated to reflect 2 -> 3 user types
- [ ] Add e2e tests for functions
- [ ] Created a Program Admin user login/password for local development: ecr-viewer-program-admin. Update README (and any other documentation).
- [ ] Update user dropdown so it displays 'Admin', 'Standard', or 'Program Admin'.

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
