### PR TITLE
feat: Add Admin Hierarchy Pt. 6 - Edit & delete users

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
@@ -26,9 +26,11 @@ import { makePlural } from "@/app/utils/format-utils";
 export const ProgramTable = ({
   programAreas,
   deleteAction,
+  isLoggedInUserAdmin
 }: {
   programAreas: ListedProgramArea[];
   deleteAction: (uuid: string) => Promise<ServerActionResult<void>>;
+  isLoggedInUserAdmin: boolean;
 }) => {
   const detailsRef = useDetailsRef();
   const [selectedProgramArea, setSelectedProgramArea] =
@@ -63,6 +65,7 @@ export const ProgramTable = ({
   return (
     <div>
       <DetailsSidePanel
+        isLoggedInUserAdmin={isLoggedInUserAdmin}
         detailsRef={detailsRef}
         title={selectedProgramArea?.name!}
         subtitle={`Created on ${formatDateTime(

--- a/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramTable.tsx
@@ -26,7 +26,7 @@ import { makePlural } from "@/app/utils/format-utils";
 export const ProgramTable = ({
   programAreas,
   deleteAction,
-  isLoggedInUserAdmin
+  isLoggedInUserAdmin,
 }: {
   programAreas: ListedProgramArea[];
   deleteAction: (uuid: string) => Promise<ServerActionResult<void>>;

--- a/containers/ecr-viewer/src/app/admin/program/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/page.tsx
@@ -3,9 +3,10 @@ import Link from "next/link";
 
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { deleteProgramAreaAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAdmin } from "@/app/services/userService";
+import { isAdmin, notFoundUnlessAdmin } from "@/app/services/userService";
 
 import { ProgramTable } from "./ProgramTable";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
  * Program admin landing page with table of active users
@@ -13,6 +14,7 @@ import { ProgramTable } from "./ProgramTable";
  */
 const ProgramAdminPage = async () => {
   await notFoundUnlessAdmin();
+  const currentUser = await getLoggedInUser();
 
   const programAreas = await listProgramAreas();
 
@@ -40,6 +42,7 @@ const ProgramAdminPage = async () => {
               revalidatePath("/ecr-viewer/admin/program");
               return res;
             }}
+            isLoggedInUserAdmin={isAdmin(currentUser)}
           />
         )}
       </div>

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -161,7 +161,9 @@ const EmailFieldSet = ({
     <FieldSet legend={<span className={disabledTextClass}>Email</span>}>
       {!isDisabled && <span>Add the new user by their login email</span>}
       <FormGroup error={emailIsDupe}>
-        <label className={classNames("usa-label", "maxw-full", disabledTextClass)}>
+        <label
+          className={classNames("usa-label", "maxw-full", disabledTextClass)}
+        >
           Email
           {!isDisabled && <RequiredMarker />}
           {emailIsDupe && (

--- a/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserForm.tsx
@@ -20,6 +20,7 @@ import { UserType, ListedUser } from "@/app/services/userService";
 import { AccordionItem } from "@/app/types";
 import { notEmpty } from "@/app/utils/data-utils";
 import { makePlural, stringSort, toKebabCase } from "@/app/utils/format-utils";
+import classNames from "classnames";
 
 export interface FormProgram extends ListedProgramArea {
   checked?: boolean;
@@ -125,11 +126,13 @@ export const UserForm = ({
         email={email}
         setEmail={setEmail}
         emailIsDupe={emailIsDupe}
+        isDisabled={action === "Edit" && !isLoggedInUserAdmin}
       />
       <UserTypeFieldSet
         userType={userType}
         setUserType={setUserType}
         isLoggedInUserAdmin={isLoggedInUserAdmin}
+        isDisabled={action === "Edit" && !isLoggedInUserAdmin}
       />
       <ProgramFieldSet
         programs={programs}
@@ -145,18 +148,22 @@ const EmailFieldSet = ({
   email,
   setEmail,
   emailIsDupe,
+  isDisabled,
 }: {
   email: string;
   setEmail: (n: string) => void;
   emailIsDupe?: boolean;
+  isDisabled: boolean;
 }) => {
+  const disabledTextClass = isDisabled ? "text-base" : undefined;
+
   return (
-    <FieldSet legend="Email">
-      <span>Add the new user by their login email</span>
+    <FieldSet legend={<span className={disabledTextClass}>Email</span>}>
+      {!isDisabled && <span>Add the new user by their login email</span>}
       <FormGroup error={emailIsDupe}>
-        <label className="usa-label maxw-full">
+        <label className={classNames("usa-label", "maxw-full", disabledTextClass)}>
           Email
-          <RequiredMarker />
+          {!isDisabled && <RequiredMarker />}
           {emailIsDupe && (
             <p className="usa-error-message margin-0">
               This email already exists. Please add a different email.
@@ -168,6 +175,7 @@ const EmailFieldSet = ({
             id="email"
             name="email"
             value={email}
+            disabled={isDisabled}
             onChange={(e) => setEmail(e.target.value)}
           />
         </label>
@@ -180,17 +188,23 @@ const UserTypeFieldSet = ({
   userType,
   setUserType,
   isLoggedInUserAdmin,
+  isDisabled,
 }: {
   userType: UserType;
   setUserType: (n: UserType) => void;
   isLoggedInUserAdmin: boolean;
+  isDisabled: boolean;
 }) => {
+  const disabledTextClass = isDisabled ? "text-base" : undefined;
+
   return (
-    <FieldSet legend="User type">
-      <span>
-        Select the user type
-        <RequiredMarker />
-      </span>
+    <FieldSet legend={<span className={disabledTextClass}>User type</span>}>
+      {!isDisabled && (
+        <span>
+          Select the user type
+          <RequiredMarker />
+        </span>
+      )}
       {[
         ...(isLoggedInUserAdmin
           ? [
@@ -225,6 +239,7 @@ const UserTypeFieldSet = ({
           id={`userType-${option.value}`}
           value={option.value}
           checked={userType === option.value}
+          disabled={isDisabled}
           onChange={(e) => setUserType(e.target.value as UserType)}
         />
       ))}

--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -167,6 +167,7 @@ export const UserTable = ({
   return (
     <div>
       <DetailsSidePanel
+        isLoggedInUserAdmin={isLoggedInUserAdmin}
         detailsRef={detailsRef}
         title={selectedUser?.name ? selectedUser?.name : selectedUser?.email!}
         subtitle={`Last logged in: ${

--- a/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
@@ -49,7 +49,11 @@ const EditUserPage = async ({
   );
 
   const isValidUserType = (value: string): value is UserType => {
-    return value === USER_TYPE.ADMIN || value === USER_TYPE.PROG_ADMIN || value === USER_TYPE.STANDARD;
+    return (
+      value === USER_TYPE.ADMIN ||
+      value === USER_TYPE.PROG_ADMIN ||
+      value === USER_TYPE.STANDARD
+    );
   };
 
   const users = await listUsers();

--- a/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
@@ -3,14 +3,15 @@ import { notFound } from "next/navigation";
 
 import { UserForm } from "@/app/admin/user/UserForm";
 import { USER_TYPE } from "@/app/constants";
-import { isAdmin, UserType } from "@/app/services/userService";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { updateUserAction } from "@/app/services/serverActionService";
 import {
+  isAdmin,
+  notFoundUnlessAnyAdmin,
+  UserType,
   getUser,
   listUserProgramAreas,
   listUsers,
-  notFoundUnlessAdmin,
 } from "@/app/services/userService";
 import { PageSearchParams } from "@/app/utils/search-param-utils";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
@@ -26,7 +27,7 @@ const EditUserPage = async ({
 }: {
   searchParams: Promise<PageSearchParams>;
 }) => {
-  await notFoundUnlessAdmin();
+  await notFoundUnlessAnyAdmin();
   const currentUser = await getLoggedInUser();
   const { uuid } = await searchParams;
 

--- a/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
@@ -71,8 +71,7 @@ const EditUserPage = async ({
         const res = await updateUserAction({
           uuid,
           updates: {
-            email,
-            user_type: userType,
+            ...(isAdmin(currentUser) ? { email, user_type: userType } : {}),
           },
           programs,
         });

--- a/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/edit/page.tsx
@@ -48,7 +48,7 @@ const EditUserPage = async ({
   );
 
   const isValidUserType = (value: string): value is UserType => {
-    return value === USER_TYPE.ADMIN || value === USER_TYPE.STANDARD;
+    return value === USER_TYPE.ADMIN || value === USER_TYPE.PROG_ADMIN || value === USER_TYPE.STANDARD;
   };
 
   const users = await listUsers();

--- a/containers/ecr-viewer/src/app/components/DetailsSidePanel.tsx
+++ b/containers/ecr-viewer/src/app/components/DetailsSidePanel.tsx
@@ -88,6 +88,7 @@ interface Detail {
  * @returns Side Panel component
  */
 export const DetailsSidePanel = ({
+  isLoggedInUserAdmin,
   detailsRef,
   details,
   title,
@@ -99,6 +100,7 @@ export const DetailsSidePanel = ({
   deleteModalTitle,
   deleteModalBody,
 }: {
+  isLoggedInUserAdmin: boolean;
   detailsRef: RefObject<ModalRef | null>;
   details: Detail[];
   title: string;
@@ -162,55 +164,61 @@ export const DetailsSidePanel = ({
             </dl>
           </section>
         </div>
-        <ModalFooter className="border-top border-base-lighter display-flex flex-justify padding-top-3 gap-1">
-          <div>
-            <h3 className="margin-top-0">Remove {itemType}</h3>
-            <p>{deleteExplainerText}</p>
-          </div>
-          <div>
-            <ModalToggleButton
-              type="button"
-              outline={true}
-              modalRef={confirmRef}
-              className="text-no-wrap"
-              opener={true}
-              closer={false}
-            >
-              Remove {itemType}
-            </ModalToggleButton>
-          </div>
-        </ModalFooter>
+        {/* Program admins can't delete users or program areas */}
+        {isLoggedInUserAdmin && (
+          <ModalFooter className="border-top border-base-lighter display-flex flex-justify padding-top-3 gap-1">
+            <div>
+              <h3 className="margin-top-0">Remove {itemType}</h3>
+              <p>{deleteExplainerText}</p>
+            </div>
+            <div>
+              <ModalToggleButton
+                type="button"
+                outline={true}
+                modalRef={confirmRef}
+                className="text-no-wrap"
+                opener={true}
+                closer={false}
+              >
+                Remove {itemType}
+              </ModalToggleButton>
+            </div>
+          </ModalFooter>
+        )}
       </Modal>
 
       {/* NOTE: order is important here so the confirmation goes on top of the side panel*/}
-      <Modal
-        id={`delete-confirm-${id}`}
-        className="delete-confirm-modal"
-        ref={confirmRef}
-        aria-labelledby={`delete-confirm-${id}-heading`}
-        aria-describedby={`delete-confirm-${id}-description`}
-      >
-        <ModalHeading id={`delete-confirm-${id}-heading`}>
-          {deleteModalTitle}
-        </ModalHeading>
-        {deleteModalBody}
-
-        <ConfirmationFooter
-          modalRef={confirmRef}
-          onConfirm={async () => {
-            const res = await deleteAction();
-            detailsRef.current?.toggleModal(undefined, false);
-            if (res.error) {
-              createToast(res.error, "error");
-            } else {
-              createToast(`${title} successfully removed`, "success");
-            }
-            router.refresh();
-          }}
+      {/* Program admins should never reach the delete confirmation modal */}
+      {isLoggedInUserAdmin && (
+        <Modal
+          id={`delete-confirm-${id}`}
+          className="delete-confirm-modal"
+          ref={confirmRef}
+          aria-labelledby={`delete-confirm-${id}-heading`}
+          aria-describedby={`delete-confirm-${id}-description`}
         >
-          Yes, remove {itemType}
-        </ConfirmationFooter>
-      </Modal>
+          <ModalHeading id={`delete-confirm-${id}-heading`}>
+            {deleteModalTitle}
+          </ModalHeading>
+          {deleteModalBody}
+
+          <ConfirmationFooter
+            modalRef={confirmRef}
+            onConfirm={async () => {
+              const res = await deleteAction();
+              detailsRef.current?.toggleModal(undefined, false);
+              if (res.error) {
+                createToast(res.error, "error");
+              } else {
+                createToast(`${title} successfully removed`, "success");
+              }
+              router.refresh();
+            }}
+          >
+            Yes, remove {itemType}
+          </ConfirmationFooter>
+        </Modal>
+      )}
     </>
   );
 };

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -9,7 +9,6 @@ import {
   ConditionReference,
   Core,
   ProgramArea,
-  User,
 } from "@/app/data/metadataDb/types/core";
 import { stringSort } from "@/app/utils/format-utils";
 
@@ -18,8 +17,6 @@ import { UserFacingError } from "./errorService";
 import {
   getCheckAdmin,
   getCheckAnyAdmin,
-  isAdmin,
-  isProgramAdmin,
   listUserProgramAreasQuery,
 } from "./userService";
 

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -123,7 +123,6 @@ export const hasRelevantProgramAreaAccess = async (
     targetUser.user_type === USER_TYPE.PROG_ADMIN ||
     targetUser.user_type === USER_TYPE.STANDARD
   ) {
-
     const res = await getDb<Core>()
       .selectFrom("user_program_area")
       .select("user_program_area.program_area_uuid")
@@ -189,23 +188,21 @@ export const hasRelevantUserAccess = async (
  * editing.
  * @returns A promise that resolves when the permission checks pass.
  */
-export async function validateAdminUserPermissions(
-  {
-    loggedInUser,
-    action,
-    targetUserType,
-    targetProgramAreaUuids,
-    targetUserUuid,
-    targetEmail,
-  }: {
-    loggedInUser: User;
-    action: "create" | "edit";
-    targetUserType?: User["user_type"];
-    targetProgramAreaUuids: string[];
-    targetUserUuid?: string;
-    targetEmail?: string | null;
-  },
-) {
+export async function validateAdminUserPermissions({
+  loggedInUser,
+  action,
+  targetUserType,
+  targetProgramAreaUuids,
+  targetUserUuid,
+  targetEmail,
+}: {
+  loggedInUser: User;
+  action: "create" | "edit";
+  targetUserType?: User["user_type"];
+  targetProgramAreaUuids: string[];
+  targetUserUuid?: string;
+  targetEmail?: string | null;
+}) {
   if (isAdmin(loggedInUser)) return;
 
   if (targetUserType === USER_TYPE.ADMIN) {
@@ -544,9 +541,7 @@ export const listLoggedInUserProgramAreas = async (): Promise<
   ProgramArea[]
 > => {
   const user = await getLoggedInUser();
-  return user
-    ? await listUserProgramAreasQuery(getDb<Core>(), user.uuid)
-    : [];
+  return user ? await listUserProgramAreasQuery(getDb<Core>(), user.uuid) : [];
 };
 
 export const listUserProgramAreasQuery = async (

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -229,7 +229,7 @@ export async function validateAdminUserPermissions({
   // Program areas
   const hasAccess = await hasRelevantProgramAreaAccess(
     loggedInUser,
-    targetProgramAreaUuids
+    targetProgramAreaUuids,
   );
   if (!hasAccess) {
     throw new UserFacingError(

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -123,6 +123,7 @@ export const hasRelevantProgramAreaAccess = async (
     targetUser.user_type === USER_TYPE.PROG_ADMIN ||
     targetUser.user_type === USER_TYPE.STANDARD
   ) {
+    // TODO ANGELA (LATER): Can this use an existing helper function?
     const res = await getDb<Core>()
       .selectFrom("user_program_area")
       .select("user_program_area.program_area_uuid")
@@ -141,23 +142,60 @@ export const hasRelevantProgramAreaAccess = async (
 };
 
 /**
- * Validates whether a user has permission to manage another user's role and
- * program area assignments.
+ * Checks whether a target user is active and shares at least one program area
+ * with the currently logged-in user.
+ * @param targetUserUuid UUID of the target user
+ * @returns whether the target user has access relevant to the logged-in user
+ */
+export const hasRelevantUserAccess = async (
+  targetUserUuid: string,
+): Promise<boolean> => {
+  const targetUser = await getUser(targetUserUuid);
+  const [targetProgramAreas, loggedInProgramAreas] = await Promise.all([
+    listUserProgramAreas(targetUserUuid),
+    listLoggedInUserProgramAreas(),
+  ]);
+  const hasSharedProgramArea = targetProgramAreas.some(({ uuid }) =>
+    loggedInProgramAreas.some(
+      ({ uuid: loggedInProgramUuid }) => loggedInProgramUuid === uuid,
+    ),
+  );
+
+  if (!targetUser || targetUser.status !== "active" || !hasSharedProgramArea) {
+    return false;
+  }
+
+  return true;
+};
+
+// TODO ANGELA: loggedInUser vs targetUserUuid cleanup? email cleanup?
+/**
+ * Validates whether the logged-in user can create or edit another user's
+ * account, role, email, and program area assignments.
  *
- * Admin users bypass all restrictions. Program admins cannot manage admin users
- * and can only assign users to program areas they have access to.
+ * Admin users bypass all restrictions. Program admins cannot manage admin
+ * users, manage users outside their program areas, or modify a user's role or
+ * email when editing an existing user.
  *
  * @param loggedInUser - The user performing the user management action.
- * @param userType - The user type being assigned to the managed user.
- * @param programs - The program area IDs being assigned to the managed user.
+ * @param userType - The user type being assigned, if provided.
+ * @param programs - The program area UUIDs being assigned.
+ * @param action - Whether the user is being created or edited.
+ * @param targetUserUuid - The UUID of the user being edited, if applicable.
+ * @param email - The email being assigned, if provided.
  *
  * @throws {UserFacingError} If a program admin attempts to manage an admin user
- * or assign a user to a program area they do not have access to.
+ * or a user outside their program areas, or modify a user's role or email while
+ * editing.
+ * @returns A promise that resolves when the permission checks pass.
  */
 export async function validateAdminUserPermissions(
   loggedInUser: User,
-  userType: UserType,
+  userType: string | undefined,
   programs: string[],
+  action: "create" | "edit",
+  targetUserUuid?: string,
+  email?: string | null,
 ) {
   if (isAdmin(loggedInUser)) return;
 
@@ -165,6 +203,24 @@ export async function validateAdminUserPermissions(
     throw new UserFacingError("Program admins cannot manage admins.");
   }
 
+  if (targetUserUuid) {
+    const hasUserAccess = await hasRelevantUserAccess(targetUserUuid);
+    if (!hasUserAccess) {
+      throw new UserFacingError(
+        "Program admins cannot manage users outside of their program areas",
+      );
+    }
+  }
+
+  if (action === "edit") {
+    if (!!userType || !!email) {
+      throw new UserFacingError(
+        "Program admins cannot modify user emails or roles.",
+      );
+    }
+  }
+
+  // Program areas
   const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, programs);
   if (!hasAccess) {
     throw new UserFacingError(
@@ -250,7 +306,12 @@ export const createUser = audit(
     trx: Transaction<Core>,
   ): Promise<string> => {
     const creatingUser = await getCheckAnyAdmin("create new users");
-    await validateAdminUserPermissions(creatingUser, userType, programs);
+    await validateAdminUserPermissions(
+      creatingUser,
+      userType,
+      programs,
+      "create",
+    );
 
     try {
       const uuid = await createUserQuery(
@@ -396,9 +457,16 @@ export const updateUser = audit(
   ): Promise<void> => {
     const updatingUser = await getCheckAnyAdmin("update users");
 
-    // TODO ANGELA: Add validateAdminUserPermissions
-
     try {
+      await validateAdminUserPermissions(
+        updatingUser,
+        updates.user_type,
+        programs,
+        "edit",
+        uuid,
+        updates.email,
+      );
+
       await checkDupeEmail(trx, updates.email, uuid);
       Object.keys(updates).length > 0 &&
         (await updateUserQuery(trx, uuid, updates));
@@ -421,7 +489,9 @@ export const updateUser = audit(
           .execute();
         // Made into a set
         const accessibleProgramUuids = new Set(
-          updatingUserPrograms.map(({ program_area_uuid }) => program_area_uuid)
+          updatingUserPrograms.map(
+            ({ program_area_uuid }) => program_area_uuid,
+          ),
         );
 
         programsToUpdate = [
@@ -432,7 +502,7 @@ export const updateUser = audit(
             ...existingPrograms
               .filter(
                 ({ program_area_uuid }) =>
-                  !accessibleProgramUuids.has(program_area_uuid)
+                  !accessibleProgramUuids.has(program_area_uuid),
               )
               .map(({ program_area_uuid }) => program_area_uuid),
           ]),

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -456,17 +456,16 @@ export const updateUser = audit(
     trx: Transaction<Core>,
   ): Promise<void> => {
     const updatingUser = await getCheckAnyAdmin("update users");
+    await validateAdminUserPermissions(
+      updatingUser,
+      updates.user_type,
+      programs,
+      "edit",
+      uuid,
+      updates.email
+    );
 
     try {
-      await validateAdminUserPermissions(
-        updatingUser,
-        updates.user_type,
-        programs,
-        "edit",
-        uuid,
-        updates.email,
-      );
-
       await checkDupeEmail(trx, updates.email, uuid);
       Object.keys(updates).length > 0 &&
         (await updateUserQuery(trx, uuid, updates));

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -207,7 +207,7 @@ export async function validateAdminUserPermissions(
     const hasUserAccess = await hasRelevantUserAccess(targetUserUuid);
     if (!hasUserAccess) {
       throw new UserFacingError(
-        "Program admins cannot manage users outside of their program areas",
+        "Program admins cannot manage users outside of their program areas.",
       );
     }
   }
@@ -224,7 +224,7 @@ export async function validateAdminUserPermissions(
   const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, programs);
   if (!hasAccess) {
     throw new UserFacingError(
-      "Program admins cannot manage users outside of their program areas",
+      "Program admins cannot manage users outside of their program areas.",
     );
   }
 }

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -123,7 +123,7 @@ export const hasRelevantProgramAreaAccess = async (
     targetUser.user_type === USER_TYPE.PROG_ADMIN ||
     targetUser.user_type === USER_TYPE.STANDARD
   ) {
-    // TODO ANGELA (LATER): Can this use an existing helper function?
+
     const res = await getDb<Core>()
       .selectFrom("user_program_area")
       .select("user_program_area.program_area_uuid")
@@ -168,7 +168,6 @@ export const hasRelevantUserAccess = async (
   return true;
 };
 
-// TODO ANGELA: loggedInUser vs targetUserUuid cleanup? email cleanup?
 /**
  * Validates whether the logged-in user can create or edit another user's
  * account, role, email, and program area assignments.
@@ -177,12 +176,13 @@ export const hasRelevantUserAccess = async (
  * users, manage users outside their program areas, or modify a user's role or
  * email when editing an existing user.
  *
- * @param loggedInUser - The user performing the user management action.
- * @param userType - The user type being assigned, if provided.
- * @param programs - The program area UUIDs being assigned.
- * @param action - Whether the user is being created or edited.
- * @param targetUserUuid - The UUID of the user being edited, if applicable.
- * @param email - The email being assigned, if provided.
+ * @param props - The user management action and proposed user changes.
+ * @param props.loggedInUser - The user performing the user management action.
+ * @param props.action - Whether the user is being created or edited.
+ * @param props.targetUserType - The user type being assigned, if provided.
+ * @param props.targetProgramAreaUuids - The program area UUIDs being assigned.
+ * @param props.targetUserUuid - The UUID of the user being edited, if applicable.
+ * @param props.targetEmail - The email being assigned, if provided.
  *
  * @throws {UserFacingError} If a program admin attempts to manage an admin user
  * or a user outside their program areas, or modify a user's role or email while
@@ -190,16 +190,25 @@ export const hasRelevantUserAccess = async (
  * @returns A promise that resolves when the permission checks pass.
  */
 export async function validateAdminUserPermissions(
-  loggedInUser: User,
-  userType: string | undefined,
-  programs: string[],
-  action: "create" | "edit",
-  targetUserUuid?: string,
-  email?: string | null,
+  {
+    loggedInUser,
+    action,
+    targetUserType,
+    targetProgramAreaUuids,
+    targetUserUuid,
+    targetEmail,
+  }: {
+    loggedInUser: User;
+    action: "create" | "edit";
+    targetUserType?: User["user_type"];
+    targetProgramAreaUuids: string[];
+    targetUserUuid?: string;
+    targetEmail?: string | null;
+  },
 ) {
   if (isAdmin(loggedInUser)) return;
 
-  if (userType === USER_TYPE.ADMIN) {
+  if (targetUserType === USER_TYPE.ADMIN) {
     throw new UserFacingError("Program admins cannot manage admins.");
   }
 
@@ -213,7 +222,7 @@ export async function validateAdminUserPermissions(
   }
 
   if (action === "edit") {
-    if (!!userType || !!email) {
+    if (targetUserType !== undefined || targetEmail != null) {
       throw new UserFacingError(
         "Program admins cannot modify user emails or roles.",
       );
@@ -221,7 +230,10 @@ export async function validateAdminUserPermissions(
   }
 
   // Program areas
-  const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, programs);
+  const hasAccess = await hasRelevantProgramAreaAccess(
+    loggedInUser,
+    targetProgramAreaUuids
+  );
   if (!hasAccess) {
     throw new UserFacingError(
       "Program admins cannot manage users outside of their program areas.",
@@ -306,12 +318,12 @@ export const createUser = audit(
     trx: Transaction<Core>,
   ): Promise<string> => {
     const creatingUser = await getCheckAnyAdmin("create new users");
-    await validateAdminUserPermissions(
-      creatingUser,
-      userType,
-      programs,
-      "create",
-    );
+    await validateAdminUserPermissions({
+      loggedInUser: creatingUser,
+      action: "create",
+      targetUserType: userType,
+      targetProgramAreaUuids: programs,
+    });
 
     try {
       const uuid = await createUserQuery(
@@ -456,14 +468,14 @@ export const updateUser = audit(
     trx: Transaction<Core>,
   ): Promise<void> => {
     const updatingUser = await getCheckAnyAdmin("update users");
-    await validateAdminUserPermissions(
-      updatingUser,
-      updates.user_type,
-      programs,
-      "edit",
-      uuid,
-      updates.email
-    );
+    await validateAdminUserPermissions({
+      loggedInUser: updatingUser,
+      action: "edit",
+      targetUserType: updates.user_type,
+      targetProgramAreaUuids: programs,
+      targetUserUuid: uuid,
+      targetEmail: updates.email,
+    });
 
     try {
       await checkDupeEmail(trx, updates.email, uuid);
@@ -472,38 +484,22 @@ export const updateUser = audit(
 
       let programsToUpdate = programs;
 
-      // TODO ANGELA: Refactor? First pass
       if (isProgramAdmin(updatingUser)) {
-        // All programs of user being edited
-        const existingPrograms = await trx
-          .selectFrom("user_program_area")
-          .select("program_area_uuid")
-          .where("user_uuid", "=", uuid)
-          .execute();
-        // All programs of program admin
-        const updatingUserPrograms = await trx
-          .selectFrom("user_program_area")
-          .select("program_area_uuid")
-          .where("user_uuid", "=", updatingUser.uuid)
-          .execute();
-        // Made into a set
+        const [targetUserPrograms, updatingUserPrograms] = await Promise.all([
+          listUserProgramAreasQuery(trx, uuid),
+          listUserProgramAreasQuery(trx, updatingUser.uuid),
+        ]);
+
         const accessibleProgramUuids = new Set(
-          updatingUserPrograms.map(
-            ({ program_area_uuid }) => program_area_uuid,
-          ),
+          updatingUserPrograms.map(({ uuid }) => uuid),
         );
 
         programsToUpdate = [
           ...new Set([
-            // Include programs program admin wants to edit
             ...programs,
-            // Keep programs the editor cannot access
-            ...existingPrograms
-              .filter(
-                ({ program_area_uuid }) =>
-                  !accessibleProgramUuids.has(program_area_uuid),
-              )
-              .map(({ program_area_uuid }) => program_area_uuid),
+            ...targetUserPrograms
+              .filter(({ uuid }) => !accessibleProgramUuids.has(uuid))
+              .map(({ uuid }) => uuid),
           ]),
         ];
       }
@@ -548,7 +544,9 @@ export const listLoggedInUserProgramAreas = async (): Promise<
   ProgramArea[]
 > => {
   const user = await getLoggedInUser();
-  return user ? await listUserProgramAreasQuery(getDb<Core>(), user.uuid) : [];
+  return user
+    ? await listUserProgramAreasQuery(getDb<Core>(), user.uuid)
+    : [];
 };
 
 export const listUserProgramAreasQuery = async (

--- a/containers/ecr-viewer/src/app/services/userService.ts
+++ b/containers/ecr-viewer/src/app/services/userService.ts
@@ -162,13 +162,13 @@ export async function validateAdminUserPermissions(
   if (isAdmin(loggedInUser)) return;
 
   if (userType === USER_TYPE.ADMIN) {
-    throw new UserFacingError("Program admins cannot create new admins.");
+    throw new UserFacingError("Program admins cannot manage admins.");
   }
 
   const hasAccess = await hasRelevantProgramAreaAccess(loggedInUser, programs);
   if (!hasAccess) {
     throw new UserFacingError(
-      "Program admins cannot create users outside of their program areas",
+      "Program admins cannot manage users outside of their program areas",
     );
   }
 }
@@ -394,13 +394,52 @@ export const updateUser = audit(
     },
     trx: Transaction<Core>,
   ): Promise<void> => {
-    await getCheckAdmin("update users");
+    const updatingUser = await getCheckAnyAdmin("update users");
+
+    // TODO ANGELA: Add validateAdminUserPermissions
 
     try {
       await checkDupeEmail(trx, updates.email, uuid);
       Object.keys(updates).length > 0 &&
         (await updateUserQuery(trx, uuid, updates));
-      await updateUserProgramAreasQuery(trx, uuid, programs);
+
+      let programsToUpdate = programs;
+
+      // TODO ANGELA: Refactor? First pass
+      if (isProgramAdmin(updatingUser)) {
+        // All programs of user being edited
+        const existingPrograms = await trx
+          .selectFrom("user_program_area")
+          .select("program_area_uuid")
+          .where("user_uuid", "=", uuid)
+          .execute();
+        // All programs of program admin
+        const updatingUserPrograms = await trx
+          .selectFrom("user_program_area")
+          .select("program_area_uuid")
+          .where("user_uuid", "=", updatingUser.uuid)
+          .execute();
+        // Made into a set
+        const accessibleProgramUuids = new Set(
+          updatingUserPrograms.map(({ program_area_uuid }) => program_area_uuid)
+        );
+
+        programsToUpdate = [
+          ...new Set([
+            // Include programs program admin wants to edit
+            ...programs,
+            // Keep programs the editor cannot access
+            ...existingPrograms
+              .filter(
+                ({ program_area_uuid }) =>
+                  !accessibleProgramUuids.has(program_area_uuid)
+              )
+              .map(({ program_area_uuid }) => program_area_uuid),
+          ]),
+        ];
+      }
+
+      await updateUserProgramAreasQuery(trx, uuid, programsToUpdate);
     } catch (error: unknown) {
       let message = "Failed to update user";
       if (error instanceof UserFacingError) {
@@ -428,7 +467,7 @@ const updateUserQuery = async (
 export const listUserProgramAreas = async (
   uuid: string,
 ): Promise<ProgramArea[]> => {
-  await getCheckAdmin("list user program areas");
+  await getCheckAnyAdmin("list user program areas");
   return listUserProgramAreasQuery(getDb<Core>(), uuid);
 };
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -340,13 +340,13 @@ test.describe("user management page", () => {
       browserName,
       page,
       "standard",
-      [otherProgram]
+      [otherProgram],
     );
     const unassignedUser = await createRandomUser(
       browserName,
       page,
       "standard",
-      []
+      [],
     );
 
     await page.context().clearCookies();
@@ -369,7 +369,7 @@ test.describe("user management page", () => {
     await page.getByLabel("Filter by program area").click();
     await expect(page.getByText("All program areas (Admin)")).not.toBeVisible();
     await expect(
-      page.getByText("No program areas (Standard)")
+      page.getByText("No program areas (Standard)"),
     ).not.toBeVisible();
     const covidFilter = page.getByLabel("COVID", { exact: true });
     await covidFilter.dispatchEvent("click");

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -358,7 +358,7 @@ test.describe("user management page", () => {
 
     await expect(page.getByText(sharedUser)).toBeVisible();
     await expect(page.getByText(restrictedUser)).not.toBeVisible();
-    await expect(page.getByText(unassignedUser)).not.toBeVisible(); // TODO ANGELA: Left off here
+    await expect(page.getByText(unassignedUser)).not.toBeVisible();
 
     // Should not see Filter by Admin user type
     await page.getByLabel("Filter by user type").click();

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -398,6 +398,9 @@ test.describe("user management page", () => {
     await page.context().clearCookies();
     await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
     await page.goto("/ecr-viewer/admin/user");
+    await page
+      .getByRole("combobox", { name: "Users per page" })
+      .selectOption("100");
     await page.getByRole("button", { name: user }).click();
     const dialog = page.getByRole("dialog");
     await dialog.getByText("Edit user").click();

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -171,7 +171,7 @@ test.describe("user management page", () => {
     await page.goto("/ecr-viewer/admin/user");
     await page
       .getByRole("combobox", { name: "Users per page" })
-      .selectOption("50"); // Increase user table pagination for testing
+      .selectOption("100"); // Increase user table pagination for testing
     const userAdmin = await createRandomUser(browserName, page, "admin", []);
     const userStandard1 = await createRandomUser(
       browserName,
@@ -340,13 +340,13 @@ test.describe("user management page", () => {
       browserName,
       page,
       "standard",
-      [otherProgram],
+      [otherProgram]
     );
     const unassignedUser = await createRandomUser(
       browserName,
       page,
       "standard",
-      [],
+      []
     );
 
     await page.context().clearCookies();
@@ -369,7 +369,7 @@ test.describe("user management page", () => {
     await page.getByLabel("Filter by program area").click();
     await expect(page.getByText("All program areas (Admin)")).not.toBeVisible();
     await expect(
-      page.getByText("No program areas (Standard)"),
+      page.getByText("No program areas (Standard)")
     ).not.toBeVisible();
     const covidFilter = page.getByLabel("COVID", { exact: true });
     await covidFilter.dispatchEvent("click");
@@ -382,6 +382,84 @@ test.describe("user management page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog.getByText("COVID", { exact: true })).toBeVisible();
     await expect(dialog.getByText(otherProgram, { exact: true })).toBeVisible();
+  });
+
+  test("program admin: can only edit accessible program areas", async ({
+    page,
+    browserName,
+  }) => {
+    await logIn(page);
+    const otherProgram = await getRandomProgramArea(page, ["COVID"]);
+    const user = await createRandomUser(browserName, page, "standard", [
+      "COVID",
+      otherProgram,
+    ]);
+
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/user");
+    await page.getByRole("button", { name: user }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByText("Edit user").click();
+    await page.waitForURL(/\/ecr-viewer\/admin\/user\/edit\?uuid=.*/);
+
+    // Program admin cannot modify user's email or user type
+    await expect(page.getByLabel("Email")).toBeDisabled();
+    await expect(page.locator('input[name="userType"]')).toHaveCount(2);
+    for (const userType of await page.locator('input[name="userType"]').all()) {
+      await expect(userType).toBeDisabled();
+    }
+
+    // Program admin should only be able to modify COVID
+    await expect(
+      page.getByLabel("Select COVID", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByLabel(`Select ${otherProgram}`, { exact: true }),
+    ).not.toBeVisible();
+
+    await page
+      .getByLabel("Select COVID", { exact: true })
+      .dispatchEvent("click");
+    await page.getByRole("button", { name: "Save user" }).first().click();
+    await page.waitForURL("/ecr-viewer/admin/user");
+
+    // Standard user should only have other program area
+    await page.context().clearCookies();
+    await logIn(page);
+    await page.goto("/ecr-viewer/admin/user");
+    await page
+      .getByRole("combobox", { name: "Users per page" })
+      .selectOption("100");
+    const row = page.getByRole("row").filter({
+      has: page.getByRole("cell", { name: user }),
+    });
+    await expect(row.getByText(otherProgram)).toBeVisible();
+    await expect(row.getByText("COVID", { exact: true })).not.toBeVisible();
+  });
+
+  test("program admin: should not be able to delete a user", async ({
+    page,
+    browserName,
+  }) => {
+    await logIn(page);
+    const user = await createRandomUser(browserName, page, "standard", [
+      "COVID",
+    ]);
+
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/user");
+    await page
+      .getByRole("combobox", { name: "Users per page" })
+      .selectOption("100");
+
+    await page.getByRole("button", { name: user }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("User information")).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Remove user" }),
+    ).not.toBeVisible();
   });
 
   test("should not show to standard user", async ({ page }) => {

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -205,11 +205,9 @@ describe("User Service", () => {
     const afterUsers = await listUsers();
     expect(afterUsers).toBeArrayOfSize(1);
     expect(afterUsers).toStrictEqual([expectedAdminUser]);
-  });
 
-  it("isLoggedInUserEcrAuthed: admin should be authed to see ecr", async () => {
-    const res = await isLoggedInUserEcrAuthed(ecrId);
-    expect(res).toBeTrue();
+    // admin should be authed to see eCR
+    expect(await isLoggedInUserEcrAuthed(ecrId)).toBeTrue();
   });
 
   describe("createUser", () => {

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -2,8 +2,6 @@
  * @jest-environment node
  */
 
-import { notFound } from "next/navigation";
-
 import {
   BundleMetadata,
   saveFhirMetadata,

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -16,25 +16,18 @@ import {
   createInitialAdminUser,
   createUser,
   deleteUser,
-  getCheckAdmin,
-  getCheckAnyAdmin,
-  hasRelevantProgramAreaAccess,
   isLoggedInUserEcrAuthed,
   isUserEcrAuthed,
   ListedUser,
   listLoggedInUserProgramAreas,
   listUserProgramAreas,
   listUsers,
-  notFoundUnlessAdmin,
-  notFoundUnlessAnyAdmin,
   updateUser,
-  validateAdminUserPermissions,
 } from "@/app/services/userService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 import { getLastAuditLog } from "./helpers/core";
 import { buildCore, dropExisting } from "./helpers/ddl";
-import { UserFacingError } from "@/app/services/errorService";
 
 export const makePromiseResolveWithStatus = (
   status: number,
@@ -584,139 +577,4 @@ describe("User Service", () => {
     });
   });
 
-  describe("getCheckAdmin", () => {
-    it("should return admin if user is an admin", async () => {
-      const admin = await getCheckAdmin("do a thing");
-      expect(admin.email).toBe(adminUserEmail);
-    });
-
-    it("should error if user is not an admin", async () => {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Sally Standard",
-        email: "standard@user.com",
-      });
-      await expect(getCheckAdmin("do a thing")).rejects.toThrow();
-    });
-  });
-
-  describe("notFoundUnlessAdmin", () => {
-    it("should do nothing if user is an admin", async () => {
-      await notFoundUnlessAdmin();
-      expect(notFound).not.toHaveBeenCalled();
-    });
-
-    it("should notFound if user is not an admin", async () => {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Sally Standard",
-        email: "standard@user.com",
-      });
-      await notFoundUnlessAdmin();
-      expect(notFound).toHaveBeenCalled();
-    });
-  });
-
-  describe("getCheckAnyAdmin", () => {
-    it("should return admin if user is an admin", async () => {
-      const admin = await getCheckAnyAdmin("do a thing");
-      expect(admin.email).toBe(adminUserEmail);
-    });
-
-    it("should error if user is a standard user", async () => {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Sally Standard",
-        email: "standard@user.com",
-      });
-      await expect(getCheckAnyAdmin("do a thing")).rejects.toThrow();
-    });
-  });
-
-  describe("notFoundUnlessAnyAdmin", () => {
-    it("should do nothing if user is an admin", async () => {
-      await notFoundUnlessAnyAdmin();
-      expect(notFound).not.toHaveBeenCalled();
-    });
-
-    it("should notFound if user is a standard user", async () => {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Sally Standard",
-        email: "standard@user.com",
-      });
-      await notFoundUnlessAnyAdmin();
-      expect(notFound).toHaveBeenCalled();
-    });
-  });
-
-  describe("hasRelevantProgramAreaAccess", () => {
-    it("should return true for admin user", async () => {
-      const adminUser = await getCheckAdmin("check");
-      const res = await hasRelevantProgramAreaAccess(adminUser, [
-        "some-prog-uuid",
-      ]);
-      expect(res).toBeTrue();
-    });
-
-    it("should return false for an inactive user", async () => {
-      const adminUser = await getCheckAdmin("check");
-      const inactiveUser = { ...adminUser, status: "inactive" as const };
-      expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, ["some-prog-uuid"]),
-      ).toBeFalse();
-    });
-
-    it("should return false when no user is passed and none is logged in", async () => {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue(undefined);
-      expect(
-        await hasRelevantProgramAreaAccess(undefined, ["some-prog-uuid"]),
-      ).toBeFalse();
-    });
-  });
-
-  // TODO ANGELA: Should this really be an integration test? Should this (and others be moved to unit tests)
-  describe("validateAdminUserPermissions", () => {
-    it("should allow admins to manage users of any type", async () => {
-      await expect(
-        validateAdminUserPermissions(expectedAdminUser, "admin", [], "create"),
-      ).resolves.toBeUndefined();
-    });
-    it("should allow program admins to manage standard users and program admins within their accessible program areas", async () => {
-      await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "standard",
-          [programArea123Id!],
-          "create",
-        ),
-      ).resolves.toBeUndefined();
-      await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "prog_admin",
-          [programArea123Id!],
-          "create",
-        ),
-      ).resolves.toBeUndefined();
-    });
-    it("should prevent program admins from managing admin users", async () => {
-      await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "admin",
-          [],
-          "create",
-        ),
-      ).rejects.toThrow(UserFacingError);
-    });
-    it("should prevent program admins from managing users outside of their accessible program areas", async () => {
-      expect(programAreaUnauthorizedId).toMatch(UUID_REGEX);
-
-      await expect(
-        validateAdminUserPermissions(
-          expectedProgramAdminUser,
-          "standard",
-          [programAreaUnauthorizedId!],
-          "create",
-        ),
-      ).rejects.toThrow(UserFacingError);
-    });
-  });
 });

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -590,6 +590,33 @@ describe("User Service", () => {
       });
     });
 
+    it("as a program admin, should preserve a user's inaccessible program area", async () => {
+      // Assign the user to one accessible and one inaccessible program area as an admin.
+      await updateUser({
+        uuid: standardUserId!,
+        updates: {},
+        programs: [programArea123Id!, programAreaUnauthorizedId!],
+      });
+
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      // The program admin submits only an accessible area.
+      await updateUser({
+        uuid: standardUserId!,
+        updates: {},
+        programs: [programArea456Id!],
+      });
+
+      expect(await listUserProgramAreas(standardUserId!)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ uuid: programArea456Id! }),
+          expect.objectContaining({ uuid: programAreaUnauthorizedId! }),
+        ]),
+      );
+    });
   });
 
   describe("isUserEcrAuthed: should now be authed to see eCR", () => {

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -37,6 +37,7 @@ export const makePromiseResolveWithStatus = (
 const adminUserEmail = "admin@admin.com";
 const standardUserEmail = "standard@standard.com";
 const programAdminEmail = "programadmin@programadmin.com";
+const unauthorizedUserEmail = "unauthorized@standard.com";
 
 const cond123 = {
   code: "123",
@@ -134,6 +135,7 @@ describe("User Service", () => {
   let adminUserId;
   let standardUserId: string;
   let programAdminUserId: string;
+  let unauthorizedUserId: string;
 
   let programArea123Id: string;
   let programArea456Id: string;
@@ -478,6 +480,116 @@ describe("User Service", () => {
         ],
       };
     });
+
+    it("as a program admin, should not update an unauthorized user", async () => {
+      programAreaUnauthorizedId = await createProgramArea(
+        programAreaUnauthorized
+      );
+      unauthorizedUserId = await createUser({
+        email: unauthorizedUserEmail,
+        userType: "standard",
+        programs: [programAreaUnauthorizedId],
+      });
+
+      // Logging in as program admin, should not be able to update unauthorized user
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+      await expect(
+        updateUser({
+          uuid: unauthorizedUserId!,
+          updates: { name: "Unauthorized Update" },
+          programs: [],
+        })
+      ).rejects.toThrow(
+        "Program admins cannot manage users outside of their program areas."
+      );
+    });
+
+    it("as a program admin, should not update a user's email", async () => {
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      await expect(
+        updateUser({
+          uuid: programAdminUserId!,
+          updates: { email: "updated@programadmin.com" },
+          programs: [programArea456Id!],
+        }),
+      ).rejects.toThrow(
+        "Program admins cannot modify user emails or roles.",
+      );
+    });
+
+    it("as a program admin, should not update a user's role", async () => {
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      await expect(
+        updateUser({
+          uuid: programAdminUserId!,
+          updates: { user_type: "standard" },
+          programs: [programArea456Id!],
+        }),
+      ).rejects.toThrow(
+        "Program admins cannot modify user emails or roles.",
+      );
+    });
+
+    it("as a program admin, should not update a user's unauthorized program areas", async () => {
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      await expect(
+        updateUser({
+          uuid: programAdminUserId!,
+          updates: {},
+          programs: [programAreaUnauthorizedId],
+        }),
+      ).rejects.toThrow(
+        "Program admins cannot manage users outside of their program areas.",
+      );
+    });
+
+    it("as a program admin, should update a user's authorized program area", async () => {
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      await updateUser({
+        uuid: standardUserId!,
+        updates: {},
+        programs: [programArea456Id!],
+      });
+      expect(await listUserProgramAreas(standardUserId!)).toStrictEqual([
+        {
+          uuid: programArea456Id!,
+          author_uuid: adminUserId!,
+          name: "Program Area 456",
+          date_created: expect.any(Date),
+        },
+      ]);
+
+      // Restore the standard user's original assignment for subsequent tests.
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Adam Admin",
+        email: adminUserEmail,
+      });
+      await updateUser({
+        uuid: standardUserId!,
+        updates: {},
+        programs: [programArea123Id!],
+      });
+    });
+
   });
 
   describe("isUserEcrAuthed: should now be authed to see eCR", () => {
@@ -505,42 +617,24 @@ describe("User Service", () => {
   });
 
   it("listUsers only returns users who share a program area with a program admin", async () => {
-    programAreaUnauthorizedId = await createProgramArea(
-      programAreaUnauthorized,
-    );
-    const unauthorizedUserEmail = "unauthorized@standard.com";
-    const unauthorizedUserId = await createUser({
-      email: unauthorizedUserEmail,
-      userType: "standard",
-      programs: [programAreaUnauthorizedId],
+    (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+      name: "Program Admin",
+      email: programAdminEmail,
     });
 
-    try {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Program Admin",
-        email: programAdminEmail,
-      });
+    const users = await listUsers();
 
-      const users = await listUsers();
-
-      // Should not return admin or unauthorized users
-      expect(users.map(({ email }) => email)).toStrictEqual([
-        programAdminEmail,
-        standardUserEmail,
-      ]);
-    } finally {
-      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
-        name: "Adam Admin",
-        email: adminUserEmail,
-      });
-      await deleteUser({ uuid: unauthorizedUserId });
-    }
+    // Should not return admin or unauthorized users
+    expect(users.map(({ email }) => email)).toStrictEqual([
+      programAdminEmail,
+      standardUserEmail,
+    ]);
   });
 
   describe("deleteUser", () => {
     it("as an admin, should delete a user", async () => {
       const beforeUsers = await listUsers();
-      expect(beforeUsers).toBeArrayOfSize(3); // admin + program admin + standard
+      expect(beforeUsers).toBeArrayOfSize(4); // admin + program admin + standard + standard (unauthorized)
 
       // standard user created in prior test
       await deleteUser({ uuid: standardUserId! });
@@ -556,7 +650,7 @@ describe("User Service", () => {
 
       // see only admin + program admin listed
       const users = await listUsers();
-      expect(users).toBeArrayOfSize(2); // admin + program admin
+      expect(users).toBeArrayOfSize(3); // admin + program admin + standard (unauthorized)
       expect(users).toEqual(
         expect.arrayContaining([
           expectedAdminUser,
@@ -572,6 +666,17 @@ describe("User Service", () => {
       // should also delete standard user program area assignments
       const progAreas = await listUserProgramAreas(standardUserId!);
       expect(progAreas).toStrictEqual([]);
+    });
+
+    it("as a program admin, should not delete a user", async () => {
+      (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+
+      await expect(deleteUser({ uuid: unauthorizedUserId! })).rejects.toThrow(
+        "Standard user cannot & program admins cannot delete users",
+      );
     });
   });
 

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -680,28 +680,42 @@ describe("User Service", () => {
     });
     it("should allow program admins to manage standard users and program admins within their accessible program areas", async () => {
       await expect(
-        validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
-          programArea123Id!,
-        ], "create"),
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "standard",
+          [programArea123Id!],
+          "create",
+        ),
       ).resolves.toBeUndefined();
       await expect(
-        validateAdminUserPermissions(expectedProgramAdminUser, "prog_admin", [
-          programArea123Id!,
-        ], "create"),
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "prog_admin",
+          [programArea123Id!],
+          "create",
+        ),
       ).resolves.toBeUndefined();
     });
     it("should prevent program admins from managing admin users", async () => {
       await expect(
-        validateAdminUserPermissions(expectedProgramAdminUser, "admin", [], "create"),
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "admin",
+          [],
+          "create",
+        ),
       ).rejects.toThrow(UserFacingError);
     });
     it("should prevent program admins from managing users outside of their accessible program areas", async () => {
       expect(programAreaUnauthorizedId).toMatch(UUID_REGEX);
 
       await expect(
-        validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
-          programAreaUnauthorizedId!,
-        ], "create"),
+        validateAdminUserPermissions(
+          expectedProgramAdminUser,
+          "standard",
+          [programAreaUnauthorizedId!],
+          "create",
+        ),
       ).rejects.toThrow(UserFacingError);
     });
   });

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -483,7 +483,7 @@ describe("User Service", () => {
 
     it("as a program admin, should not update an unauthorized user", async () => {
       programAreaUnauthorizedId = await createProgramArea(
-        programAreaUnauthorized
+        programAreaUnauthorized,
       );
       unauthorizedUserId = await createUser({
         email: unauthorizedUserEmail,
@@ -501,9 +501,9 @@ describe("User Service", () => {
           uuid: unauthorizedUserId!,
           updates: { name: "Unauthorized Update" },
           programs: [],
-        })
+        }),
       ).rejects.toThrow(
-        "Program admins cannot manage users outside of their program areas."
+        "Program admins cannot manage users outside of their program areas.",
       );
     });
 
@@ -519,9 +519,7 @@ describe("User Service", () => {
           updates: { email: "updated@programadmin.com" },
           programs: [programArea456Id!],
         }),
-      ).rejects.toThrow(
-        "Program admins cannot modify user emails or roles.",
-      );
+      ).rejects.toThrow("Program admins cannot modify user emails or roles.");
     });
 
     it("as a program admin, should not update a user's role", async () => {
@@ -536,9 +534,7 @@ describe("User Service", () => {
           updates: { user_type: "standard" },
           programs: [programArea456Id!],
         }),
-      ).rejects.toThrow(
-        "Program admins cannot modify user emails or roles.",
-      );
+      ).rejects.toThrow("Program admins cannot modify user emails or roles.");
     });
 
     it("as a program admin, should not update a user's unauthorized program areas", async () => {
@@ -706,5 +702,4 @@ describe("User Service", () => {
       );
     });
   });
-
 });

--- a/containers/ecr-viewer/tests/integration/userService.test.ts
+++ b/containers/ecr-viewer/tests/integration/userService.test.ts
@@ -320,7 +320,7 @@ describe("User Service", () => {
           userType: "admin",
           programs: [],
         }),
-      ).rejects.toThrow("Program admins cannot create new admins");
+      ).rejects.toThrow("Program admins cannot manage admins.");
     });
 
     it("as a program admin, should not create a user for an unauthorized program area", async () => {
@@ -353,7 +353,7 @@ describe("User Service", () => {
           programs: [programArea123Id],
         }),
       ).rejects.toThrow(
-        "Program admins cannot create users outside of their program areas",
+        "Program admins cannot manage users outside of their program areas.",
       );
     });
   });
@@ -675,24 +675,24 @@ describe("User Service", () => {
   describe("validateAdminUserPermissions", () => {
     it("should allow admins to manage users of any type", async () => {
       await expect(
-        validateAdminUserPermissions(expectedAdminUser, "admin", []),
+        validateAdminUserPermissions(expectedAdminUser, "admin", [], "create"),
       ).resolves.toBeUndefined();
     });
     it("should allow program admins to manage standard users and program admins within their accessible program areas", async () => {
       await expect(
         validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
           programArea123Id!,
-        ]),
+        ], "create"),
       ).resolves.toBeUndefined();
       await expect(
         validateAdminUserPermissions(expectedProgramAdminUser, "prog_admin", [
           programArea123Id!,
-        ]),
+        ], "create"),
       ).resolves.toBeUndefined();
     });
     it("should prevent program admins from managing admin users", async () => {
       await expect(
-        validateAdminUserPermissions(expectedProgramAdminUser, "admin", []),
+        validateAdminUserPermissions(expectedProgramAdminUser, "admin", [], "create"),
       ).rejects.toThrow(UserFacingError);
     });
     it("should prevent program admins from managing users outside of their accessible program areas", async () => {
@@ -701,7 +701,7 @@ describe("User Service", () => {
       await expect(
         validateAdminUserPermissions(expectedProgramAdminUser, "standard", [
           programAreaUnauthorizedId!,
-        ]),
+        ], "create"),
       ).rejects.toThrow(UserFacingError);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -304,9 +304,7 @@ describe("User Admin Page", () => {
       );
       (isAdmin as unknown as jest.Mock).mockReturnValue(false);
       (getUser as jest.Mock).mockResolvedValue(mockUsers[2]);
-      (listUserProgramAreas as jest.Mock).mockResolvedValue([
-        mockPrograms[0],
-      ]);
+      (listUserProgramAreas as jest.Mock).mockResolvedValue([mockPrograms[0]]);
       (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
       (listUsers as jest.Mock).mockResolvedValue(mockUsers);
 
@@ -322,15 +320,13 @@ describe("User Admin Page", () => {
       });
       expect(results).toHaveNoViolations();
     });
-    
+
     it("as a program admin, cannot edit a user's email or user type", async () => {
       (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockResolvedValue(true);
       (getLoggedInUser as jest.Mock).mockResolvedValue(mockProgramAdmin);
       (isAdmin as unknown as jest.Mock).mockReturnValue(false);
       (getUser as jest.Mock).mockResolvedValue(mockUsers[2]);
-      (listUserProgramAreas as jest.Mock).mockResolvedValue([
-        mockPrograms[0],
-      ]);
+      (listUserProgramAreas as jest.Mock).mockResolvedValue([mockPrograms[0]]);
       (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
       (listUsers as jest.Mock).mockResolvedValue(mockUsers);
 
@@ -342,9 +338,9 @@ describe("User Admin Page", () => {
 
       expect(screen.getByLabelText(/Email/i)).toBeDisabled();
       expect(screen.getAllByRole("radio")).toHaveLength(2);
-      screen.getAllByRole("radio").forEach((radio) =>
-        expect(radio).toBeDisabled(),
-      );
+      screen
+        .getAllByRole("radio")
+        .forEach((radio) => expect(radio).toBeDisabled());
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/UserAdminPage.test.tsx
@@ -4,12 +4,15 @@ import { notFound } from "next/navigation";
 
 import { FormProgram, ProgramFieldSet } from "@/app/admin/user/UserForm";
 import CreateUserPage from "@/app/admin/user/create/page";
+import EditUserPage from "@/app/admin/user/edit/page";
 import UserAdminPage from "@/app/admin/user/page";
 import { listProgramAreas } from "@/app/services/programAreaService";
 import {
   isAdmin,
+  getUser,
   ListedUser,
   listUsers,
+  listUserProgramAreas,
   notFoundUnlessAnyAdmin,
 } from "@/app/services/userService";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
@@ -290,6 +293,58 @@ describe("User Admin Page", () => {
       );
 
       await expect(CreateUserPage()).rejects.toThrow("Not found");
+    });
+  });
+
+  describe("Editing users", () => {
+    it("as a program admin, should render an edit user page with restricted permissions", async () => {
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockResolvedValue(true);
+      (getLoggedInUser as unknown as jest.Mock).mockResolvedValue(
+        mockProgramAdmin,
+      );
+      (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+      (getUser as jest.Mock).mockResolvedValue(mockUsers[2]);
+      (listUserProgramAreas as jest.Mock).mockResolvedValue([
+        mockPrograms[0],
+      ]);
+      (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
+      (listUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      const { container } = render(
+        await EditUserPage({
+          searchParams: Promise.resolve({ uuid: "234" }),
+        }),
+      );
+      expect(container).toMatchSnapshot();
+      let results;
+      await act(async () => {
+        results = await axe(container);
+      });
+      expect(results).toHaveNoViolations();
+    });
+    
+    it("as a program admin, cannot edit a user's email or user type", async () => {
+      (notFoundUnlessAnyAdmin as unknown as jest.Mock).mockResolvedValue(true);
+      (getLoggedInUser as jest.Mock).mockResolvedValue(mockProgramAdmin);
+      (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+      (getUser as jest.Mock).mockResolvedValue(mockUsers[2]);
+      (listUserProgramAreas as jest.Mock).mockResolvedValue([
+        mockPrograms[0],
+      ]);
+      (listProgramAreas as jest.Mock).mockResolvedValue(mockPrograms);
+      (listUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      render(
+        await EditUserPage({
+          searchParams: Promise.resolve({ uuid: "234" }),
+        }),
+      );
+
+      expect(screen.getByLabelText(/Email/i)).toBeDisabled();
+      expect(screen.getAllByRole("radio")).toHaveLength(2);
+      screen.getAllByRole("radio").forEach((radio) =>
+        expect(radio).toBeDisabled(),
+      );
     });
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -713,6 +713,370 @@ exports[`User Admin Page Creating users should render a create user page with no
 </div>
 `;
 
+exports[`User Admin Page Editing users as a program admin, should render an edit user page with restricted permissions 1`] = `
+<div>
+  <main
+    class="main-container display-flex flex-column flex-align-center"
+  >
+    <div
+      class="width-full border-bottom border-base-lighter position-sticky top-0 isolate z-500 padding-top-1 bg-container shadow-2 display-flex flex-justify-center"
+    >
+      <div
+        class="content-container"
+      >
+        <a
+          class="action-text display-inline-flex flex-align-center margin-bottom-1 margin-top-2"
+          href="/admin/user"
+        >
+          <svg
+            aria-hidden="true"
+            class="usa-icon square-3"
+            focusable="false"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+            />
+          </svg>
+          Back to 
+          user
+           management
+        </a>
+        <div
+          class="margin-bottom-1"
+        />
+        <div
+          class="display-flex flex-justify flex-align-center margin-bottom-2"
+        >
+          <h2
+            class="margin-0"
+          >
+            Edit user
+          </h2>
+          <div>
+            <button
+              class="usa-button margin-0"
+              data-testid="button"
+              disabled=""
+              form="r:id"
+              type="submit"
+            >
+              Save 
+              user
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content-container margin-top-3"
+    >
+      <form
+        class="margin-top-3 isolate"
+        id="r:id"
+      >
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            <span
+              class="text-base"
+            >
+              Email
+            </span>
+          </legend>
+          <div
+            class="usa-form-group"
+            data-testid="formGroup"
+          >
+            <label
+              class="usa-label maxw-full text-base"
+            >
+              Email
+              <input
+                class="usa-input"
+                data-testid="textInput"
+                disabled=""
+                id="email"
+                name="email"
+                required=""
+                type="email"
+                value="sallystandard@standard.com"
+              />
+            </label>
+          </div>
+        </fieldset>
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            <span
+              class="text-base"
+            >
+              User type
+            </span>
+          </legend>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
+              class="usa-radio__input"
+              disabled=""
+              id="userType-prog_admin"
+              name="userType"
+              required=""
+              type="radio"
+              value="prog_admin"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-prog_admin"
+            >
+              Program admin
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Program Admins have limited access to user management, program management, and the eCR Library
+              </span>
+            </label>
+          </div>
+          <div
+            class="usa-radio"
+            data-testid="radio"
+          >
+            <input
+              checked=""
+              class="usa-radio__input"
+              disabled=""
+              id="userType-standard"
+              name="userType"
+              required=""
+              type="radio"
+              value="standard"
+            />
+            <label
+              class="usa-radio__label"
+              for="userType-standard"
+            >
+              Standard user
+              <span
+                class="usa-checkbox__label-description"
+              >
+                Standard users can only use the eCR Library with limited access to program area(s)
+              </span>
+            </label>
+          </div>
+        </fieldset>
+        <fieldset
+          class="dibbs-fieldset"
+        >
+          <legend>
+            Program area access
+          </legend>
+          <span>
+            Select one or more program areas
+          </span>
+          <p
+            class="text-bold font-size-md"
+          >
+            1
+             program area
+             
+            selected
+          </p>
+          <div
+            class="margin-right-auto"
+          >
+            <button
+              aria-controls="program-area-three program-area-two"
+              class="usa-button usa-button--outline margin-top-0"
+              data-testid="button"
+              type="button"
+            >
+              Select
+               all
+            </button>
+            <button
+              aria-controls="program-area-three program-area-two"
+              class="usa-button usa-button--outline margin-top-0"
+              data-testid="button"
+              type="button"
+            >
+              Deselect
+               all
+            </button>
+          </div>
+          <div
+            class="display-flex"
+          >
+            <div
+              class="margin-left-auto padding-top-1"
+            >
+              <button
+                class="usa-button usa-button--unstyled"
+                data-testid="button"
+                type="button"
+              >
+                Expand all 
+                program areas
+              </button>
+              <span
+                class="vertical-line"
+              />
+              <button
+                class="usa-button usa-button--unstyled"
+                data-testid="button"
+                type="button"
+              >
+                Collapse all 
+                program areas
+              </button>
+            </div>
+          </div>
+          <div
+            class="usa-accordion accordion-dibbs margin-top-3"
+            data-allow-multiple="true"
+            data-testid="accordion"
+          >
+            <div
+              class="display-flex flex-align-top margin-bottom-2"
+            >
+              <div
+                class="usa-checkbox margin-right-1 margin-top-3"
+                data-testid="checkbox"
+              >
+                <input
+                  aria-label="Select Program Area Three"
+                  class="usa-checkbox__input"
+                  id="checkbox-program-area-three"
+                  name="program"
+                  type="checkbox"
+                />
+                <label
+                  class="usa-checkbox__label"
+                  for="checkbox-program-area-three"
+                />
+              </div>
+              <div
+                class="flex-grow-1 width-full"
+              >
+                <h3
+                  class="usa-accordion__heading"
+                >
+                  <button
+                    aria-controls="program-area-three"
+                    aria-expanded="false"
+                    class="usa-accordion__button"
+                    data-testid="accordionButton_program-area-three"
+                    type="button"
+                  >
+                    <div
+                      class="display-flex flex-justify flex-align-center"
+                    >
+                      <span>
+                        Program Area Three
+                      </span>
+                      <span>
+                        2
+                         condition
+                        s
+                      </span>
+                    </div>
+                  </button>
+                </h3>
+                <div
+                  class="usa-accordion__content usa-prose"
+                  data-testid="accordionItem_program-area-three"
+                  hidden=""
+                  id="program-area-three"
+                >
+                  condition, condition
+                </div>
+              </div>
+            </div>
+            <div
+              class="display-flex flex-align-top margin-bottom-2"
+            >
+              <div
+                class="usa-checkbox margin-right-1 margin-top-3"
+                data-testid="checkbox"
+              >
+                <input
+                  aria-label="Select Program Area Two"
+                  checked=""
+                  class="usa-checkbox__input"
+                  id="checkbox-program-area-two"
+                  name="program"
+                  type="checkbox"
+                />
+                <label
+                  class="usa-checkbox__label"
+                  for="checkbox-program-area-two"
+                />
+              </div>
+              <div
+                class="flex-grow-1 width-full"
+              >
+                <h3
+                  class="usa-accordion__heading"
+                >
+                  <button
+                    aria-controls="program-area-two"
+                    aria-expanded="false"
+                    class="usa-accordion__button"
+                    data-testid="accordionButton_program-area-two"
+                    type="button"
+                  >
+                    <div
+                      class="display-flex flex-justify flex-align-center"
+                    >
+                      <span>
+                        Program Area Two
+                      </span>
+                      <span>
+                        1
+                         condition
+                      </span>
+                    </div>
+                  </button>
+                </h3>
+                <div
+                  class="usa-accordion__content usa-prose"
+                  data-testid="accordionItem_program-area-two"
+                  hidden=""
+                  id="program-area-two"
+                >
+                  condition
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+        <div
+          class="display-flex flex-justify-end margin-y-4"
+        >
+          <button
+            class="usa-button margin-0"
+            data-testid="button"
+            disabled=""
+            form="r:id"
+            type="submit"
+          >
+            Save 
+            user
+          </button>
+        </div>
+      </form>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`User Admin Page for an admin, should list all users and program areas 1`] = `
 <div>
   <main

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -70,7 +70,9 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
           class="dibbs-fieldset"
         >
           <legend>
-            Email
+            <span>
+              Email
+            </span>
           </legend>
           <span>
             Add the new user by their login email
@@ -105,7 +107,9 @@ exports[`User Admin Page Creating users should render a create user page 1`] = `
           class="dibbs-fieldset"
         >
           <legend>
-            User type
+            <span>
+              User type
+            </span>
           </legend>
           <span>
             Select the user type
@@ -492,7 +496,9 @@ exports[`User Admin Page Creating users should render a create user page with no
           class="dibbs-fieldset"
         >
           <legend>
-            Email
+            <span>
+              Email
+            </span>
           </legend>
           <span>
             Add the new user by their login email
@@ -527,7 +533,9 @@ exports[`User Admin Page Creating users should render a create user page with no
           class="dibbs-fieldset"
         >
           <legend>
-            User type
+            <span>
+              User type
+            </span>
           </legend>
           <span>
             Select the user type

--- a/containers/ecr-viewer/tests/unit/app/components/DetailsSidePanel.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/DetailsSidePanel.test.tsx
@@ -28,6 +28,7 @@ const SidePanel = (
         Click me
       </DetailsTrigger>
       <DetailsSidePanel
+        isLoggedInUserAdmin={true}
         detailsRef={detailsRef}
         title="Title"
         subtitle="Subtitle"

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -262,7 +262,7 @@ describe("userService", () => {
           action: "create",
           targetUserType: "admin",
           targetProgramAreaUuids: [],
-        })
+        }),
       ).resolves.toBeUndefined();
     });
 
@@ -273,7 +273,7 @@ describe("userService", () => {
           action: "create",
           targetUserType: "standard",
           targetProgramAreaUuids: [accessibleProgramAreaId],
-        })
+        }),
       ).resolves.toBeUndefined();
       await expect(
         validateAdminUserPermissions({
@@ -281,7 +281,7 @@ describe("userService", () => {
           action: "create",
           targetUserType: "prog_admin",
           targetProgramAreaUuids: [accessibleProgramAreaId],
-        })
+        }),
       ).resolves.toBeUndefined();
     });
 
@@ -292,7 +292,7 @@ describe("userService", () => {
           action: "create",
           targetUserType: "admin",
           targetProgramAreaUuids: [],
-        })
+        }),
       ).rejects.toThrow(UserFacingError);
     });
 
@@ -303,7 +303,7 @@ describe("userService", () => {
           action: "create",
           targetUserType: "standard",
           targetProgramAreaUuids: [inaccessibleProgramAreaId],
-        })
+        }),
       ).rejects.toThrow(UserFacingError);
     });
 
@@ -314,7 +314,7 @@ describe("userService", () => {
           action: "edit",
           targetUserUuid: "no-shared-user",
           targetProgramAreaUuids: [],
-        })
+        }),
       ).rejects.toThrow(UserFacingError);
     });
 

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -215,10 +215,9 @@ describe("userService", () => {
   describe("hasRelevantProgramAreaAccess", () => {
     it("should return true for admin user", async () => {
       const adminUser = await getCheckAdmin("check");
-      const res = await hasRelevantProgramAreaAccess(
-        adminUser,
-        ["some-prog-uuid"],
-      );
+      const res = await hasRelevantProgramAreaAccess(adminUser, [
+        "some-prog-uuid",
+      ]);
       expect(res).toBeTrue();
     });
 

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -80,7 +80,11 @@ jest.mock("@/app/data/metadataDb/database", () => ({
           return query;
         }),
         where: jest.fn(
-          (_column: string, _operator: string, value: string | (() => void)) => {
+          (
+            _column: string,
+            _operator: string,
+            value: string | (() => void),
+          ) => {
             if (typeof value === "string") programAreaValues.push(value);
             return query;
           },
@@ -91,7 +95,10 @@ jest.mock("@/app/data/metadataDb/database", () => ({
             ? {
                 ...standardUser,
                 uuid: programAreaValues[0],
-                status: programAreaValues[0] === "inactive-user" ? "inactive" : "active",
+                status:
+                  programAreaValues[0] === "inactive-user"
+                    ? "inactive"
+                    : "active",
               }
             : programAreaValues.includes(accessibleProgramAreaId)
               ? { program_area_uuid: accessibleProgramAreaId }
@@ -109,7 +116,6 @@ jest.mock("@/app/data/metadataDb/database", () => ({
 }));
 
 describe("userService", () => {
-  
   describe("isLoggedInUserEcrAuthed", () => {
     it("admin should be authed to see ecr", async () => {
       const res = await isLoggedInUserEcrAuthed("some-ecr-id");
@@ -127,13 +133,19 @@ describe("userService", () => {
 
   describe("isUserEcrAuthed", () => {
     it("should authorize a user with access to the eCR's program area", async () => {
-      const res = await isUserEcrAuthed("some-user-id", accessibleProgramAreaId);
+      const res = await isUserEcrAuthed(
+        "some-user-id",
+        accessibleProgramAreaId,
+      );
 
       expect(res).toBeTrue();
     });
 
     it("should not authorize a user without access to the eCR's program area", async () => {
-      const res = await isUserEcrAuthed("some-user-id", inaccessibleProgramAreaId);
+      const res = await isUserEcrAuthed(
+        "some-user-id",
+        inaccessibleProgramAreaId,
+      );
 
       expect(res).toBeFalse();
     });
@@ -205,7 +217,7 @@ describe("userService", () => {
       const adminUser = await getCheckAdmin("check");
       const res = await hasRelevantProgramAreaAccess(
         adminUser,
-        "some-prog-uuid"
+        ["some-prog-uuid"],
       );
       expect(res).toBeTrue();
     });
@@ -214,14 +226,14 @@ describe("userService", () => {
       const adminUser = await getCheckAdmin("check");
       const inactiveUser = { ...adminUser, status: "inactive" as const };
       expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid")
+        await hasRelevantProgramAreaAccess(inactiveUser, ["some-prog-uuid"]),
       ).toBeFalse();
     });
 
     it("should return false when no user is passed and none is logged in", async () => {
       (getLoggedInUser as jest.Mock).mockResolvedValue(undefined);
       expect(
-        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid")
+        await hasRelevantProgramAreaAccess(undefined, ["some-prog-uuid"]),
       ).toBeFalse();
     });
   });
@@ -232,7 +244,9 @@ describe("userService", () => {
     });
 
     it("should return false when users do not share a program area", async () => {
-      await expect(hasRelevantUserAccess("no-shared-user")).resolves.toBeFalse();
+      await expect(
+        hasRelevantUserAccess("no-shared-user"),
+      ).resolves.toBeFalse();
     });
 
     it("should return false for an inactive user", async () => {

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -3,7 +3,10 @@ import { UserFacingError } from "@/app/services/errorService";
 import {
   getCheckAdmin,
   getCheckAnyAdmin,
+  hasRelevantUserAccess,
   hasRelevantProgramAreaAccess,
+  isLoggedInUserEcrAuthed,
+  isUserEcrAuthed,
   notFoundUnlessAdmin,
   notFoundUnlessAnyAdmin,
   validateAdminUserPermissions,
@@ -62,20 +65,42 @@ jest.mock("@/app/data/metadataDb/database", () => ({
   getDb: jest.fn(() => ({
     selectFrom: jest.fn(() => {
       const programAreaValues: string[] = [];
+      let isUserQuery = false;
       const query: {
         select: jest.Mock;
+        selectAll: jest.Mock;
         where: jest.Mock;
+        innerJoin: jest.Mock;
         executeTakeFirst: jest.Mock;
+        execute: jest.Mock;
       } = {
         select: jest.fn(() => query),
-        where: jest.fn((_column: string, _operator: string, value: string) => {
-          programAreaValues.push(value);
+        selectAll: jest.fn((...fields: unknown[]) => {
+          isUserQuery = fields.length === 0;
           return query;
         }),
+        where: jest.fn(
+          (_column: string, _operator: string, value: string | (() => void)) => {
+            if (typeof value === "string") programAreaValues.push(value);
+            return query;
+          },
+        ),
+        innerJoin: jest.fn(() => query),
         executeTakeFirst: jest.fn(async () =>
-          programAreaValues.includes(accessibleProgramAreaId)
-            ? { program_area_uuid: accessibleProgramAreaId }
-            : undefined,
+          isUserQuery
+            ? {
+                ...standardUser,
+                uuid: programAreaValues[0],
+                status: programAreaValues[0] === "inactive-user" ? "inactive" : "active",
+              }
+            : programAreaValues.includes(accessibleProgramAreaId)
+              ? { program_area_uuid: accessibleProgramAreaId }
+              : undefined,
+        ),
+        execute: jest.fn(async () =>
+          programAreaValues.includes("no-shared-user")
+            ? []
+            : [{ uuid: accessibleProgramAreaId }],
         ),
       };
       return query;
@@ -84,6 +109,36 @@ jest.mock("@/app/data/metadataDb/database", () => ({
 }));
 
 describe("userService", () => {
+  
+  describe("isLoggedInUserEcrAuthed", () => {
+    it("admin should be authed to see ecr", async () => {
+      const res = await isLoggedInUserEcrAuthed("some-ecr-id");
+      expect(res).toBeTrue();
+    });
+
+    it("should not authorize a user when no user is logged in", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(undefined);
+
+      const res = await isLoggedInUserEcrAuthed("some-ecr-id");
+
+      expect(res).toBeFalse();
+    });
+  });
+
+  describe("isUserEcrAuthed", () => {
+    it("should authorize a user with access to the eCR's program area", async () => {
+      const res = await isUserEcrAuthed("some-user-id", accessibleProgramAreaId);
+
+      expect(res).toBeTrue();
+    });
+
+    it("should not authorize a user without access to the eCR's program area", async () => {
+      const res = await isUserEcrAuthed("some-user-id", inaccessibleProgramAreaId);
+
+      expect(res).toBeFalse();
+    });
+  });
+
   describe("getCheckAdmin", () => {
     it("should return admin if user is an admin", async () => {
       const admin = await getCheckAdmin("do a thing");
@@ -100,6 +155,12 @@ describe("userService", () => {
     it("should return admin if user is an admin", async () => {
       const admin = await getCheckAnyAdmin("do a thing");
       expect(admin.email).toBe(adminUserEmail);
+    });
+
+    it("should return admin if user is a program admin", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(programAdminUser);
+      const programAdmin = await getCheckAnyAdmin("do a thing");
+      expect(programAdmin.email).toBe(programAdminEmail);
     });
 
     it("should error if user is a standard user", async () => {
@@ -127,6 +188,11 @@ describe("userService", () => {
       expect(notFound).not.toHaveBeenCalled();
     });
 
+    it("should do nothing if user is a program admin", async () => {
+      await notFoundUnlessAnyAdmin();
+      expect(notFound).not.toHaveBeenCalled();
+    });
+
     it("should notFound if user is a standard user", async () => {
       (getLoggedInUser as jest.Mock).mockResolvedValue(standardUser);
       await notFoundUnlessAnyAdmin();
@@ -139,7 +205,7 @@ describe("userService", () => {
       const adminUser = await getCheckAdmin("check");
       const res = await hasRelevantProgramAreaAccess(
         adminUser,
-        "some-prog-uuid",
+        "some-prog-uuid"
       );
       expect(res).toBeTrue();
     });
@@ -148,24 +214,36 @@ describe("userService", () => {
       const adminUser = await getCheckAdmin("check");
       const inactiveUser = { ...adminUser, status: "inactive" as const };
       expect(
-        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid")
       ).toBeFalse();
     });
 
     it("should return false when no user is passed and none is logged in", async () => {
       (getLoggedInUser as jest.Mock).mockResolvedValue(undefined);
       expect(
-        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid"),
+        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid")
       ).toBeFalse();
     });
   });
 
-  // TODO ANGELA: Add for hasRelevantUserAccess
+  describe("hasRelevantUserAccess", () => {
+    it("should return true for an active user sharing a program area", async () => {
+      await expect(hasRelevantUserAccess("target-user")).resolves.toBeTrue();
+    });
+
+    it("should return false when users do not share a program area", async () => {
+      await expect(hasRelevantUserAccess("no-shared-user")).resolves.toBeFalse();
+    });
+
+    it("should return false for an inactive user", async () => {
+      await expect(hasRelevantUserAccess("inactive-user")).resolves.toBeFalse();
+    });
+  });
 
   describe("validateAdminUserPermissions", () => {
     it("allows admins to manage users of any type", async () => {
       await expect(
-        validateAdminUserPermissions(adminUser, "admin", [], "create"),
+        validateAdminUserPermissions(adminUser, "admin", [], "create")
       ).resolves.toBeUndefined();
     });
 
@@ -175,22 +253,22 @@ describe("userService", () => {
           programAdminUser,
           "standard",
           [accessibleProgramAreaId],
-          "create",
-        ),
+          "create"
+        )
       ).resolves.toBeUndefined();
       await expect(
         validateAdminUserPermissions(
           programAdminUser,
           "prog_admin",
           [accessibleProgramAreaId],
-          "create",
-        ),
+          "create"
+        )
       ).resolves.toBeUndefined();
     });
 
     it("prevents program admins from managing admin users", async () => {
       await expect(
-        validateAdminUserPermissions(programAdminUser, "admin", [], "create"),
+        validateAdminUserPermissions(programAdminUser, "admin", [], "create")
       ).rejects.toThrow(UserFacingError);
     });
 
@@ -200,8 +278,8 @@ describe("userService", () => {
           programAdminUser,
           "standard",
           [inaccessibleProgramAreaId],
-          "create",
-        ),
+          "create"
+        )
       ).rejects.toThrow(UserFacingError);
     });
   });

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -1,0 +1,208 @@
+import { User } from "@/app/data/metadataDb/types/core";
+import { UserFacingError } from "@/app/services/errorService";
+import {
+  getCheckAdmin,
+  getCheckAnyAdmin,
+  hasRelevantProgramAreaAccess,
+  notFoundUnlessAdmin,
+  notFoundUnlessAnyAdmin,
+  validateAdminUserPermissions,
+} from "@/app/services/userService";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
+import { notFound } from "next/navigation";
+
+const accessibleProgramAreaId = "123";
+const inaccessibleProgramAreaId = "456";
+
+jest.mock("@/app/services/loggedInUserService", () => ({
+  getLoggedInUser: jest.fn(),
+  getUserByEmail: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+const adminUserEmail = "admin@admin.com";
+const programAdminEmail = "programadmin@programadmin.com";
+const standardUserEmail = "standard@standard.com";
+
+const adminUser: User = {
+  uuid: "001",
+  email: adminUserEmail,
+  name: "Admin",
+  date_of_last_login: null,
+  user_type: "admin",
+  status: "active",
+  date_created: new Date(),
+  author_uuid: "001",
+};
+
+const programAdminUser: User = {
+  ...adminUser,
+  uuid: "002",
+  email: programAdminEmail,
+  user_type: "prog_admin",
+};
+
+const standardUser: User = {
+  ...adminUser,
+  uuid: "003",
+  email: standardUserEmail,
+  user_type: "standard",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: logged in user is admin
+  (getLoggedInUser as jest.Mock).mockResolvedValue(adminUser);
+});
+
+jest.mock("@/app/data/metadataDb/database", () => ({
+  getDb: jest.fn(() => ({
+    selectFrom: jest.fn(() => {
+      const programAreaValues: string[] = [];
+      const query: {
+        select: jest.Mock;
+        where: jest.Mock;
+        executeTakeFirst: jest.Mock;
+      } = {
+        select: jest.fn(() => query),
+        where: jest.fn((_column: string, _operator: string, value: string) => {
+          programAreaValues.push(value);
+          return query;
+        }),
+        executeTakeFirst: jest.fn(async () =>
+          programAreaValues.includes(accessibleProgramAreaId)
+            ? { program_area_uuid: accessibleProgramAreaId }
+            : undefined,
+        ),
+      };
+      return query;
+    }),
+  })),
+}));
+
+describe("userService", () => {
+  describe("getCheckAdmin", () => {
+    it("should return admin if user is an admin", async () => {
+      const admin = await getCheckAdmin("do a thing");
+      expect(admin.email).toBe(adminUserEmail);
+    });
+
+    it("should error if user is not an admin", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(undefined);
+      await expect(getCheckAdmin("do a thing")).rejects.toThrow();
+    });
+  });
+
+  describe("getCheckAnyAdmin", () => {
+    it("should return admin if user is an admin", async () => {
+      const admin = await getCheckAnyAdmin("do a thing");
+      expect(admin.email).toBe(adminUserEmail);
+    });
+
+    it("should error if user is a standard user", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(standardUser);
+      await expect(getCheckAnyAdmin("do a thing")).rejects.toThrow();
+    });
+  });
+
+  describe("notFoundUnlessAdmin", () => {
+    it("should do nothing if user is an admin", async () => {
+      await notFoundUnlessAdmin();
+      expect(notFound).not.toHaveBeenCalled();
+    });
+
+    it("should notFound if user is not an admin", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(standardUser);
+      await notFoundUnlessAdmin();
+      expect(notFound).toHaveBeenCalled();
+    });
+  });
+
+  describe("notFoundUnlessAnyAdmin", () => {
+    it("should do nothing if user is an admin", async () => {
+      await notFoundUnlessAnyAdmin();
+      expect(notFound).not.toHaveBeenCalled();
+    });
+
+    it("should notFound if user is a standard user", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(standardUser);
+      await notFoundUnlessAnyAdmin();
+      expect(notFound).toHaveBeenCalled();
+    });
+  });
+
+  describe("hasRelevantProgramAreaAccess", () => {
+    it("should return true for admin user", async () => {
+      const adminUser = await getCheckAdmin("check");
+      const res = await hasRelevantProgramAreaAccess(
+        adminUser,
+        "some-prog-uuid",
+      );
+      expect(res).toBeTrue();
+    });
+
+    it("should return false for an inactive user", async () => {
+      const adminUser = await getCheckAdmin("check");
+      const inactiveUser = { ...adminUser, status: "inactive" as const };
+      expect(
+        await hasRelevantProgramAreaAccess(inactiveUser, "some-prog-uuid"),
+      ).toBeFalse();
+    });
+
+    it("should return false when no user is passed and none is logged in", async () => {
+      (getLoggedInUser as jest.Mock).mockResolvedValue(undefined);
+      expect(
+        await hasRelevantProgramAreaAccess(undefined, "some-prog-uuid"),
+      ).toBeFalse();
+    });
+  });
+
+  // TODO ANGELA: Add for hasRelevantUserAccess
+
+  describe("validateAdminUserPermissions", () => {
+    it("allows admins to manage users of any type", async () => {
+      await expect(
+        validateAdminUserPermissions(adminUser, "admin", [], "create"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("allows program admins to manage users in accessible program areas", async () => {
+      await expect(
+        validateAdminUserPermissions(
+          programAdminUser,
+          "standard",
+          [accessibleProgramAreaId],
+          "create",
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        validateAdminUserPermissions(
+          programAdminUser,
+          "prog_admin",
+          [accessibleProgramAreaId],
+          "create",
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("prevents program admins from managing admin users", async () => {
+      await expect(
+        validateAdminUserPermissions(programAdminUser, "admin", [], "create"),
+      ).rejects.toThrow(UserFacingError);
+    });
+
+    it("prevents program admins from managing users outside their accessible program areas", async () => {
+      await expect(
+        validateAdminUserPermissions(
+          programAdminUser,
+          "standard",
+          [inaccessibleProgramAreaId],
+          "create",
+        ),
+      ).rejects.toThrow(UserFacingError);
+    });
+  });
+});

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -83,9 +83,13 @@ jest.mock("@/app/data/metadataDb/database", () => ({
           (
             _column: string,
             _operator: string,
-            value: string | (() => void),
+            value: string | string[] | (() => void),
           ) => {
-            if (typeof value === "string") programAreaValues.push(value);
+            if (typeof value === "string") {
+              programAreaValues.push(value);
+            } else if (Array.isArray(value)) {
+              programAreaValues.push(...value);
+            }
             return query;
           },
         ),
@@ -107,7 +111,12 @@ jest.mock("@/app/data/metadataDb/database", () => ({
         execute: jest.fn(async () =>
           programAreaValues.includes("no-shared-user")
             ? []
-            : [{ uuid: accessibleProgramAreaId }],
+            : [
+                {
+                  uuid: accessibleProgramAreaId,
+                  program_area_uuid: accessibleProgramAreaId,
+                },
+              ],
         ),
       };
       return query;

--- a/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/userService.test.ts
@@ -243,44 +243,109 @@ describe("userService", () => {
   describe("validateAdminUserPermissions", () => {
     it("allows admins to manage users of any type", async () => {
       await expect(
-        validateAdminUserPermissions(adminUser, "admin", [], "create")
+        validateAdminUserPermissions({
+          loggedInUser: adminUser,
+          action: "create",
+          targetUserType: "admin",
+          targetProgramAreaUuids: [],
+        })
       ).resolves.toBeUndefined();
     });
 
-    it("allows program admins to manage users in accessible program areas", async () => {
+    it("allows program admins to create users in accessible program areas", async () => {
       await expect(
-        validateAdminUserPermissions(
-          programAdminUser,
-          "standard",
-          [accessibleProgramAreaId],
-          "create"
-        )
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "create",
+          targetUserType: "standard",
+          targetProgramAreaUuids: [accessibleProgramAreaId],
+        })
       ).resolves.toBeUndefined();
       await expect(
-        validateAdminUserPermissions(
-          programAdminUser,
-          "prog_admin",
-          [accessibleProgramAreaId],
-          "create"
-        )
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "create",
+          targetUserType: "prog_admin",
+          targetProgramAreaUuids: [accessibleProgramAreaId],
+        })
       ).resolves.toBeUndefined();
     });
 
-    it("prevents program admins from managing admin users", async () => {
+    it("should invalidate program admins from managing admin users", async () => {
       await expect(
-        validateAdminUserPermissions(programAdminUser, "admin", [], "create")
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "create",
+          targetUserType: "admin",
+          targetProgramAreaUuids: [],
+        })
       ).rejects.toThrow(UserFacingError);
     });
 
-    it("prevents program admins from managing users outside their accessible program areas", async () => {
+    it("should invalidate program admins from creating users outside their accessible program areas", async () => {
       await expect(
-        validateAdminUserPermissions(
-          programAdminUser,
-          "standard",
-          [inaccessibleProgramAreaId],
-          "create"
-        )
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "create",
+          targetUserType: "standard",
+          targetProgramAreaUuids: [inaccessibleProgramAreaId],
+        })
       ).rejects.toThrow(UserFacingError);
+    });
+
+    it("should invalidate program admins from editing users outside their program areas", async () => {
+      await expect(
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "edit",
+          targetUserUuid: "no-shared-user",
+          targetProgramAreaUuids: [],
+        })
+      ).rejects.toThrow(UserFacingError);
+    });
+
+    it("should invalidate program admins from editing a user's role or email", async () => {
+      await expect(
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "edit",
+          targetUserUuid: "target-user",
+          targetUserType: "standard",
+          targetProgramAreaUuids: [],
+        }),
+      ).rejects.toThrow(UserFacingError);
+
+      await expect(
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "edit",
+          targetUserUuid: "target-user",
+          targetEmail: "updated@example.com",
+          targetProgramAreaUuids: [],
+        }),
+      ).rejects.toThrow(UserFacingError);
+    });
+
+    it("should invalidate program admins from assigning inaccessible program areas while editing", async () => {
+      await expect(
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "edit",
+          targetUserUuid: "target-user",
+          targetProgramAreaUuids: [inaccessibleProgramAreaId],
+        }),
+      ).rejects.toThrow(UserFacingError);
+    });
+
+    it("allows program admins to assign accessible program areas while editing", async () => {
+      await expect(
+        validateAdminUserPermissions({
+          loggedInUser: programAdminUser,
+          action: "edit",
+          targetUserUuid: "target-user",
+          targetProgramAreaUuids: [accessibleProgramAreaId],
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

Update user management permissions for program area admins such that they:
- Can NOT delete users (or view the Delete user button)
- Can NOT change a user's role or email
- Can only add or remove a user's program area assignments within the program area(s) they administer.

Testing:
- Moved some tests in userService (integration) to userService (unit). Adds more unit testing, esp. for `validateAdminUserPermissions` and `hasRelevantUserAccess`.
- Add render snapshot & axe test for Edit User page (for program admins)
- Add integration testing for `updateUser` and `deleteUser`
- Add e2e testing for program admin edit user & delete user flow

## Screenshots
Program admin (COVID) can view all users' program areas (COVID & Zika). Program admin does not see `Delete user` button
<img width="1513" height="821" alt="Screenshot 2026-08-11 at 19 18 22" src="https://github.com/user-attachments/assets/910be733-084e-4d92-bd99-a6c0bb49f3f4" />

Program admin cannot edit a user's email or user type. Program admin can only edit a user's program areas they have access to (COVID, not Zika).
<img width="1061" height="810" alt="Screenshot 2026-08-11 at 19 19 18" src="https://github.com/user-attachments/assets/7e9c7b6d-6e5e-4eb5-99dd-41f4730c09b6" />

## Related Issue

Fixes #1640 

## Acceptance Criteria

- [ ] Program admins cannot delete ANY users.
- [ ] Program admins cannot change a user's role or email.
- [ ] Program admins can only add or remove a user's program area assignments within the program area(s) they administer. User must be in their program area(s).
- [ ] Ensure that functionality for (super) admins and standard users remains the same.
- [ ] Add/update any tests, esp. e2e tests

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
