### PR TITLE
fix: Edit user/program area button should stay violet

### DIFF
--- a/containers/ecr-viewer/src/styles/dibbs-design-system.scss
+++ b/containers/ecr-viewer/src/styles/dibbs-design-system.scss
@@ -75,6 +75,11 @@ h5,
     background-color: transparent;
     color: color("secondary");
 
+    &:visited {
+      background-color: transparent;
+      color: color("secondary");
+    }
+
     &:hover {
       background-color: transparent;
       box-shadow: inset 0 0 0 2px color("secondary-dark");


### PR DESCRIPTION
# PULL REQUEST

## Summary

`Edit user` and `Edit program area` buttons were changing color to blue when clicked. Modified so that both buttons keep violet text when clicked on.

## Screenshots
**Before**
<img width="1442" height="536" alt="Screenshot 2026-08-04 at 10 30 20" src="https://github.com/user-attachments/assets/faacf17e-5223-49ef-a975-5503012279d7" />

**After**
<img width="1472" height="521" alt="Screenshot 2026-08-04 at 10 30 43" src="https://github.com/user-attachments/assets/0eae99d6-9956-4468-bf99-611e960c7b58" />

## Related Issue

Fixes #974 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
