### PR TITLE
fix: Prevent FHIR evaluation cache collisions across eCR versions

### DIFF
--- a/containers/ecr-viewer/src/app/utils/evaluate/index.ts
+++ b/containers/ecr-viewer/src/app/utils/evaluate/index.ts
@@ -2,7 +2,6 @@ import "server-only"; // fhirpath should only be used on the server
 
 import {
   Address,
-  Bundle,
   CodeableConcept,
   Coding,
   Element,
@@ -35,17 +34,7 @@ import {
   getResourceById,
 } from "@/app/view-data/services/fhirResourcesIndexService";
 
-// TODO: Follow up on FHIR/fhirpath typing
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const evaluateCache: Map<string, any> = new Map();
-
-const isBundle = (e: Element | Element[] | FhirResource): e is Bundle => {
-  if ("resourceType" in e) {
-    return e?.resourceType === "Bundle";
-  }
-
-  return false;
-};
+let evaluateCache = new WeakMap<object, Map<string, unknown[]>>();
 
 type FhirData = Element | Element[] | FhirResource | undefined;
 
@@ -123,13 +112,17 @@ export const evaluateAllAndCheck = <Result>(
   base?: string,
 ): Result[] => {
   if (!fhirData) return [];
-  const fhirDataIdentifier: string =
-    (isBundle(fhirData)
-      ? fhirData?.entry?.[0]?.fullUrl
-      : !Array.isArray(fhirData) && fhirData?.id) || JSON.stringify(fhirData);
-  const key =
-    fhirDataIdentifier + JSON.stringify(context) + JSON.stringify(path);
-  if (!evaluateCache.has(key)) {
+
+  const cacheTarget = fhirData as object;
+  const key = JSON.stringify({ path, expectedType, context, base });
+  let resourceCache = evaluateCache.get(cacheTarget);
+
+  if (!resourceCache) {
+    resourceCache = new Map<string, unknown[]>();
+    evaluateCache.set(cacheTarget, resourceCache);
+  }
+
+  if (!resourceCache.has(key)) {
     const result = fhirPathEvaluate(
       fhirData,
       base ? { expression: path, base } : path,
@@ -137,9 +130,10 @@ export const evaluateAllAndCheck = <Result>(
       fhirpath_r4_model,
     ) as Result[];
     checkResult(result, expectedType);
-    evaluateCache.set(key, result);
+    resourceCache.set(key, result);
   }
-  return evaluateCache.get(key);
+
+  return resourceCache.get(key) as Result[];
 };
 
 /**
@@ -171,7 +165,7 @@ export const evaluateOneAndCheck = <Result>(
  * Reset the evaluate cache map
  */
 export const clearEvaluateCache = () => {
-  evaluateCache.clear();
+  evaluateCache = new WeakMap<object, Map<string, unknown[]>>();
 };
 
 /**

--- a/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/utils/evaluate.test.ts
@@ -37,82 +37,78 @@ describe("evaluate", () => {
     );
   });
   it("should call fhirpath.evaluate 1 time when the same call is made 2 times", () => {
-    evaluateAllAndCheck<string>({ id: "2345" }, "id", "string");
-    evaluateAllAndCheck<string>({ id: "2345" }, "id", "string");
+    const resource = { id: "2345" };
+
+    evaluateAllAndCheck<string>(resource, "id", "string");
+    evaluateAllAndCheck<string>(resource, "id", "string");
 
     expect(fhirPathEvaluateSpy).toHaveBeenCalledExactlyOnceWith(
-      { id: "2345" },
+      resource,
       "id",
       undefined,
       fhirpath_r4_model,
     );
   });
   it("should call fhirpath.evaluate 2 time when the context is different", () => {
-    evaluateAllAndCheck<string>({ id: "%id" }, "id", "string", { id: 1 });
-    evaluateAllAndCheck<string>({ id: "%id" }, "id", "string", { id: 2 });
+    const resource = { id: "%id" };
+
+    evaluateAllAndCheck<string>(resource, "id", "string", { id: 1 });
+    evaluateAllAndCheck<string>(resource, "id", "string", { id: 2 });
 
     expect(fhirPathEvaluateSpy).toHaveBeenCalledTimes(2);
     expect(fhirPathEvaluateSpy).toHaveBeenNthCalledWith(
       1,
-      { id: "%id" },
+      resource,
       "id",
       { id: 1 },
       fhirpath_r4_model,
     );
     expect(fhirPathEvaluateSpy).toHaveBeenNthCalledWith(
       2,
-      { id: "%id" },
+      resource,
       "id",
       { id: 2 },
       fhirpath_r4_model,
     );
   });
 
-  it("should call once per bundle url", () => {
-    // this test can use any valid mapping
-    evaluateAll(
-      {
-        resourceType: "Bundle",
-        type: "document",
-        entry: [{ fullUrl: "test/123" }],
-      },
-      fhirPathMappings.careTeamParticipantPeriod,
-    );
-    evaluateAll(
-      {
-        resourceType: "Bundle",
-        type: "document",
-        entry: [{ fullUrl: "test/123" }],
-      },
-      fhirPathMappings.careTeamParticipantPeriod,
-    );
+  it("should reuse an evaluation for the same bundle instance", () => {
+    const bundle: Bundle = {
+      resourceType: "Bundle",
+      type: "document",
+      entry: [{ fullUrl: "test/123" }],
+    };
+
+    evaluateAll(bundle, fhirPathMappings.careTeamParticipantPeriod);
+    evaluateAll(bundle, fhirPathMappings.careTeamParticipantPeriod);
 
     expect(fhirPathEvaluateSpy).toHaveBeenCalledExactlyOnceWith(
-      {
-        resourceType: "Bundle",
-        type: "document",
-        entry: [{ fullUrl: "test/123" }],
-      },
+      bundle,
       "period.text",
       undefined,
       fhirpath_r4_model,
     );
   });
 
-  it("should call once if id is the same", () => {
-    // this test can use any valid mapping
-    evaluateAll({ id: "1234" }, fhirPathMappings.careTeamParticipantPeriod);
-    evaluateAll(
-      { id: "1234", resourceType: "Observation" },
-      fhirPathMappings.careTeamParticipantPeriod,
-    );
+  it("should evaluate distinct resources that share an ID separately", () => {
+    const preliminary = {
+      id: "same-id",
+      resourceType: "Observation",
+      status: "preliminary",
+    } as Observation;
+    const final = {
+      id: "same-id",
+      resourceType: "Observation",
+      status: "final",
+    } as Observation;
 
-    expect(fhirPathEvaluateSpy).toHaveBeenCalledExactlyOnceWith(
-      { id: "1234" },
-      "period.text",
-      undefined,
-      fhirpath_r4_model,
-    );
+    expect(
+      evaluateAllAndCheck<string>(preliminary, "status", "string"),
+    ).toEqual(["preliminary"]);
+    expect(evaluateAllAndCheck<string>(final, "status", "string")).toEqual([
+      "final",
+    ]);
+    expect(fhirPathEvaluateSpy).toHaveBeenCalledTimes(2);
   });
 
   describe("evaluateOne", () => {

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/ClinicalInfo.test.tsx
@@ -94,7 +94,7 @@ describe("Snapshot tests", () => {
                   entry: [
                     {
                       reference:
-                        "Procedure/b40f0081-4052-4971-3f3b-e3d9f5e1e44d",
+                        "Procedure/b40f0081-4052-4971-3f3b-e3d9f5e1e44d-2",
                     },
                     {
                       reference:
@@ -171,7 +171,7 @@ describe("Snapshot tests", () => {
           },
           {
             resource: {
-              id: "b40f0081-4052-4971-3f3b-e3d9f5e1e44d",
+              id: "b40f0081-4052-4971-3f3b-e3d9f5e1e44d-2",
               code: {
                 coding: [
                   {

--- a/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/components/__snapshots__/ClinicalInfo.test.tsx.snap
@@ -898,12 +898,12 @@ exports[`Snapshot tests Snapshot test for Procedures (Treatment Details) should 
                           <td
                             class="text-top text-pre-line"
                           >
-                            HC HETEROPHILE ANTIBODIES SCREENING
+                            HC INFECTIOUS DISEASE PATHOGEN SPECIFIC RNA SARS-COV-2/INF A&B/RSV UPPER RESP SPEC DETECTED OR NOT
                           </td>
                           <td
                             class="text-top text-pre-line"
                           >
-                            02/04/2025 12:53 PM EST
+                            06/24/2022 12:50 PM EDT
                           </td>
                           <td
                             class="text-top text-pre-line"
@@ -913,11 +913,47 @@ exports[`Snapshot tests Snapshot test for Procedures (Treatment Details) should 
                           <td
                             class="text-top text-pre-line"
                           >
-                            <span
-                              class="text-italic text-base"
+                            <button
+                              aria-controls="hidden-comment-r:id"
+                              aria-expanded="false"
+                              class="usa-button usa-button--unstyled"
+                              data-test-id="comment-button"
+                              data-testid="button"
+                              type="button"
                             >
-                              No data
-                            </span>
+                              View
+                               
+                              details
+                            </button>
+                          </td>
+                        </tr>
+                        <tr
+                          hidden=""
+                          id="hidden-comment-r:id"
+                        >
+                          <td
+                            class="p-list"
+                            colspan="4"
+                          >
+                            <div
+                              class="border-top border-base-lighter margin-top-neg-105 margin-bottom-1"
+                            />
+                            <div>
+                              <div
+                                class="grid-row"
+                              >
+                                <div
+                                  class="data-title padding-right-1"
+                                >
+                                  Reason
+                                </div>
+                                <div
+                                  class="grid-col maxw7 text-pre-line p-list"
+                                >
+                                  Struck by nonvenomous lizards, sequela
+                                </div>
+                              </div>
+                            </div>
                           </td>
                         </tr>
                         <tr>

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/socialHistoryService.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/__snapshots__/socialHistoryService.test.tsx.snap
@@ -542,7 +542,7 @@ Nowhereville, KS",
         </React.Fragment>,
         "expanded": false,
         "headingLevel": "h5",
-        "id": "12345",
+        "id": "12345-2",
         "title": <div
           className="display-flex flex-row flex-no-wrap flex-justify"
         >
@@ -582,105 +582,13 @@ Nowhereville, KS",
           <DataDisplay
             item={
               {
-                "fullWidthContent": true,
+                "fullWidthContent": false,
                 "title": "Workplace Information",
-                "value": [
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Address",
-                        "titleNormal": true,
-                        "value": "123 Test St
-Nowhereville, KS",
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Schedule",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Hours",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Days",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Duties",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Pay Grade",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                  <DataDisplay
-                    item={
-                      {
-                        "dividerLine": false,
-                        "title": "Employment Type",
-                        "titleNormal": true,
-                        "value": <span
-                          className="text-italic text-base"
-                        >
-                          No data
-                        </span>,
-                      }
-                    }
-                  />,
-                ],
+                "value": <span
+                  className="text-italic text-base"
+                >
+                  No data
+                </span>,
               }
             }
           />

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/socialHistoryService.test.tsx
@@ -896,7 +896,7 @@ describe("Evaluate Patient Info: Social History", () => {
           {
             resource: {
               resourceType: "Observation",
-              id: "12345",
+              id: "12345-2",
               status: "final",
               meta: {
                 profile: [


### PR DESCRIPTION
# PULL REQUEST

## Summary

Problem: FHIR resource IDs can remain the same across different versions of an eCR even when the resource content changes. 

Examples: a preliminary lab result may become final, a patient may be marked as deceased....

- **Previously**: FHIRPath evaluation was caching (global) using resource ID and FHIR path.
    - Incorrect behavior: Viewer would return values cached from whichever version was evaluated first -> stale and/or incorrect FHIR information was appearing across bundles that shared those resource IDs (i.e. different eCR versions).
    - Ex. Mon Mothma v3 (Vital Status = Alive) was displaying Vital Status = Deceased when they were only marked as deceased in v4).

- **Solution**: Update evaluation cache to use the resource object as the key through a WeakMap. So even when FHIR resource IDs match, prevents values from one version leaking into another

Also updated tests (evaluation tests, snapshot tests that were prev. incorrect due to cache collisions)

## Screenshot
Mon Mothma v3 (Left) vs. Mon Mothma v4 (Right) -- Same patient resource ID, but no collision
<img width="1434" height="358" alt="Screenshot 2026-07-30 at 20 48 58" src="https://github.com/user-attachments/assets/bc605609-1db4-4799-bb78-fc20c23ae999" />


## Related Issue

Fixes # NA

Bug found during release `11.0.0` testing (though NOT introduced in this past release)

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Possible cons: higher CPU? Open to any thoughts about improving this!

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
