### PR TITLE
fix: Patient deceased dateTime formatted to include time

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/services/demographicsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/demographicsService.tsx
@@ -219,7 +219,7 @@ export const evaluatePatientVitalStatus = (patient: Patient | undefined) => {
 };
 
 /***
- * A patient is deceased if `patient.deceasedBoolean` is true or if there is a date of death. If both are `undefined`
+ * A patient is deceased if `patient.deceasedBoolean` is true or if there is a date/time of death. If both are `undefined`
  * return `undefined`.
  */
 const isPatientDeceased = (patient: Patient | undefined) => {
@@ -359,7 +359,7 @@ export const evaluateDemographicsData = (
       value: evaluatePatientVitalStatus(patient),
     },
     {
-      title: "Date of Death",
+      title: "Death Date/Time",
       value: formatDateTime(evaluateOne(patient, fhirPathMappings.patientDOD)),
     },
     {

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/EcrDocument/__snapshots__/EcrDocument.test.tsx.snap
@@ -547,7 +547,7 @@ exports[`Tests for eCR Document Given no data, info message for empty sections s
                         <div
                           class="data-title padding-right-1"
                         >
-                          Date of Death
+                          Death Date/Time
                         </div>
                         <div
                           class="grid-col maxw7 text-pre-line p-list text-italic text-base"

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
@@ -187,7 +187,7 @@ describe("Evaluate Patient Info: Demographics", () => {
 
       // Date of death
       const actualDateOfDeath = formatDateTime(
-        evaluateOne(patientWithDOD, fhirPathMappings.patientDOD)
+        evaluateOne(patientWithDOD, fhirPathMappings.patientDOD),
       );
       expect(actualDateOfDeath).toInclude("01/27/2026 8:00");
     });

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
@@ -4,7 +4,7 @@ import * as _BundleWithPatient from "@/../../../test-data/fhir/BundlePatient.jso
 import * as _BundleWithDeceasedPatient from "@/../../../test-data/fhir/BundlePatientDeceased.json";
 import * as _BundlePatientMultiple from "@/../../../test-data/fhir/BundlePatientMultiple.json";
 import { formatAge } from "@/app/services/formatService";
-import { evaluateValue } from "@/app/utils/evaluate";
+import { evaluateOne, evaluateValue } from "@/app/utils/evaluate";
 import mappings from "@/app/utils/evaluate/fhir-paths";
 
 import {
@@ -21,6 +21,8 @@ import {
   createPatientAgeDataProp,
 } from "@/app/view-data/services/demographicsService";
 import { getFhirIndex } from "@/app/view-data/services/fhirResourcesIndexService";
+import { formatDateTime } from "@/app/services/formatDateService";
+import fhirPathMappings from "@/app/utils/evaluate/fhir-paths";
 
 const BundleWithPatient = _BundleWithPatient as Bundle;
 const fhirIndexBundleWithPatient = getFhirIndex(BundleWithPatient);
@@ -173,7 +175,7 @@ describe("Evaluate Patient Info: Demographics", () => {
             resource: {
               id: "1",
               resourceType: "Patient",
-              deceasedDateTime: "2026-01-27",
+              deceasedDateTime: "2026-01-27T08:00:00",
             },
           },
         ],
@@ -182,6 +184,12 @@ describe("Evaluate Patient Info: Demographics", () => {
       const patientWithDOD = getPatient(fhirIndex);
       const actual = evaluatePatientVitalStatus(patientWithDOD);
       expect(actual).toEqual("Deceased");
+
+      // Date of death
+      const actualDateOfDeath = formatDateTime(
+        evaluateOne(patientWithDOD, fhirPathMappings.patientDOD)
+      );
+      expect(actualDateOfDeath).toInclude("01/27/2026 8:00");
     });
   });
 

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
@@ -185,7 +185,7 @@ describe("Evaluate Patient Info: Demographics", () => {
       const actual = evaluatePatientVitalStatus(patientWithDOD);
       expect(actual).toEqual("Deceased");
 
-      // Date of death
+      // Death Date/Time
       const actualDateOfDeath = formatDateTime(
         evaluateOne(patientWithDOD, fhirPathMappings.patientDOD),
       );
@@ -208,7 +208,7 @@ describe("Evaluate Patient Info: Demographics", () => {
   });
 
   describe("Create Patient Age Data Prop", () => {
-    it("should return Age at Death if there is a date of death", () => {
+    it("should return Age at Death if there is a death date/time", () => {
       const patientAgeProp = createPatientAgeDataProp(
         BundleWithDeceasedPatient,
         patientDeceased,
@@ -632,7 +632,7 @@ Home: 123-456-6909`,
     );
   });
 
-  it("should show Vital Status as Deceased and Date of Death when deceasedDateTime is present", () => {
+  it("should show Vital Status as Deceased and Death Date/Time when deceasedDateTime is present", () => {
     const deceasedBundle = {
       resourceType: "Bundle",
       entry: [
@@ -651,7 +651,7 @@ Home: 123-456-6909`,
     const vitalStatus = actual.availableData.find(
       (d) => d.title === "Vital Status",
     );
-    const dod = actual.availableData.find((d) => d.title === "Date of Death");
+    const dod = actual.availableData.find((d) => d.title === "Death Date/Time");
 
     expect(vitalStatus?.value).toEqual("Deceased");
     expect(dod?.value).toEqual("01/27/2026");

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/fix-patient-deceased-dateTime --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.11 --depth 1 /App
 
 WORKDIR /App
 

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.7.10 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch angela/fix-patient-deceased-dateTime --depth 1 /App
 
 WORKDIR /App
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

Fix datetime formatting for patient deceasedDateTime (FHIR converter PR). Adds unit test to cover deceased Time in `demographicsService`. Update `Date of Death` title to `Death Date/Time`

## Screenshot
<img width="1478" height="393" alt="Screenshot 2026-07-30 at 17 47 33" src="https://github.com/user-attachments/assets/db0098ee-f004-4378-9107-47111b5063d9" />

## Related Issue

Fixes https://github.com/CDCgov/dibbs-ecr-viewer/issues/1338

(FUP fix to https://github.com/CDCgov/dibbs-ecr-viewer/pull/1641 and https://github.com/CDCgov/dibbs-FHIR-Converter/pull/149)

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
