### PR TITLE
fix: eCRs with no versionNumber are displayed properly in the library

### DIFF
--- a/containers/ecr-viewer/src/app/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/services/listEcrDataService.ts
@@ -87,6 +87,10 @@ export const listEcrData = audit(
   },
 );
 
+// Used to treat missing version_number values as 1 for comparison logic without changing the stored/displayed metadata.
+const versionForComparison = (ref: string) =>
+  sql<number>`COALESCE(CAST(NULLIF(${sql.ref(ref)}, '') AS integer), 1)`;
+
 const executeSearchQuery = async (
   db: Transaction<Core>,
   startIndex: number,
@@ -102,11 +106,11 @@ const executeSearchQuery = async (
     db
       .selectFrom("ecr_data")
       .$call((qb) => limitEcrDataToUser(user, qb))
-      .select(({ eb }) => [
+      .select([
         "ecr_data.set_id",
-        eb.fn
-          .max(eb.cast<number>("ecr_data.eicr_version_number", "integer"))
-          .as("max_version_number"),
+        sql<number>`MAX(${versionForComparison("ecr_data.eicr_version_number")})`.as(
+          "max_version_number",
+        ),
       ])
       .groupBy(["ecr_data.set_id"])
       .where((eb) =>
@@ -126,8 +130,8 @@ const executeSearchQuery = async (
       .leftJoin("ecr_data", (join) =>
         join
           .onRef("ecr_data.set_id", "=", "ecr_sets.set_id")
-          .on("ecr_sets.max_version_number", "=", (eb) =>
-            eb.cast<number>("ecr_data.eicr_version_number", "integer"),
+          .on("ecr_sets.max_version_number", "=", () =>
+            versionForComparison("ecr_data.eicr_version_number"),
           ),
       )
       .select([
@@ -208,7 +212,7 @@ const groupSummariesByCondition = (
     if (!condition) continue;
     if (!summaries.has(condition)) summaries.set(condition, new Set());
     if (rule_summary) summaries.get(condition)!.add(rule_summary);
-    const v = Number(eicr_version_number ?? 0);
+    const v = Number(eicr_version_number || 1);
     if (v > (maxVersion.get(condition) ?? 0)) maxVersion.set(condition, v);
   }
   // Sort descending by max version so the most recently added condition appears first
@@ -243,9 +247,9 @@ const getMetaModelData = async (
         .onRef("ecr_data.set_id", "=", "ecrs.set_id")
         .on((eb) =>
           eb(
-            eb.cast<number>("ecr_data.eicr_version_number", "integer"),
+            versionForComparison("ecr_data.eicr_version_number"),
             "<=",
-            eb.cast<number>("ecrs.eicr_version_number", "integer"),
+            versionForComparison("ecrs.eicr_version_number"),
           ),
         ),
     )
@@ -265,9 +269,9 @@ const getMetaModelData = async (
         .onRef("ecr_data.set_id", "=", "ecrs.set_id")
         .on((eb) =>
           eb(
-            eb.cast<number>("ecr_data.eicr_version_number", "integer"),
+            versionForComparison("ecr_data.eicr_version_number"),
             "<=",
-            eb.cast<number>("ecrs.eicr_version_number", "integer"),
+            versionForComparison("ecrs.eicr_version_number"),
           ),
         ),
     )
@@ -299,15 +303,12 @@ const getMetaModelData = async (
       "ecr_data.eicr_version_number",
       "ecr_data.date_created",
     ])
-    .orderBy(
-      (eb) => eb.cast<number>("ecr_data.eicr_version_number", "integer"),
-      "desc",
-    )
+    .orderBy(() => versionForComparison("ecr_data.eicr_version_number"), "desc")
     .where((eb) =>
       eb(
         "ecr_sets.max_version_number",
         "!=",
-        eb.cast<number>("ecr_data.eicr_version_number", "integer"),
+        versionForComparison("ecr_data.eicr_version_number"),
       ),
     )
     .execute();

--- a/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
+++ b/containers/ecr-viewer/tests/integration/listEcrDataService/core.test.ts
@@ -299,6 +299,55 @@ describe("listEcrData - core", () => {
     await clearEcrCore();
   });
 
+  it("should return populated data when version number is missing", async () => {
+    const missingVersionEcr = {
+      ...coreTemplate,
+      eicr_id: "missing-version-eicr-id",
+      set_id: "missing-version-set-id",
+      eicr_version_number: undefined,
+    };
+
+    await createCoreEcr(missingVersionEcr);
+    await createEcrCondition({
+      uuid: "missing-version-condition",
+      eicr_id: "missing-version-eicr-id",
+      condition: "Condition1",
+    });
+    await createEcrRule({
+      uuid: "missing-version-rule",
+      ecr_rr_conditions_id: "missing-version-condition",
+      rule_summary: "Rule1",
+    });
+
+    const actual: EcrDisplay[] = await listEcrData({
+      startIndex: 0,
+      itemsPerPage: 25,
+      sortColumn: "date_created",
+      sortDirection: "DESC",
+      filterDates,
+    });
+
+    expect(actual).toHaveLength(1);
+    expect(actual[0].ecrId).toEqual("missing-version-eicr-id");
+    expect(actual[0].eicr_set_id).toEqual("missing-version-set-id");
+    expect(actual[0].eicr_version_number).toBeFalsy();
+    expect(actual[0].patient_first_name).toEqual("Billy");
+    expect(actual[0].patient_last_name).toEqual("Bob");
+    expect(actual[0].patient_date_of_birth).toEqual("12/01/2024");
+    expect(actual[0].date_created).toEqual("12/02/2024 7:00\u00A0AM\u00A0EST");
+    expect(actual[0].patient_report_date).toEqual(
+      "12/02/2024 7:00\u00A0AM\u00A0EST",
+    );
+    expect(actual[0].facility_name).toEqual("Hospital A");
+    expect(actual[0].reportable_conditions).toEqual(["Condition1"]);
+    expect(actual[0].rule_summaries).toEqual([
+      { condition: "Condition1", rule_summaries: ["Rule1"] },
+    ]);
+    expect(actual[0].related_ecrs).toEqual([]);
+
+    await clearEcrCore();
+  });
+
   it("should not return unauthorized data when found for standard user", async () => {
     (getLoggedInUserSession as jest.Mock).mockResolvedValue({
       email: "standard@standard.com",


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Updates eCR library queries to fix joining/sorting/filtering when eCR version number is null.
Example of how an eCR with no version number is displayed in the library without this fix:
<img width="3807" height="152" alt="image" src="https://github.com/user-attachments/assets/6565f60a-e403-4820-90c0-c57d80132d84" />

## Related Issue

Fixes #1716 

## Acceptance Criteria

- [ ] eCRs with null or blank eicr_version_number appear in the eCR library with populated patient name, eCR ID, dates, facility, conditions, and rule summaries.
- [ ] The original eicr_version_number value remains unchanged in the database.
- [ ] The UI does not display an invented version badge for eCRs whose source version is missing.
- [ ] Existing multi-version eCR behavior continues to work.
- [ ] Add regression test coverage for at least one eCR with no version number.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
