### PR TITLE
fix: Change min widths of eCR Library columns

### DIFF
--- a/containers/ecr-viewer/src/styles/ecr-library.scss
+++ b/containers/ecr-viewer/src/styles/ecr-library.scss
@@ -15,22 +15,22 @@
 }
 
 .library-received-date-column {
-  width: 8.3rem;
-  min-width: 8.3rem;
+  min-width: 9.8rem;
+  width: 10%;
 }
 
 .library-encounter-date-column {
+  min-width: 10.2rem;
   width: 10%;
-  min-width: 8.3rem;
 }
 
 .library-condition-column {
-  min-width: 23rem;
+  min-width: 18rem;
   width: 25%;
 }
 
 .library-rule-column {
-  min-width: 35.5rem;
+  min-width: 28rem;
   width: auto;
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Update min widths of eCR Library columns (widen date columns, reduce RR condition & rule summaries columns)

## Screenshot
Before:
<img width="1505" height="615" alt="Screenshot 2026-08-12 at 12 57 41" src="https://github.com/user-attachments/assets/74035490-166f-4d7a-928f-29d1e648f585" />

After:
<img width="1510" height="663" alt="Screenshot 2026-08-12 at 12 56 48" src="https://github.com/user-attachments/assets/66a6eeea-f166-4ce6-ab7d-07c22dd7b2d1" />

## Related Issue

Fixes #1703 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
