### PR TITLE
feat: Add admin hierarchy Pt.7 - Program management

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { listProgramAreas } from "@/app/services/programAreaService";
 import { deleteProgramAreaAction } from "@/app/services/serverActionService";
-import { isAdmin, notFoundUnlessAdmin } from "@/app/services/userService";
+import { isAdmin, notFoundUnlessAnyAdmin } from "@/app/services/userService";
 
 import { ProgramTable } from "./ProgramTable";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
@@ -13,7 +13,7 @@ import { getLoggedInUser } from "@/app/services/loggedInUserService";
  * @returns user admin page
  */
 const ProgramAdminPage = async () => {
-  await notFoundUnlessAdmin();
+  await notFoundUnlessAnyAdmin();
   const currentUser = await getLoggedInUser();
 
   const programAreas = await listProgramAreas();

--- a/containers/ecr-viewer/src/app/admin/program/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/page.tsx
@@ -6,6 +6,7 @@ import { deleteProgramAreaAction } from "@/app/services/serverActionService";
 import { isAdmin, notFoundUnlessAnyAdmin } from "@/app/services/userService";
 
 import { ProgramTable } from "./ProgramTable";
+import { ProgramManagementWithoutProgramAreas } from "@/app/components/ErrorPage";
 import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
@@ -15,8 +16,11 @@ import { getLoggedInUser } from "@/app/services/loggedInUserService";
 const ProgramAdminPage = async () => {
   await notFoundUnlessAnyAdmin();
   const currentUser = await getLoggedInUser();
-
   const programAreas = await listProgramAreas();
+
+  if (!isAdmin(currentUser) && programAreas.length === 0) {
+    return <ProgramManagementWithoutProgramAreas />;
+  }
 
   return (
     <main className="main-container">

--- a/containers/ecr-viewer/src/app/components/ErrorPage.tsx
+++ b/containers/ecr-viewer/src/app/components/ErrorPage.tsx
@@ -14,10 +14,12 @@ const ErrorPage = ({
   title,
   subTitle,
   children,
+  showBackButton = true,
 }: {
   title: string;
   subTitle?: string;
   children: React.ReactNode;
+  showBackButton?: boolean;
 }) => (
   <div className="height-viewport-header-footer width-viewport display-flex flex-column">
     <main className="display-flex flex-justify-center height-full">
@@ -36,7 +38,9 @@ const ErrorPage = ({
         <div className="bg-primary-lighter border border-info-light radius-md font-sans-md line-height-sans-4 padding-3 margin-top-2 width-tablet error-message-content">
           {children}
         </div>
-        <BackButton className="margin-top-3 font-sans-md text-primary" />
+        {showBackButton && (
+          <BackButton className="margin-top-3 font-sans-md text-primary" />
+        )}
       </div>
     </main>
   </div>
@@ -87,13 +91,26 @@ export const MetadataDbInvalid = () => (
 );
 
 /**
- * @returns The incomplete user setup error page for users without program areas.
+ * @returns The incomplete user setup error page for viewing the eCR Library without program areas.
  * Relevant to standard users and program admins.
  */
-export const UserWithoutProgramAreas = () => (
+export const LibraryWithoutProgramAreas = () => (
   <ErrorPage title="Your user setup is incomplete">
     <p>
       To be able to view eCRs, you must be added to at least one program area.
+      Reach out to your eCR Viewer admin to complete setup.
+    </p>
+  </ErrorPage>
+);
+
+/**
+ * @returns The incomplete user setup error page for managing programs without program areas.
+ * Relevant to program admins.
+ */
+export const ProgramManagementWithoutProgramAreas = () => (
+  <ErrorPage title="Your user setup is incomplete" showBackButton={false}>
+    <p>
+      To manage a program, you must be assigned to at least one program area.
       Reach out to your eCR Viewer admin to complete setup.
     </p>
   </ErrorPage>

--- a/containers/ecr-viewer/src/app/page.tsx
+++ b/containers/ecr-viewer/src/app/page.tsx
@@ -7,7 +7,7 @@ import { dbIsValid } from "./api/migrate-db/migrate";
 import Filters from "./components/EcrFilters";
 import {
   MetadataDbInvalid,
-  UserWithoutProgramAreas,
+  LibraryWithoutProgramAreas,
 } from "./components/ErrorPage";
 import LibrarySearch from "./components/LibrarySearch";
 import { NoDataRow } from "./components/table/NoDataRow";
@@ -45,7 +45,7 @@ const HomePage = async ({
   } else if (!isAdmin(user)) {
     const progAreas = await listLoggedInUserProgramAreas();
     if (progAreas.length === 0) {
-      return <UserWithoutProgramAreas />;
+      return <LibraryWithoutProgramAreas />;
     }
   }
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -19,7 +19,27 @@ test.describe("program management page", () => {
     expect(accessibilityScanResultsBase.violations).toEqual([]);
   });
 
-  test("should create a program", async ({ page }) => {
+  test("as program admin, should only see accessible programs", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/program");
+
+    await expect(
+      page.getByRole("heading", { name: "Program management" }),
+    ).toBeVisible();
+
+    const programRows = page
+      .getByRole("table")
+      .getByRole("row")
+      .filter({ has: page.getByRole("cell") });
+    await expect(programRows).toHaveCount(1);
+    await expect(programRows.getByRole("cell", { name: "COVID", exact: true }))
+      .toBeVisible();
+  });
+
+  test("as admin, should create a program", async ({ page }) => {
     await page.goto("/ecr-viewer/admin/program");
 
     await expect(

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -35,8 +35,9 @@ test.describe("program management page", () => {
       .getByRole("row")
       .filter({ has: page.getByRole("cell") });
     await expect(programRows).toHaveCount(1);
-    await expect(programRows.getByRole("cell", { name: "COVID", exact: true }))
-      .toBeVisible();
+    await expect(
+      programRows.getByRole("cell", { name: "COVID", exact: true }),
+    ).toBeVisible();
   });
 
   test("as admin, should create a program", async ({ page }) => {

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -287,6 +287,7 @@ describe("program area service", () => {
     expect(programAreaIds).toStrictEqual([accessibleProgramId]);
     expect(programAreaIds).not.toContain(restrictedProgramId);
 
+    // When viewing user details side panel, should see all their programs
     const detailProgramAreas = await listProgramAreas({
       userUuids: [visibleUserId],
     });

--- a/containers/ecr-viewer/tests/unit/app/admin/ProgramAdminPage.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/ProgramAdminPage.test.tsx
@@ -7,7 +7,7 @@ import ProgramCreatePage from "@/app/admin/program/create/page";
 import ProgramAdminPage from "@/app/admin/program/page";
 import { listConditionReferences } from "@/app/services/listConditionsService";
 import { listProgramAreas } from "@/app/services/programAreaService";
-import { isAdmin, notFoundUnlessAdmin } from "@/app/services/userService";
+import { isAdmin, notFoundUnlessAnyAdmin } from "@/app/services/userService";
 
 jest.mock("@/app/data/metadataDb/database");
 jest.mock("@/app/utils/auth-utils", () => ({
@@ -27,12 +27,12 @@ describe("Program Admin Page", () => {
     jest.clearAllMocks();
   });
 
-  it("should check user is an admin", async () => {
+  it("should check user is any admin", async () => {
     (isAdmin as unknown as jest.Mock).mockReturnValue(false);
     (listProgramAreas as jest.Mock).mockResolvedValue([]);
 
     render(await ProgramAdminPage());
-    expect(notFoundUnlessAdmin).toHaveBeenCalled();
+    expect(notFoundUnlessAnyAdmin).toHaveBeenCalled();
   });
 
   it("should show no program areas message if none", async () => {


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Program management page is visible to program admins and lists only their authorized program areas.
- If not assigned to any program areas, the program admin encounters an error page.
- Add e2e test
- Refactor: `listProgramAreas` to reuse the `listUserProgramAreas()` function (see: Pt. 9 cleanup comments for more details on how this will be further refactored later)

## Screenshot
Program admin (COVID) can only see COVID in program management table.
(Note: `Create program area` button will be removed in Pt. 8)
<img height="500" alt="Screenshot 2026-08-12 at 10 35 26" src="https://github.com/user-attachments/assets/9dd56f6a-5042-44e9-842a-9def8276db20" />

Program admin (not assigned to any program areas yet) receives this error page.
<img width="1514" height="822" alt="Screenshot 2026-08-13 at 12 20 01" src="https://github.com/user-attachments/assets/beeedddb-bf92-427e-94f2-00547365f7c1" />

## Related Issue

Fixes #1642 

## Acceptance Criteria
- [ ] For program admins, the program management table lists all program area(s) they have access to.
- [ ] When clicking on a program area, a program admin can view all the condition information.
- [ ] Ensure that functionality for (super) admins and standard users remains the same.
- [ ] Add/update any tests, esp. e2e tests

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
