### PR TITLE
fix: Increase size of ethnicity column in ecr_data

### DIFF
--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260812173622_ethnicity_varchar_max.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260812173622_ethnicity_varchar_max.ts
@@ -14,9 +14,7 @@ export async function up(db: Kysely<AnyDb>): Promise<void> {
 
   await _db.schema
     .alterTable("ecr_data")
-    .alterColumn("ethnicity", (col) =>
-      col.setDataType(getSql("maxVarchar")),
-    )
+    .alterColumn("ethnicity", (col) => col.setDataType(getSql("maxVarchar")))
     .execute();
 }
 
@@ -28,8 +26,6 @@ export async function down(db: Kysely<AnyDb>): Promise<void> {
   const _db = db.withSchema(dbNamespace());
   await _db.schema
     .alterTable("ecr_data")
-    .alterColumn("ethnicity", (col) =>
-      col.setDataType("varchar(255)"),
-    )
+    .alterColumn("ethnicity", (col) => col.setDataType("varchar(255)"))
     .execute();
 }

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260812173622_ethnicity_varchar_max.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/20260812173622_ethnicity_varchar_max.ts
@@ -1,0 +1,35 @@
+import { Kysely } from "kysely";
+
+import { AnyDb } from "@/app/data/metadataDb/database";
+import { getSql } from "@/app/data/metadataDb/dialects/common";
+import { dbNamespace } from "@/app/data/metadataDb/utils/db-config";
+
+/**
+ * Expand ethnicity column length to varchar(max).
+ * @param db - the database connection
+ */
+export async function up(db: Kysely<AnyDb>): Promise<void> {
+  const schema = dbNamespace();
+  const _db = db.withSchema(schema);
+
+  await _db.schema
+    .alterTable("ecr_data")
+    .alterColumn("ethnicity", (col) =>
+      col.setDataType(getSql("maxVarchar")),
+    )
+    .execute();
+}
+
+/**
+ * Reduce ethnicity column length to varchar(255)
+ * @param db - the database connection
+ */
+export async function down(db: Kysely<AnyDb>): Promise<void> {
+  const _db = db.withSchema(dbNamespace());
+  await _db.schema
+    .alterTable("ecr_data")
+    .alterColumn("ethnicity", (col) =>
+      col.setDataType("varchar(255)"),
+    )
+    .execute();
+}

--- a/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/migrations/extended/index.ts
@@ -7,4 +7,5 @@ export default {
   "20260403143048_add_immunization_variables": require("./20260403143048_add_immunization_variables"),
   "20260609174023_update_immunization": require("./20260609174023_update_immunization"),
   "20260723173756_remove_unused_cols": require("./20260723173756_remove_unused_cols"),
+  "20260812173622_ethnicity_varchar_max.ts": require("./20260812173622_ethnicity_varchar_max"),
 };


### PR DESCRIPTION
# PULL REQUEST

## Summary

Create a new migration to increase size of `ethnicity` column in `ecr_data` table to `varchar(max)`.

## Related Issue

Fixes #1705 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

FUP ticket to display multiple ethnicites is [here](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1706)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
