### PR TITLE
fix: add --no-pager to docker install diagnostics

### DIFF
--- a/deployment/vm/docker-install.sh
+++ b/deployment/vm/docker-install.sh
@@ -57,9 +57,9 @@ systemctl enable containerd.service
 if ! systemctl is-active --quiet docker.service; then
   echo "[$(date)] ERROR: Docker service failed to start."
   echo "Docker status:"
-  systemctl status docker.service
+  systemctl status docker.service --no-pager
   echo "Journal logs:"
-  journalctl -xeu docker.service --no-pager -n 40
+  journalctl -xeu docker.service --no-pager
   if [ -f /var/log/docker.log ]; then
     echo "[$(date)] Showing last 40 lines of /var/log/docker.log:"
     tail -40 /var/log/docker.log

--- a/deployment/vm/docker-install.sh
+++ b/deployment/vm/docker-install.sh
@@ -67,5 +67,5 @@ if ! systemctl is-active --quiet docker.service; then
   exit 4
 fi
 
-systemctl status docker.service
+systemctl status docker.service --no-pager
 echo "Docker installation complete!"

--- a/deployment/vm/ecrv-init.sh
+++ b/deployment/vm/ecrv-init.sh
@@ -73,7 +73,7 @@ download_scripts() {
 }
 
 download_config() {
-  cd ~
+  cd
   echo "Downloading docker configuration..."
 
   # -P set directory, -nc skip if file exists because we don't want to overwrite any user settings

--- a/deployment/vm/ecrv-init.sh
+++ b/deployment/vm/ecrv-init.sh
@@ -73,7 +73,7 @@ download_scripts() {
 }
 
 download_config() {
-  cd
+  cd "$HOME"
   echo "Downloading docker configuration..."
 
   # -P set directory, -nc skip if file exists because we don't want to overwrite any user settings

--- a/deployment/vm/ecrv-init.sh
+++ b/deployment/vm/ecrv-init.sh
@@ -73,7 +73,7 @@ download_scripts() {
 }
 
 download_config() {
-  cd "$HOME"
+  cd ~
   echo "Downloading docker configuration..."
 
   # -P set directory, -nc skip if file exists because we don't want to overwrite any user settings


### PR DESCRIPTION
## Summary

Improve the Docker install script failure output in `deployment/vm/docker-install.sh`.

- Add `--no-pager` to `systemctl status docker.service` so the command returns immediately instead of stalling on a pager keypress in non-interactive runs.
- Drop the `-n 40` limit on `journalctl -xeu docker.service` so the full service journal is printed when Docker fails to start.

## Acceptance Criteria

- `systemctl status docker.service` exits without waiting for a pager keypress.
- Docker service failure prints the complete `journalctl` output, not just the last 40 lines.
- Success path still prints service status and "Docker installation complete!".