### PR TITLE
fix: Configure HTTP timeout for Azure AD

### DIFF
--- a/containers/ecr-viewer/src/app/api/auth/providers.ts
+++ b/containers/ecr-viewer/src/app/api/auth/providers.ts
@@ -31,6 +31,9 @@ const azure = () => {
       clientId: process.env.AUTH_CLIENT_ID,
       clientSecret: process.env.AUTH_CLIENT_SECRET,
       tenantId: process.env.AUTH_ISSUER,
+      httpOptions: {
+        timeout: 10000,
+      },
       // Override the default profile fetcher as 1) we don't care about images and 2)
       // azure makes it look like you have an email, but it's really a UPN, so use that
       // as a fall-back for email if needed and it looks email-like


### PR DESCRIPTION
# PULL REQUEST

## Summary

Configure HTTP timeout to 10 seconds for Azure AD

## Related Issue

Fixes # NA

When signing into our Cloud Run GCP environment, Alis got a timeout (similar to this [discussion](https://github.com/nextauthjs/next-auth/discussions/3186)). Making recommended fix from https://github.com/nextauthjs/next-auth/pull/3188
 
## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
