### PR TITLE
feat: Add admin hierarchy Pt.8 - Edit program areas

### DIFF
--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -88,19 +88,19 @@ export const ProgramForm = ({
   progUuid?: string;
   submitAction: (
     name: string,
-    conditions: string[]
+    conditions: string[],
   ) => Promise<ServerActionResult<string | void>>;
   formTouchedMsg?: string;
   isLoggedInUserAdmin: boolean;
 }) => {
   const [name, setName] = useState(initValues.name || "");
   const [conditionCategories, setConditionCategories] = useState(
-    groupByCategory(initValues.conditions)
+    groupByCategory(initValues.conditions),
   );
   const { createToast } = React.useContext(ToastContext);
 
   const selectedConditions = sortedCodes(
-    Object.values(conditionCategories).flatMap((id) => id)
+    Object.values(conditionCategories).flatMap((id) => id),
   );
   const numConditionsSelected = selectedConditions.length;
 
@@ -155,7 +155,7 @@ const NameFieldSet = ({
   name,
   setName,
   nameIsDupe,
-  isDisabled
+  isDisabled,
 }: {
   name: string;
   setName: (n: string) => void;
@@ -168,11 +168,11 @@ const NameFieldSet = ({
     <FieldSet
       legend={<span className={disabledTextClass}>Name program area</span>}
     >
-      {!isDisabled && 
-      <span className={disabledTextClass}>
-        Required fields are marked with an asterisk (<RequiredMarker />)
-      </span>
-      }
+      {!isDisabled && (
+        <span className={disabledTextClass}>
+          Required fields are marked with an asterisk (<RequiredMarker />)
+        </span>
+      )}
       <FormGroup error={nameIsDupe} className={disabledTextClass}>
         <label className="usa-label maxw-full">
           Program area name

--- a/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/ProgramForm.tsx
@@ -81,24 +81,26 @@ export const ProgramForm = ({
   progUuid,
   submitAction,
   formTouchedMsg,
+  isLoggedInUserAdmin,
 }: {
   action: string;
   initValues: FormValues;
   progUuid?: string;
   submitAction: (
     name: string,
-    conditions: string[],
+    conditions: string[]
   ) => Promise<ServerActionResult<string | void>>;
   formTouchedMsg?: string;
+  isLoggedInUserAdmin: boolean;
 }) => {
   const [name, setName] = useState(initValues.name || "");
   const [conditionCategories, setConditionCategories] = useState(
-    groupByCategory(initValues.conditions),
+    groupByCategory(initValues.conditions)
   );
   const { createToast } = React.useContext(ToastContext);
 
   const selectedConditions = sortedCodes(
-    Object.values(conditionCategories).flatMap((id) => id),
+    Object.values(conditionCategories).flatMap((id) => id)
   );
   const numConditionsSelected = selectedConditions.length;
 
@@ -133,7 +135,12 @@ export const ProgramForm = ({
         return res;
       }}
     >
-      <NameFieldSet name={name} setName={setName} nameIsDupe={nameIsDupe} />
+      <NameFieldSet
+        name={name}
+        setName={setName}
+        nameIsDupe={nameIsDupe}
+        isDisabled={!isLoggedInUserAdmin}
+      />
       <ConditionFieldSet
         progUuid={progUuid}
         conditionCategories={conditionCategories}
@@ -148,20 +155,28 @@ const NameFieldSet = ({
   name,
   setName,
   nameIsDupe,
+  isDisabled
 }: {
   name: string;
   setName: (n: string) => void;
   nameIsDupe: boolean;
+  isDisabled: boolean;
 }) => {
+  const disabledTextClass = isDisabled ? "text-base" : undefined;
+
   return (
-    <FieldSet legend="Name program area">
-      <span>
+    <FieldSet
+      legend={<span className={disabledTextClass}>Name program area</span>}
+    >
+      {!isDisabled && 
+      <span className={disabledTextClass}>
         Required fields are marked with an asterisk (<RequiredMarker />)
       </span>
-      <FormGroup error={nameIsDupe}>
+      }
+      <FormGroup error={nameIsDupe} className={disabledTextClass}>
         <label className="usa-label maxw-full">
           Program area name
-          <RequiredMarker />
+          {!isDisabled && <RequiredMarker />}
           {nameIsDupe && (
             <p className="usa-error-message margin-0">
               Please pick a different program name. This program name already
@@ -174,6 +189,7 @@ const NameFieldSet = ({
             id="name"
             name="name"
             value={name}
+            disabled={isDisabled}
             onChange={(e) => setName(e.target.value)}
           />
         </label>

--- a/containers/ecr-viewer/src/app/admin/program/create/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/create/page.tsx
@@ -3,13 +3,15 @@ import { revalidatePath } from "next/cache";
 import { ProgramForm } from "@/app/admin/program/ProgramForm";
 import { listConditionReferences } from "@/app/services/listConditionsService";
 import { createProgramAreaAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAdmin } from "@/app/services/userService";
+import { isAdmin, notFoundUnlessAdmin } from "@/app/services/userService";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
  * @returns Page to create a program area
  */
 const CreateProgramPage = async () => {
   await notFoundUnlessAdmin();
+  const currentUser = await getLoggedInUser();
 
   const conditions = await listConditionReferences();
 
@@ -23,6 +25,7 @@ const CreateProgramPage = async () => {
         return await createProgramAreaAction({ name, conditions });
       }}
       formTouchedMsg="You have unsaved changes. To create a program area, you must add a program name and at least one condition."
+      isLoggedInUserAdmin={isAdmin(currentUser)}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
@@ -5,8 +5,9 @@ import { ProgramForm } from "@/app/admin/program/ProgramForm";
 import { listAdminConditionReferences } from "@/app/services/listConditionsService";
 import { getProgramArea } from "@/app/services/programAreaService";
 import { updateProgramAreaAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAnyAdmin } from "@/app/services/userService";
+import { isAdmin, notFoundUnlessAnyAdmin } from "@/app/services/userService";
 import { PageSearchParams } from "@/app/utils/search-param-utils";
+import { getLoggedInUser } from "@/app/services/loggedInUserService";
 
 /**
  * @param props page props
@@ -19,6 +20,7 @@ const EditProgramPage = async ({
   searchParams: Promise<PageSearchParams>;
 }) => {
   await notFoundUnlessAnyAdmin();
+  const currentUser = await getLoggedInUser();
   const { uuid } = await searchParams;
 
   // nothing to edit here
@@ -45,6 +47,7 @@ const EditProgramPage = async ({
         revalidatePath("/ecr-viewer/admin/program");
         return await updateProgramAreaAction({ uuid, name, conditions });
       }}
+      isLoggedInUserAdmin={isAdmin(currentUser)}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/edit/page.tsx
@@ -2,10 +2,10 @@ import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 
 import { ProgramForm } from "@/app/admin/program/ProgramForm";
-import { listConditionReferences } from "@/app/services/listConditionsService";
+import { listAdminConditionReferences } from "@/app/services/listConditionsService";
 import { getProgramArea } from "@/app/services/programAreaService";
 import { updateProgramAreaAction } from "@/app/services/serverActionService";
-import { notFoundUnlessAdmin } from "@/app/services/userService";
+import { notFoundUnlessAnyAdmin } from "@/app/services/userService";
 import { PageSearchParams } from "@/app/utils/search-param-utils";
 
 /**
@@ -18,7 +18,7 @@ const EditProgramPage = async ({
 }: {
   searchParams: Promise<PageSearchParams>;
 }) => {
-  await notFoundUnlessAdmin();
+  await notFoundUnlessAnyAdmin();
   const { uuid } = await searchParams;
 
   // nothing to edit here
@@ -31,7 +31,7 @@ const EditProgramPage = async ({
   if (!prog) {
     notFound();
   }
-  const conditions = (await listConditionReferences()).map((c) =>
+  const conditions = (await listAdminConditionReferences()).map((c) =>
     c.program_area_uuid === prog.uuid ? { ...c, checked: true } : c,
   );
 

--- a/containers/ecr-viewer/src/app/admin/program/page.tsx
+++ b/containers/ecr-viewer/src/app/admin/program/page.tsx
@@ -27,11 +27,13 @@ const ProgramAdminPage = async () => {
       <div className="content-container margin-top-10">
         <div className="display-flex flex-justify">
           <h2 className="margin-bottom-5">Program management</h2>
-          <div>
-            <Link href="/admin/program/create" className="usa-button">
-              Create program area
-            </Link>
-          </div>
+          {isAdmin(currentUser) && (
+            <div>
+              <Link href="/admin/program/create" className="usa-button">
+                Create program area
+              </Link>
+            </div>
+          )}
         </div>
         {programAreas.length === 0 ? (
           <div className="width-full height-half bg-base-lightest display-flex flex-align-center flex-justify-center">

--- a/containers/ecr-viewer/src/app/services/listConditionsService.ts
+++ b/containers/ecr-viewer/src/app/services/listConditionsService.ts
@@ -1,7 +1,13 @@
 import { NO_CONDITIONS_REPORTED_OPTION, USER_TYPE } from "@/app/constants";
 import { getDb } from "@/app/data/metadataDb/database";
-import { ConditionReference, Core } from "@/app/data/metadataDb/types/core";
+import {
+  ConditionReference,
+  Core,
+  User,
+} from "@/app/data/metadataDb/types/core";
+import { Kysely } from "kysely";
 
+import { getCheckAnyAdmin } from "./userService";
 import { getLoggedInUser } from "./loggedInUserService";
 
 /**
@@ -92,4 +98,59 @@ export const listConditionReferences = async (): Promise<ListedCondition[]> => {
     console.error({ message, error });
     throw new Error(message);
   }
+};
+
+/**
+ * List condition references visible to an admin. Admins see all conditions;
+ * program admins see only conditions assigned to one of their program areas.
+ */
+export const listAdminConditionReferences = async (): Promise<
+  ListedCondition[]
+> => {
+  const user = await getCheckAnyAdmin("list condition references");
+
+  try {
+    return await listAdminConditionReferencesQuery(user, getDb<Core>());
+  } catch (error: unknown) {
+    const message = "Failed to list accessible condition references";
+    console.error({ message, error });
+    throw new Error(message);
+  }
+};
+
+/**
+ * Lists condition references accessible to a user.
+ * @param user User whose access determines the returned condition references.
+ * @param db Database connection used to query condition references.
+ * @param codes Optional condition codes used to filter the results.
+ * @returns Condition references accessible to the user.
+ */
+export const listAdminConditionReferencesQuery = async (
+  user: User,
+  db: Kysely<Core>,
+  codes?: string[],
+): Promise<ListedCondition[]> => {
+  const query = db
+    .selectFrom("condition_reference")
+    .leftJoin(
+      "program_area",
+      "condition_reference.program_area_uuid",
+      "program_area.uuid",
+    )
+    .selectAll("condition_reference")
+    .select("program_area.name as program_area_name")
+    .$if(user.user_type !== "admin", (qb) =>
+      qb
+        .innerJoin(
+          "user_program_area",
+          "user_program_area.program_area_uuid",
+          "condition_reference.program_area_uuid",
+        )
+        .where("user_program_area.user_uuid", "=", user.uuid),
+    )
+    .$if(!!codes, (qb) =>
+      qb.where("condition_reference.code", "in", codes ?? []),
+    );
+
+  return await query.execute();
 };

--- a/containers/ecr-viewer/src/app/services/listConditionsService.ts
+++ b/containers/ecr-viewer/src/app/services/listConditionsService.ts
@@ -150,7 +150,8 @@ export const listAdminConditionReferencesQuery = async (
     )
     .$if(!!codes, (qb) =>
       qb.where("condition_reference.code", "in", codes ?? []),
-    );
+    )
+    .orderBy("condition_reference.code");
 
   return await query.execute();
 };

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -18,6 +18,7 @@ import { listAdminConditionReferencesQuery } from "./listConditionsService";
 import {
   getCheckAdmin,
   getCheckAnyAdmin,
+  isAdmin,
   listUserProgramAreasQuery,
 } from "./userService";
 
@@ -124,12 +125,12 @@ export const getProgramArea = async (
  * @param trx Transaction used to query the user's accessible conditions.
  * @throws {UserFacingError} If an admin includes an inaccessible condition.
  */
-const validateAdminConditionAccess = async (
+export const validateAdminConditionAccess = async (
   user: Awaited<ReturnType<typeof getCheckAnyAdmin>>,
   conditions: string[],
   trx: Transaction<Core>,
 ): Promise<void> => {
-  if (!isProgramAdmin(user) || conditions.length === 0) return;
+  if (isAdmin(user) || conditions.length === 0) return;
 
   const accessibleConditions = await listAdminConditionReferencesQuery(
     user,
@@ -172,6 +173,20 @@ export const updateProgramArea = audit(
 
     try {
       if (!!name) {
+        if (!isAdmin(updatingUser)) {
+          const currentProgramArea = await trx
+            .selectFrom("program_area")
+            .select("name")
+            .where("uuid", "=", uuid)
+            .executeTakeFirst();
+
+          if (currentProgramArea?.name !== name) {
+            throw new UserFacingError(
+              "Program admins cannot update program area names.",
+            );
+          }
+        }
+
         await checkDupeName(trx, name, uuid);
         await trx
           .updateTable("program_area")

--- a/containers/ecr-viewer/src/app/services/programAreaService.ts
+++ b/containers/ecr-viewer/src/app/services/programAreaService.ts
@@ -14,6 +14,7 @@ import { stringSort } from "@/app/utils/format-utils";
 
 import { audit } from "./auditLogService";
 import { UserFacingError } from "./errorService";
+import { listAdminConditionReferencesQuery } from "./listConditionsService";
 import {
   getCheckAdmin,
   getCheckAnyAdmin,
@@ -115,6 +116,36 @@ export const getProgramArea = async (
 };
 
 /**
+ * Validate admins permissions to manage conditions.
+ * Full admins and empty condition lists pass validation by default.
+ *
+ * @param user User whose access should be validated.
+ * @param conditions Condition codes the user is attempting to manage.
+ * @param trx Transaction used to query the user's accessible conditions.
+ * @throws {UserFacingError} If an admin includes an inaccessible condition.
+ */
+const validateAdminConditionAccess = async (
+  user: Awaited<ReturnType<typeof getCheckAnyAdmin>>,
+  conditions: string[],
+  trx: Transaction<Core>,
+): Promise<void> => {
+  if (!isProgramAdmin(user) || conditions.length === 0) return;
+
+  const accessibleConditions = await listAdminConditionReferencesQuery(
+    user,
+    trx,
+    conditions,
+  );
+
+  const accessibleCodes = new Set(accessibleConditions.map(({ code }) => code));
+  if (conditions.some((code) => !accessibleCodes.has(code))) {
+    throw new UserFacingError(
+      "Program admins cannot manage conditions outside of their program areas.",
+    );
+  }
+};
+
+/**
  * Update a program with the the given uuid.
  * @param uuid (current) id of the program area to update
  * @param updates object with fields to update in the record.
@@ -137,7 +168,7 @@ export const updateProgramArea = audit(
     },
     trx: Transaction<Core>,
   ): Promise<void> => {
-    await getCheckAdmin("update program areas");
+    const updatingUser = await getCheckAnyAdmin("update program areas");
 
     try {
       if (!!name) {
@@ -150,6 +181,7 @@ export const updateProgramArea = audit(
       }
 
       if (!!conditions) {
+        await validateAdminConditionAccess(updatingUser, conditions, trx);
         await trx
           .updateTable("condition_reference")
           .set({ program_area_uuid: null })

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -257,12 +257,13 @@ test.describe("program management page", () => {
     page,
     browserName,
   }) => {
-    const targetProgram = await createRandomProgramArea(page, browserName, ["covid"]);
-    const sourceProgram = await createRandomProgramArea(
-      page,
-      browserName,
-      [targetProgram.conditionName, "covid"],
-    );
+    const targetProgram = await createRandomProgramArea(page, browserName, [
+      "covid",
+    ]);
+    const sourceProgram = await createRandomProgramArea(page, browserName, [
+      targetProgram.conditionName,
+      "covid",
+    ]);
 
     // Assign both programs to program admin
     await page.goto("/ecr-viewer/admin/user");
@@ -275,12 +276,16 @@ test.describe("program management page", () => {
     await rowProgramAdmin.dispatchEvent("click");
     await page.getByRole("dialog").getByText("Edit user").click();
     await page.waitForURL(/\/ecr-viewer\/admin\/user\/edit\?uuid=.*/);
-    const checkboxTarget = await page
-      .getByLabel(`Select ${targetProgram.name}`, { exact: true });
+    const checkboxTarget = await page.getByLabel(
+      `Select ${targetProgram.name}`,
+      { exact: true },
+    );
     await checkboxTarget.scrollIntoViewIfNeeded();
     await checkboxTarget.dispatchEvent("click");
-    const checkboxSource = await page
-      .getByLabel(`Select ${sourceProgram.name}`, { exact: true });
+    const checkboxSource = await page.getByLabel(
+      `Select ${sourceProgram.name}`,
+      { exact: true },
+    );
     await checkboxSource.scrollIntoViewIfNeeded();
     await checkboxSource.dispatchEvent("click");
     await page.getByRole("button", { name: "Save user" }).first().click();
@@ -306,7 +311,7 @@ test.describe("program management page", () => {
     await expect(sourceConditionInSource).toBeVisible();
     const sourceConditionCheckbox = await page.getByLabel(
       sourceProgram.conditionName,
-      { exact: true }
+      { exact: true },
     );
     await sourceConditionCheckbox.scrollIntoViewIfNeeded();
     await sourceConditionCheckbox.dispatchEvent("click");
@@ -320,11 +325,9 @@ test.describe("program management page", () => {
     await page.waitForURL("/ecr-viewer/admin/program");
 
     // The reassigned condition is in target
-    const sourceProgramRow = page
-      .getByRole("row")
-      .filter({
-        has: page.getByRole("button", { name: sourceProgram.name }),
-      });
+    const sourceProgramRow = page.getByRole("row").filter({
+      has: page.getByRole("button", { name: sourceProgram.name }),
+    });
     await expect(
       sourceProgramRow.getByRole("cell", { name: "0 conditions", exact: true }),
     ).toBeVisible();

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -267,8 +267,12 @@ test.describe("program management page", () => {
     // Assign both programs to program admin
     await page.goto("/ecr-viewer/admin/user");
     await page
-      .getByRole("button", { name: process.env.AUTH_PROGRAM_ADMIN_USER! })
-      .click();
+      .getByRole("combobox", { name: "Users per page" })
+      .selectOption("25");
+    const rowProgramAdmin = await page
+      .getByRole("button", { name: process.env.AUTH_PROGRAM_ADMIN_USER! });
+    await rowProgramAdmin.scrollIntoViewIfNeeded();
+    await rowProgramAdmin.dispatchEvent("click");
     await page.getByRole("dialog").getByText("Edit user").click();
     await page.waitForURL(/\/ecr-viewer\/admin\/user\/edit\?uuid=.*/);
     const checkboxTarget = await page

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -270,8 +270,9 @@ test.describe("program management page", () => {
     await page
       .getByRole("combobox", { name: "Users per page" })
       .selectOption("25");
-    const rowProgramAdmin = await page
-      .getByRole("button", { name: process.env.AUTH_PROGRAM_ADMIN_USER! });
+    const rowProgramAdmin = await page.getByRole("button", {
+      name: process.env.AUTH_PROGRAM_ADMIN_USER!,
+    });
     await rowProgramAdmin.scrollIntoViewIfNeeded();
     await rowProgramAdmin.dispatchEvent("click");
     await page.getByRole("dialog").getByText("Edit user").click();
@@ -358,8 +359,7 @@ const createRandomProgramArea = async (
       throw new Error("Could not find an unassigned condition");
     }
 
-    const checkbox =
-      checkboxes[Math.floor(Math.random() * checkboxes.length)];
+    const checkbox = checkboxes[Math.floor(Math.random() * checkboxes.length)];
     const selectedConditionName = await checkbox
       .locator("..")
       .locator("p")
@@ -369,13 +369,14 @@ const createRandomProgramArea = async (
 
     triedConditionNames.add(selectedConditionName);
     const conditionIsAssigned =
-      (await checkbox.locator("..").getByText(/Condition in /).count()) > 0;
+      (await checkbox
+        .locator("..")
+        .getByText(/Condition in /)
+        .count()) > 0;
     if (conditionIsAssigned) continue;
 
     await checkbox.scrollIntoViewIfNeeded();
-    await checkbox.evaluate((element) =>
-      (element as HTMLInputElement).click(),
-    );
+    await checkbox.evaluate((element) => (element as HTMLInputElement).click());
 
     const reassignmentModal = page
       .getByRole("dialog")

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -337,43 +337,50 @@ const createRandomProgramArea = async (
   conditionNamesToAvoid: string[] = [],
 ) => {
   const random = Math.floor(Math.random() * 10000);
-  const name = `Program ${browserName}-${random}`;
+  const name = `Prog admin-program-${browserName}-${random}`;
 
   await page.goto("/ecr-viewer/admin/program/create");
   await page.getByLabel("Program area name").fill(name);
 
-  const checkboxes = await page.getByRole("checkbox").all();
-  let condition: (typeof checkboxes)[number] | undefined;
-  for (const checkbox of checkboxes) {
-    const conditionIsAssigned =
-      (await checkbox.locator("..").getByText(/Condition in /).count()) > 0;
-    const conditionName = await checkbox
+  const triedConditionNames = new Set(conditionNamesToAvoid);
+  let conditionName: string | undefined;
+
+  while (!conditionName) {
+    const checkboxes = await page.getByRole("checkbox").all();
+    if (triedConditionNames.size >= checkboxes.length) {
+      throw new Error("Could not find an unassigned condition");
+    }
+
+    const checkbox =
+      checkboxes[Math.floor(Math.random() * checkboxes.length)];
+    const selectedConditionName = await checkbox
       .locator("..")
       .locator("p")
       .first()
       .innerText();
-    if (
-      !conditionIsAssigned &&
-      !conditionNamesToAvoid.includes(conditionName)
-    ) {
-      condition = checkbox;
-      break;
+    if (triedConditionNames.has(selectedConditionName)) continue;
+
+    triedConditionNames.add(selectedConditionName);
+    const conditionIsAssigned =
+      (await checkbox.locator("..").getByText(/Condition in /).count()) > 0;
+    if (conditionIsAssigned) continue;
+
+    await checkbox.scrollIntoViewIfNeeded();
+    await checkbox.evaluate((element) =>
+      (element as HTMLInputElement).click(),
+    );
+
+    const reassignmentModal = page
+      .getByRole("dialog")
+      .filter({ hasText: "Are you sure you want to add" });
+    if (await reassignmentModal.isVisible()) {
+      await reassignmentModal
+        .getByRole("button", { name: "Close this window" })
+        .click();
+    } else {
+      conditionName = selectedConditionName;
     }
   }
-
-  if (!condition) {
-    throw new Error("Could not find an unassigned condition");
-  }
-
-  const conditionName = await condition
-    .locator("..")
-    .locator("p")
-    .first()
-    .innerText();
-  await condition.scrollIntoViewIfNeeded();
-  await condition.evaluate((element) =>
-    (element as HTMLInputElement).click(),
-  );
 
   await page.getByRole("button", { name: "Save program area" }).first().click();
   await page.waitForURL("/ecr-viewer/admin/program");

--- a/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-program.spec.ts
@@ -1,5 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 
 import { logIn } from "../utils";
 
@@ -34,7 +34,6 @@ test.describe("program management page", () => {
       .getByRole("table")
       .getByRole("row")
       .filter({ has: page.getByRole("cell") });
-    await expect(programRows).toHaveCount(1);
     await expect(
       programRows.getByRole("cell", { name: "COVID", exact: true }),
     ).toBeVisible();
@@ -222,4 +221,162 @@ test.describe("program management page", () => {
       await expect(el).not.toBeVisible();
     }
   });
+
+  test("as a program admin, should not be able to create program area", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/program");
+
+    await expect(
+      page.getByRole("heading", { name: "Program management" }),
+    ).toBeVisible();
+    await expect(page.getByText("Create program area")).not.toBeVisible();
+
+    const response = await page.goto("/ecr-viewer/admin/program/create");
+    expect(response?.status()).toBe(404);
+  });
+
+  test("as a program admin, should not be able to delete a program area", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/program");
+
+    await page.getByRole("button", { name: "COVID" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Program area information")).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Remove program area" }),
+    ).not.toBeVisible();
+  });
+
+  test("as a program admin, should be able to switch conditions between accessible programs", async ({
+    page,
+    browserName,
+  }) => {
+    const targetProgram = await createRandomProgramArea(page, browserName, ["covid"]);
+    const sourceProgram = await createRandomProgramArea(
+      page,
+      browserName,
+      [targetProgram.conditionName, "covid"],
+    );
+
+    // Assign both programs to program admin
+    await page.goto("/ecr-viewer/admin/user");
+    await page
+      .getByRole("button", { name: process.env.AUTH_PROGRAM_ADMIN_USER! })
+      .click();
+    await page.getByRole("dialog").getByText("Edit user").click();
+    await page.waitForURL(/\/ecr-viewer\/admin\/user\/edit\?uuid=.*/);
+    const checkboxTarget = await page
+      .getByLabel(`Select ${targetProgram.name}`, { exact: true });
+    await checkboxTarget.scrollIntoViewIfNeeded();
+    await checkboxTarget.dispatchEvent("click");
+    const checkboxSource = await page
+      .getByLabel(`Select ${sourceProgram.name}`, { exact: true });
+    await checkboxSource.scrollIntoViewIfNeeded();
+    await checkboxSource.dispatchEvent("click");
+    await page.getByRole("button", { name: "Save user" }).first().click();
+    await page.waitForURL("/ecr-viewer/admin/user");
+
+    // As a program admin, editing program area
+    await page.context().clearCookies();
+    await logIn(page, { userType: "PROGRAM_ADMIN", useCookies: false });
+    await page.goto("/ecr-viewer/admin/program");
+    await page.getByRole("button", { name: targetProgram.name }).click();
+    await page.getByRole("dialog").getByText("Edit program area").click();
+    await page.waitForURL(/\/ecr-viewer\/admin\/program\/edit\?uuid=.*/);
+
+    await expect(page.getByLabel("Program area name")).toBeDisabled();
+
+    // Can move a condition from source to target program
+    await page
+      .getByPlaceholder("Search condition or category")
+      .fill(sourceProgram.conditionName);
+    const sourceConditionInSource = page
+      .getByText(`Condition in ${sourceProgram.name}`)
+      .first();
+    await expect(sourceConditionInSource).toBeVisible();
+    const sourceConditionCheckbox = await page.getByLabel(
+      sourceProgram.conditionName,
+      { exact: true }
+    );
+    await sourceConditionCheckbox.scrollIntoViewIfNeeded();
+    await sourceConditionCheckbox.dispatchEvent("click");
+
+    await expect(page.getByText(/Are you sure you want to add/)).toBeVisible();
+    await page.getByRole("button", { name: "Yes, add condition" }).click();
+    await page
+      .getByRole("button", { name: "Save program area" })
+      .first()
+      .click();
+    await page.waitForURL("/ecr-viewer/admin/program");
+
+    // The reassigned condition is in target
+    const sourceProgramRow = page
+      .getByRole("row")
+      .filter({
+        has: page.getByRole("button", { name: sourceProgram.name }),
+      });
+    await expect(
+      sourceProgramRow.getByRole("cell", { name: "0 conditions", exact: true }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: targetProgram.name }).click();
+    await expect(
+      page.getByText(sourceProgram.conditionName).first(),
+    ).toBeVisible();
+  });
 });
+
+const createRandomProgramArea = async (
+  page: Page,
+  browserName: string,
+  conditionNamesToAvoid: string[] = [],
+) => {
+  const random = Math.floor(Math.random() * 10000);
+  const name = `Program ${browserName}-${random}`;
+
+  await page.goto("/ecr-viewer/admin/program/create");
+  await page.getByLabel("Program area name").fill(name);
+
+  const checkboxes = await page.getByRole("checkbox").all();
+  let condition: (typeof checkboxes)[number] | undefined;
+  for (const checkbox of checkboxes) {
+    const conditionIsAssigned =
+      (await checkbox.locator("..").getByText(/Condition in /).count()) > 0;
+    const conditionName = await checkbox
+      .locator("..")
+      .locator("p")
+      .first()
+      .innerText();
+    if (
+      !conditionIsAssigned &&
+      !conditionNamesToAvoid.includes(conditionName)
+    ) {
+      condition = checkbox;
+      break;
+    }
+  }
+
+  if (!condition) {
+    throw new Error("Could not find an unassigned condition");
+  }
+
+  const conditionName = await condition
+    .locator("..")
+    .locator("p")
+    .first()
+    .innerText();
+  await condition.scrollIntoViewIfNeeded();
+  await condition.evaluate((element) =>
+    (element as HTMLInputElement).click(),
+  );
+
+  await page.getByRole("button", { name: "Save program area" }).first().click();
+  await page.waitForURL("/ecr-viewer/admin/program");
+
+  return { name, conditionName };
+};

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -480,20 +480,22 @@ test.describe("user management page", () => {
 
 const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
   await page.goto("/ecr-viewer/admin/program");
-  const adminProgramTestProgram = /^Prog admin-program-(?:chromium|firefox|webkit)-\d+$/;
+  const adminProgramTestProgram =
+    /^Prog admin-program-(?:chromium|firefox|webkit)-\d+$/;
 
-  const rows = await page.getByRole("row").all();
-  for (const row of rows) {
-    const cell = row.getByRole("cell").first();
-    const program = (await cell.allInnerTexts()).join(" ");
-    // avoid program reuse and don't touch the programs from the `admin-program` tests
-    // as those get deleted during testing (vs teardown)
-    if (
-      !!program &&
-      !notThese.includes(program) &&
-      !adminProgramTestProgram.test(program)
-    ) {
-      return program;
+  // A fresh program is required when excluding programs. Reusing an existing
+  // program can race with admin-program tests, which assign their fixtures to
+  // the shared program-admin user.
+  if (notThese.length === 0) {
+    const rows = await page.getByRole("row").all();
+    for (const row of rows) {
+      const cell = row.getByRole("cell").first();
+      const program = (await cell.allInnerTexts()).join(" ");
+      // avoid program reuse and don't touch the programs from the `admin-program` tests
+      // as those get deleted during testing (vs teardown)
+      if (!!program && !adminProgramTestProgram.test(program)) {
+        return program;
+      }
     }
   }
 
@@ -510,7 +512,7 @@ const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
 
   // Read the value BEFORE clicking it, avoiding any DOM-blocking modal issues
   const conditionName = await checkboxCond.inputValue();
-  const programName = `Test Program ${conditionName}`;
+  const programName = `Test Program ${conditionName}-${Math.floor(Math.random() * 10000)}`;
 
   await checkboxCond.dispatchEvent("click");
 

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -480,7 +480,7 @@ test.describe("user management page", () => {
 
 const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
   await page.goto("/ecr-viewer/admin/program");
-  const adminProgramTestProgram = /^Program (?:\d+|(?:chromium|firefox|webkit)\d+)/;
+  const adminProgramTestProgram = /^Prog admin-program-(?:chromium|firefox|webkit)-\d+$/;
 
   const rows = await page.getByRole("row").all();
   for (const row of rows) {

--- a/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
+++ b/containers/ecr-viewer/tests/e2e/dual/admin-user.spec.ts
@@ -480,6 +480,7 @@ test.describe("user management page", () => {
 
 const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
   await page.goto("/ecr-viewer/admin/program");
+  const adminProgramTestProgram = /^Program (?:\d+|(?:chromium|firefox|webkit)\d+)/;
 
   const rows = await page.getByRole("row").all();
   for (const row of rows) {
@@ -490,7 +491,7 @@ const getRandomProgramArea = async (page: Page, notThese: string[] = []) => {
     if (
       !!program &&
       !notThese.includes(program) &&
-      !program.match(/^Program \d+/)
+      !adminProgramTestProgram.test(program)
     ) {
       return program;
     }

--- a/containers/ecr-viewer/tests/integration/helpers/seed.ts
+++ b/containers/ecr-viewer/tests/integration/helpers/seed.ts
@@ -1,5 +1,5 @@
 import { getDb } from "@/app/data/metadataDb/database";
-import { Core } from "@/app/data/metadataDb/types/core";
+import { Core, User } from "@/app/data/metadataDb/types/core";
 import { createProgramArea } from "@/app/services/programAreaService";
 import { createInitialAdminUser, createUser } from "@/app/services/userService";
 
@@ -43,4 +43,22 @@ export const seedUserProgramData = async () => {
     userType: "prog_admin",
     programs: [progId],
   });
+};
+
+/**
+ * Retrieve a seeded user by email address.
+ *
+ * @param email - The email address of the seeded user.
+ * @returns The matching seeded user.
+ * @throws {Error} If no seeded user matches the email address.
+ */
+export const getSeededUser = async (email: string): Promise<User> => {
+  const user = await getDb<Core>()
+    .selectFrom("user")
+    .selectAll()
+    .where("email", "=", email)
+    .executeTakeFirst();
+
+  if (!user) throw new Error(`Could not find seeded user ${email}`);
+  return user;
 };

--- a/containers/ecr-viewer/tests/integration/listConditionsService.test.ts
+++ b/containers/ecr-viewer/tests/integration/listConditionsService.test.ts
@@ -3,12 +3,18 @@
  */
 
 import { NO_CONDITIONS_REPORTED_OPTION } from "@/app/constants";
-import { getAllConditions } from "@/app/services/listConditionsService";
+import { getDb } from "@/app/data/metadataDb/database";
+import { Core } from "@/app/data/metadataDb/types/core";
+import {
+  getAllConditions,
+  listAdminConditionReferences,
+  listAdminConditionReferencesQuery,
+} from "@/app/services/listConditionsService";
 import { getLoggedInUserSession } from "@/app/utils/auth-utils";
 
 import { createCoreEcr, createEcrCondition } from "./helpers/core";
 import { buildCore, dropExisting } from "./helpers/ddl";
-import { seedUserProgramData } from "./helpers/seed";
+import { getSeededUser, seedUserProgramData } from "./helpers/seed";
 
 jest.mock("@/app/utils/auth-utils");
 
@@ -139,3 +145,63 @@ describe.each([
     });
   },
 );
+
+describe("listAdminConditionReferences", () => {
+  it("returns all condition references for admins", async () => {
+    (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+      email: "admin@admin.com",
+    });
+
+    const conditions = await listAdminConditionReferences();
+
+    expect(conditions.map(({ code }) => code)).toStrictEqual(["123", "456"]);
+  });
+
+  it("returns only condition references in a program admin's program areas", async () => {
+    (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+      email: "programadmin@programadmin.com",
+    });
+
+    const conditions = await listAdminConditionReferences();
+
+    expect(conditions.map(({ code }) => code)).toStrictEqual(["123"]);
+  });
+
+  it("rejects standard users", async () => {
+    (getLoggedInUserSession as jest.Mock).mockResolvedValue({
+      email: "standard@standard.com",
+    });
+
+    await expect(listAdminConditionReferences()).rejects.toThrow(
+      "Standard user cannot list condition references",
+    );
+  });
+});
+
+describe("listAdminConditionReferencesQuery", () => {
+  it("returns all references for an admin and filters by requested codes", async () => {
+    const admin = await getSeededUser("admin@admin.com");
+    const db = getDb<Core>();
+
+    const allConditions = await listAdminConditionReferencesQuery(admin, db);
+    const filteredConditions = await listAdminConditionReferencesQuery(
+      admin,
+      db,
+      ["456"],
+    );
+
+    expect(allConditions.map(({ code }) => code)).toStrictEqual(["123", "456"]);
+    expect(filteredConditions.map(({ code }) => code)).toStrictEqual(["456"]);
+  });
+
+  it("returns only references accessible to a program admin", async () => {
+    const programAdmin = await getSeededUser("programadmin@programadmin.com");
+
+    const conditions = await listAdminConditionReferencesQuery(
+      programAdmin,
+      getDb<Core>(),
+    );
+
+    expect(conditions.map(({ code }) => code)).toStrictEqual(["123"]);
+  });
+});

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -42,6 +42,9 @@ const cond789 = {
 };
 
 let adminId;
+let programAdminId;
+const programAdminEmail = "programadmin@programadmin.com";
+
 beforeAll(async () => {
   await buildCore();
   adminId = await createInitialAdminUser({ email: "admin@admin.com" });
@@ -51,6 +54,16 @@ beforeAll(async () => {
       .values(cond)
       .execute();
   }
+  // Create program admin
+  mockedGetLoggedInUserSession.mockResolvedValue({
+    name: "Adam Admin",
+    email: "admin@admin.com",
+  });
+  programAdminId = await createUser({
+    email: programAdminEmail,
+    userType: "prog_admin",
+    programs: [],
+  });
 });
 
 afterAll(async () => {
@@ -73,259 +86,351 @@ const mockedGetLoggedInUserSession = getLoggedInUserSession as jest.Mock;
 describe("program area service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
 
-  let progId;
-
-  it("should create a program area", async () => {
     mockedGetLoggedInUserSession.mockResolvedValue({
       name: "Adam Admin",
       email: "admin@admin.com",
     });
-    const progName = "Fun Times";
-    const conditionCodes = ["123", "456"];
-    progId = await createProgramArea({
-      name: progName,
-      conditions: conditionCodes,
-    });
-    expect(progId).toMatch(UUID_REGEX);
+  });
 
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("program_area");
-    expect(log.action).toEqual("create");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      name: "Fun Times",
-      conditions: conditionCodes,
-      uuid: progId,
-    });
-
-    // see program area listed
-    const programAreas = await listProgramAreas();
-    expect(programAreas).toBeArrayOfSize(1);
-    expect(programAreas).toStrictEqual([
-      {
-        uuid: progId,
+  describe("as an admin", () => {
+    let progId;
+    
+    it("should create a program area", async () => {
+      const progName = "Fun Times";
+      const conditionCodes = ["123", "456"];
+      progId = await createProgramArea({
         name: progName,
-        author_uuid: expect.any(String),
-        date_created: expect.any(Date),
-        conditions: [
-          { ...cond123, program_area_uuid: progId, is_duplicate: false },
-          { ...cond456, program_area_uuid: progId, is_duplicate: false },
-        ],
-      },
-    ]);
-
-    const conditions = await listConditionReferences();
-    expect(conditions).toBeArrayOfSize(3);
-    for (const code of conditionCodes) {
-      expect(conditions.find((c) => c.code === code)).toHaveProperty(
-        "program_area_uuid",
-        progId,
-      );
-    }
-    expect(
-      conditions.filter((c) => c.program_area_uuid === null),
-    ).toBeArrayOfSize(1);
-
-    // program with name already exists
-    jest.spyOn(console, "error").mockImplementation();
-    await expect(
-      createProgramArea({
-        name: progName.toUpperCase(),
         conditions: conditionCodes,
-      }),
-    ).rejects.toThrow(
-      "Failed to create program area. This program area name already exists.",
-    );
+      });
+      expect(progId).toMatch(UUID_REGEX);
+  
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminId!);
+      expect(log.subject).toEqual("program_area");
+      expect(log.action).toEqual("create");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        name: "Fun Times",
+        conditions: conditionCodes,
+        uuid: progId,
+      });
+  
+      // see program area listed
+      const programAreas = await listProgramAreas();
+      expect(programAreas).toBeArrayOfSize(1);
+      expect(programAreas).toStrictEqual([
+        {
+          uuid: progId,
+          name: progName,
+          author_uuid: expect.any(String),
+          date_created: expect.any(Date),
+          conditions: [
+            { ...cond123, program_area_uuid: progId, is_duplicate: false },
+            { ...cond456, program_area_uuid: progId, is_duplicate: false },
+          ],
+        },
+      ]);
+  
+      const conditions = await listConditionReferences();
+      expect(conditions).toBeArrayOfSize(3);
+      for (const code of conditionCodes) {
+        expect(conditions.find((c) => c.code === code)).toHaveProperty(
+          "program_area_uuid",
+          progId,
+        );
+      }
+      expect(
+        conditions.filter((c) => c.program_area_uuid === null),
+      ).toBeArrayOfSize(1);
+  
+      // program with name already exists
+      jest.spyOn(console, "error").mockImplementation();
+      await expect(
+        createProgramArea({
+          name: progName.toUpperCase(),
+          conditions: conditionCodes,
+        }),
+      ).rejects.toThrow(
+        "Failed to create program area. This program area name already exists.",
+      );
+    });
+  
+    it("should update a program area name", async () => {
+      const progName = "Sad Times";
+      const id = await createProgramArea({ name: progName, conditions: ["123"] });
+  
+      const beforeNameConds = await listConditionReferences();
+      await updateProgramArea({ uuid: id, name: "Happy Days" });
+      const afterNameConds = await listConditionReferences();
+      const afterNameProgramAreas = await listProgramAreas();
+  
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminId!);
+      expect(log.subject).toEqual("program_area");
+      expect(log.action).toEqual("update");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        name: "Happy Days",
+        uuid: id,
+      });
+  
+      expect(
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        beforeNameConds.map(({ program_area_name, ...cond }) => cond),
+      ).toStrictEqual(
+        // eslint-disable-next-line unused-imports/no-unused-vars
+        afterNameConds.map(({ program_area_name, ...cond }) => cond),
+      );
+      const progArea = afterNameProgramAreas.find((p) => p.uuid === id);
+      expect(progArea).toHaveProperty("name", "Happy Days");
+  
+      // program with name already exists
+      jest.spyOn(console, "error").mockImplementation();
+      await expect(
+        updateProgramArea({ uuid: id, name: "Fun TIMES" }),
+      ).rejects.toThrow(
+        "Failed to update program area. This program area name already exists.",
+      );
+    });
+  
+    it("should update a program area conditions", async () => {
+      const progName = "Sad Times";
+      const id = await createProgramArea({ name: progName, conditions: ["123"] });
+  
+      const beforeConds = await listConditionReferences();
+      const beforeCond = beforeConds.filter((c) => c.program_area_uuid === id);
+      expect(beforeCond).toBeArrayOfSize(1);
+      expect(beforeCond[0]).toHaveProperty("code", "123");
+      await updateProgramArea({ uuid: id, conditions: ["789"] });
+  
+      const afterConds = await listConditionReferences();
+  
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminId!);
+      expect(log.subject).toEqual("program_area");
+      expect(log.action).toEqual("update");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        conditions: ["789"],
+        uuid: id,
+      });
+  
+      expect(beforeConds).not.toStrictEqual(afterConds);
+      const cond = afterConds.filter((c) => c.program_area_uuid === id);
+      expect(cond).toBeArrayOfSize(1);
+      expect(cond[0]).toHaveProperty("code", "789");
+    });
+  
+    it("should delete a program area", async () => {
+      const beforeCreate = await listProgramAreas();
+      const id = await createProgramArea({ name: "test", conditions: ["123"] });
+      const afterCreate = await listProgramAreas();
+  
+      await updateUser({ uuid: adminId!, updates: {}, programs: [id, progId!] });
+      const beforeUserProgramAreas = await listUserProgramAreas(adminId!);
+      expect(beforeUserProgramAreas).toBeArrayOfSize(2);
+  
+      await deleteProgramArea({ uuid: id });
+  
+      // check audit log
+      const log = await getLastAuditLog();
+      expect(log.actor).toEqual(adminId!);
+      expect(log.subject).toEqual("program_area");
+      expect(log.action).toEqual("delete");
+      expect(JSON.parse(log.parameter_json)).toStrictEqual({
+        uuid: id,
+      });
+  
+      const afterDelete = await listProgramAreas();
+  
+      expect(beforeCreate.map(({ uuid }) => uuid)).toStrictEqual(
+        afterDelete.map(({ uuid }) => uuid),
+      );
+      expect(afterDelete).toBeArrayOfSize(3);
+      expect(afterCreate).toBeArrayOfSize(4);
+  
+      const afterUserProgramAreas = await listUserProgramAreas(adminId!);
+      expect(afterUserProgramAreas).toBeArrayOfSize(1);
+      expect(
+        afterUserProgramAreas.filter((p) => p.uuid === progId!),
+      ).toBeArrayOfSize(1);
+    });
+  
+    it("should return program areas for only the requested users", async () => {
+      const firstId = await createProgramArea({
+        name: "Requested Program One",
+        conditions: ["123"],
+      });
+      const secondId = await createProgramArea({
+        name: "Requested Program Two",
+        conditions: ["456"],
+      });
+      await createProgramArea({
+        name: "Unrequested Program",
+        conditions: ["789"],
+      });
+  
+      const userId = await createUser({
+        email: "requested@standard.com",
+        userType: "standard",
+        programs: [secondId, firstId],
+      });
+  
+      const programAreas = await listProgramAreas({
+        userUuids: [userId],
+      });
+  
+      expect(programAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
+        [firstId, secondId].sort(),
+      );
+    });
   });
 
-  it("should update a program area name", async () => {
-    mockedGetLoggedInUserSession.mockResolvedValue({
-      name: "Adam Admin",
-      email: "admin@admin.com",
-    });
-    const progName = "Sad Times";
-    const id = await createProgramArea({ name: progName, conditions: ["123"] });
+  describe("as a program admin", () => {
+    const logInAsProgramAdmin = async (programs: string[]) => {
+      await updateUser({ uuid: programAdminId!, updates: {}, programs });
 
-    const beforeNameConds = await listConditionReferences();
-    await updateProgramArea({ uuid: id, name: "Happy Days" });
-    const afterNameConds = await listConditionReferences();
-    const afterNameProgramAreas = await listProgramAreas();
+      mockedGetLoggedInUserSession.mockResolvedValue({
+        name: "Program Admin",
+        email: programAdminEmail,
+      });
+    };
 
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("program_area");
-    expect(log.action).toEqual("update");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      name: "Happy Days",
-      uuid: id,
-    });
+    it("should only return program areas a program admin has access to", async () => {
+      const accessibleProgramId = await createProgramArea({
+        name: "Accessible Program",
+        conditions: ["123"],
+      });
+      const restrictedProgramId = await createProgramArea({
+        name: "Restricted Program",
+        conditions: ["456"],
+      });
 
-    expect(
-      // eslint-disable-next-line unused-imports/no-unused-vars
-      beforeNameConds.map(({ program_area_name, ...cond }) => cond),
-    ).toStrictEqual(
-      // eslint-disable-next-line unused-imports/no-unused-vars
-      afterNameConds.map(({ program_area_name, ...cond }) => cond),
-    );
-    const progArea = afterNameProgramAreas.find((p) => p.uuid === id);
-    expect(progArea).toHaveProperty("name", "Happy Days");
+      const visibleUserId = await createUser({
+        email: "visible@standard.com",
+        userType: "standard",
+        programs: [accessibleProgramId, restrictedProgramId],
+      });
 
-    // program with name already exists
-    jest.spyOn(console, "error").mockImplementation();
-    await expect(
-      updateProgramArea({ uuid: id, name: "Fun TIMES" }),
-    ).rejects.toThrow(
-      "Failed to update program area. This program area name already exists.",
-    );
-  });
+      await logInAsProgramAdmin([accessibleProgramId]);
 
-  it("should update a program area conditions", async () => {
-    mockedGetLoggedInUserSession.mockResolvedValue({
-      name: "Adam Admin",
-      email: "admin@admin.com",
-    });
-    const progName = "Sad Times";
-    const id = await createProgramArea({ name: progName, conditions: ["123"] });
+      const programAreas = await listProgramAreas();
+      const programAreaIds = programAreas.map(({ uuid }) => uuid);
 
-    const beforeConds = await listConditionReferences();
-    const beforeCond = beforeConds.filter((c) => c.program_area_uuid === id);
-    expect(beforeCond).toBeArrayOfSize(1);
-    expect(beforeCond[0]).toHaveProperty("code", "123");
-    await updateProgramArea({ uuid: id, conditions: ["789"] });
+      expect(programAreaIds).toStrictEqual([accessibleProgramId]);
+      expect(programAreaIds).not.toContain(restrictedProgramId);
 
-    const afterConds = await listConditionReferences();
-
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("program_area");
-    expect(log.action).toEqual("update");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      conditions: ["789"],
-      uuid: id,
+      // When viewing user details side panel, should see all their programs
+      const detailProgramAreas = await listProgramAreas({
+        userUuids: [visibleUserId],
+      });
+      expect(detailProgramAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
+        [accessibleProgramId, restrictedProgramId].sort()
+      );
     });
 
-    expect(beforeConds).not.toStrictEqual(afterConds);
-    const cond = afterConds.filter((c) => c.program_area_uuid === id);
-    expect(cond).toBeArrayOfSize(1);
-    expect(cond[0]).toHaveProperty("code", "789");
-  });
+    it("can not create or delete program areas", async () => {
+      const programAreaId = await createProgramArea({
+        name: "Program admin program area",
+        conditions: ["123"],
+      });
+      await logInAsProgramAdmin([programAreaId]);
 
-  it("should delete a program area", async () => {
-    mockedGetLoggedInUserSession.mockResolvedValue({
-      name: "Adam Admin",
-      email: "admin@admin.com",
-    });
-    const beforeCreate = await listProgramAreas();
-    const id = await createProgramArea({ name: "test", conditions: ["123"] });
-    const afterCreate = await listProgramAreas();
-
-    await updateUser({ uuid: adminId!, updates: {}, programs: [id, progId!] });
-    const beforeUserProgramAreas = await listUserProgramAreas(adminId!);
-    expect(beforeUserProgramAreas).toBeArrayOfSize(2);
-
-    await deleteProgramArea({ uuid: id });
-
-    // check audit log
-    const log = await getLastAuditLog();
-    expect(log.actor).toEqual(adminId!);
-    expect(log.subject).toEqual("program_area");
-    expect(log.action).toEqual("delete");
-    expect(JSON.parse(log.parameter_json)).toStrictEqual({
-      uuid: id,
+      await expect(
+        createProgramArea({
+          name: "Program Admin Created Area",
+          conditions: ["456"],
+        }),
+      ).rejects.toThrow(
+        "Standard user cannot & program admins cannot create program areas",
+      );
+      await expect(deleteProgramArea({ uuid: programAreaId })).rejects.toThrow(
+        "Standard user cannot & program admins cannot delete program areas"
+      );
     });
 
-    const afterDelete = await listProgramAreas();
+    it("can not update a program area name", async () => {
+      const programAreaId = await createProgramArea({
+        name: "program area name",
+        conditions: ["123"],
+      });
+      await logInAsProgramAdmin([programAreaId]);
 
-    expect(beforeCreate.map(({ uuid }) => uuid)).toStrictEqual(
-      afterDelete.map(({ uuid }) => uuid),
-    );
-    expect(afterDelete).toBeArrayOfSize(3);
-    expect(afterCreate).toBeArrayOfSize(4);
-
-    const afterUserProgramAreas = await listUserProgramAreas(adminId!);
-    expect(afterUserProgramAreas).toBeArrayOfSize(1);
-    expect(
-      afterUserProgramAreas.filter((p) => p.uuid === progId!),
-    ).toBeArrayOfSize(1);
-  });
-
-  it("should only return program areas a program admin has access to", async () => {
-    const accessibleProgramId = await createProgramArea({
-      name: "Accessible Program",
-      conditions: ["123"],
-    });
-    const restrictedProgramId = await createProgramArea({
-      name: "Restricted Program",
-      conditions: ["456"],
-    });
-
-    const programAdminEmail = "programadmin@programadmin.com";
-    await createUser({
-      email: programAdminEmail,
-      userType: "prog_admin",
-      programs: [accessibleProgramId],
-    });
-    const visibleUserId = await createUser({
-      email: "visible@standard.com",
-      userType: "standard",
-      programs: [accessibleProgramId, restrictedProgramId],
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation();
+      try {
+        await expect(
+          updateProgramArea({
+            uuid: programAreaId,
+            name: "program area renamed",
+          }),
+        ).rejects.toThrow(
+          "Failed to update program area. Program admins cannot update program area names.",
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
     });
 
-    mockedGetLoggedInUserSession.mockResolvedValue({
-      name: "Philip Program-Admin",
-      email: "programadmin@programadmin.com",
+    it("should update a program area with an accessible condition", async () => {
+      const accessibleProgramAreaId = await createProgramArea({
+        name: "Program Admin Accessible Conditions",
+        conditions: ["123"],
+      });
+      const targetProgramAreaId = await createProgramArea({
+        name: "Program Admin Condition Target",
+        conditions: ["789"],
+      });
+      await logInAsProgramAdmin([
+        accessibleProgramAreaId,
+        targetProgramAreaId,
+      ]);
+
+      await updateProgramArea({
+        uuid: targetProgramAreaId,
+        name: "Program Admin Condition Target",
+        conditions: ["123", "789"],
+      });
+
+      const programArea = (await listProgramAreas()).find(
+        ({ uuid }) => uuid === targetProgramAreaId,
+      );
+      expect(programArea?.conditions.map(({ code }) => code)).toStrictEqual([
+        "123", "789"
+      ]);
     });
 
-    const programAreas = await listProgramAreas();
-    const programAreaIds = programAreas.map(({ uuid }) => uuid);
+    it("should not update a program area with an inaccessible condition", async () => {
+      const accessibleProgramAreaId = await createProgramArea({
+        name: "Program Admin Allowed Conditions",
+        conditions: ["123"],
+      });
+      const targetProgramAreaId = await createProgramArea({
+        name: "Program Admin Restricted Condition Target",
+        conditions: ["789"],
+      });
+      await logInAsProgramAdmin([
+        accessibleProgramAreaId,
+        targetProgramAreaId,
+      ]);
 
-    expect(programAreaIds).toStrictEqual([accessibleProgramId]);
-    expect(programAreaIds).not.toContain(restrictedProgramId);
-
-    // When viewing user details side panel, should see all their programs
-    const detailProgramAreas = await listProgramAreas({
-      userUuids: [visibleUserId],
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation();
+      try {
+        await expect(
+          updateProgramArea({
+            uuid: targetProgramAreaId,
+            conditions: ["123", "456"],
+          }),
+        ).rejects.toThrow(
+          "Failed to update program area. Program admins cannot manage conditions outside of their program areas.",
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
     });
-    expect(detailProgramAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
-      [accessibleProgramId, restrictedProgramId].sort(),
-    );
-  });
-
-  it("should return program areas for only the requested users", async () => {
-    mockedGetLoggedInUserSession.mockResolvedValue({
-      name: "Adam Admin",
-      email: "admin@admin.com",
-    });
-    const firstId = await createProgramArea({
-      name: "Requested Program One",
-      conditions: ["123"],
-    });
-    const secondId = await createProgramArea({
-      name: "Requested Program Two",
-      conditions: ["456"],
-    });
-    await createProgramArea({
-      name: "Unrequested Program",
-      conditions: ["789"],
-    });
-
-    const userId = await createUser({
-      email: "requested@standard.com",
-      userType: "standard",
-      programs: [secondId, firstId],
-    });
-
-    const programAreas = await listProgramAreas({
-      userUuids: [userId],
-    });
-
-    expect(programAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
-      [firstId, secondId].sort(),
-    );
   });
 });

--- a/containers/ecr-viewer/tests/integration/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/integration/programAreaService.test.ts
@@ -95,7 +95,7 @@ describe("program area service", () => {
 
   describe("as an admin", () => {
     let progId;
-    
+
     it("should create a program area", async () => {
       const progName = "Fun Times";
       const conditionCodes = ["123", "456"];
@@ -104,7 +104,7 @@ describe("program area service", () => {
         conditions: conditionCodes,
       });
       expect(progId).toMatch(UUID_REGEX);
-  
+
       // check audit log
       const log = await getLastAuditLog();
       expect(log.actor).toEqual(adminId!);
@@ -115,7 +115,7 @@ describe("program area service", () => {
         conditions: conditionCodes,
         uuid: progId,
       });
-  
+
       // see program area listed
       const programAreas = await listProgramAreas();
       expect(programAreas).toBeArrayOfSize(1);
@@ -131,7 +131,7 @@ describe("program area service", () => {
           ],
         },
       ]);
-  
+
       const conditions = await listConditionReferences();
       expect(conditions).toBeArrayOfSize(3);
       for (const code of conditionCodes) {
@@ -143,7 +143,7 @@ describe("program area service", () => {
       expect(
         conditions.filter((c) => c.program_area_uuid === null),
       ).toBeArrayOfSize(1);
-  
+
       // program with name already exists
       jest.spyOn(console, "error").mockImplementation();
       await expect(
@@ -155,16 +155,19 @@ describe("program area service", () => {
         "Failed to create program area. This program area name already exists.",
       );
     });
-  
+
     it("should update a program area name", async () => {
       const progName = "Sad Times";
-      const id = await createProgramArea({ name: progName, conditions: ["123"] });
-  
+      const id = await createProgramArea({
+        name: progName,
+        conditions: ["123"],
+      });
+
       const beforeNameConds = await listConditionReferences();
       await updateProgramArea({ uuid: id, name: "Happy Days" });
       const afterNameConds = await listConditionReferences();
       const afterNameProgramAreas = await listProgramAreas();
-  
+
       // check audit log
       const log = await getLastAuditLog();
       expect(log.actor).toEqual(adminId!);
@@ -174,7 +177,7 @@ describe("program area service", () => {
         name: "Happy Days",
         uuid: id,
       });
-  
+
       expect(
         // eslint-disable-next-line unused-imports/no-unused-vars
         beforeNameConds.map(({ program_area_name, ...cond }) => cond),
@@ -184,7 +187,7 @@ describe("program area service", () => {
       );
       const progArea = afterNameProgramAreas.find((p) => p.uuid === id);
       expect(progArea).toHaveProperty("name", "Happy Days");
-  
+
       // program with name already exists
       jest.spyOn(console, "error").mockImplementation();
       await expect(
@@ -193,19 +196,22 @@ describe("program area service", () => {
         "Failed to update program area. This program area name already exists.",
       );
     });
-  
+
     it("should update a program area conditions", async () => {
       const progName = "Sad Times";
-      const id = await createProgramArea({ name: progName, conditions: ["123"] });
-  
+      const id = await createProgramArea({
+        name: progName,
+        conditions: ["123"],
+      });
+
       const beforeConds = await listConditionReferences();
       const beforeCond = beforeConds.filter((c) => c.program_area_uuid === id);
       expect(beforeCond).toBeArrayOfSize(1);
       expect(beforeCond[0]).toHaveProperty("code", "123");
       await updateProgramArea({ uuid: id, conditions: ["789"] });
-  
+
       const afterConds = await listConditionReferences();
-  
+
       // check audit log
       const log = await getLastAuditLog();
       expect(log.actor).toEqual(adminId!);
@@ -215,24 +221,28 @@ describe("program area service", () => {
         conditions: ["789"],
         uuid: id,
       });
-  
+
       expect(beforeConds).not.toStrictEqual(afterConds);
       const cond = afterConds.filter((c) => c.program_area_uuid === id);
       expect(cond).toBeArrayOfSize(1);
       expect(cond[0]).toHaveProperty("code", "789");
     });
-  
+
     it("should delete a program area", async () => {
       const beforeCreate = await listProgramAreas();
       const id = await createProgramArea({ name: "test", conditions: ["123"] });
       const afterCreate = await listProgramAreas();
-  
-      await updateUser({ uuid: adminId!, updates: {}, programs: [id, progId!] });
+
+      await updateUser({
+        uuid: adminId!,
+        updates: {},
+        programs: [id, progId!],
+      });
       const beforeUserProgramAreas = await listUserProgramAreas(adminId!);
       expect(beforeUserProgramAreas).toBeArrayOfSize(2);
-  
+
       await deleteProgramArea({ uuid: id });
-  
+
       // check audit log
       const log = await getLastAuditLog();
       expect(log.actor).toEqual(adminId!);
@@ -241,22 +251,22 @@ describe("program area service", () => {
       expect(JSON.parse(log.parameter_json)).toStrictEqual({
         uuid: id,
       });
-  
+
       const afterDelete = await listProgramAreas();
-  
+
       expect(beforeCreate.map(({ uuid }) => uuid)).toStrictEqual(
         afterDelete.map(({ uuid }) => uuid),
       );
       expect(afterDelete).toBeArrayOfSize(3);
       expect(afterCreate).toBeArrayOfSize(4);
-  
+
       const afterUserProgramAreas = await listUserProgramAreas(adminId!);
       expect(afterUserProgramAreas).toBeArrayOfSize(1);
       expect(
         afterUserProgramAreas.filter((p) => p.uuid === progId!),
       ).toBeArrayOfSize(1);
     });
-  
+
     it("should return program areas for only the requested users", async () => {
       const firstId = await createProgramArea({
         name: "Requested Program One",
@@ -270,17 +280,17 @@ describe("program area service", () => {
         name: "Unrequested Program",
         conditions: ["789"],
       });
-  
+
       const userId = await createUser({
         email: "requested@standard.com",
         userType: "standard",
         programs: [secondId, firstId],
       });
-  
+
       const programAreas = await listProgramAreas({
         userUuids: [userId],
       });
-  
+
       expect(programAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
         [firstId, secondId].sort(),
       );
@@ -326,7 +336,7 @@ describe("program area service", () => {
         userUuids: [visibleUserId],
       });
       expect(detailProgramAreas.map(({ uuid }) => uuid).sort()).toStrictEqual(
-        [accessibleProgramId, restrictedProgramId].sort()
+        [accessibleProgramId, restrictedProgramId].sort(),
       );
     });
 
@@ -346,7 +356,7 @@ describe("program area service", () => {
         "Standard user cannot & program admins cannot create program areas",
       );
       await expect(deleteProgramArea({ uuid: programAreaId })).rejects.toThrow(
-        "Standard user cannot & program admins cannot delete program areas"
+        "Standard user cannot & program admins cannot delete program areas",
       );
     });
 
@@ -357,9 +367,7 @@ describe("program area service", () => {
       });
       await logInAsProgramAdmin([programAreaId]);
 
-      const consoleError = jest
-        .spyOn(console, "error")
-        .mockImplementation();
+      const consoleError = jest.spyOn(console, "error").mockImplementation();
       try {
         await expect(
           updateProgramArea({
@@ -383,10 +391,7 @@ describe("program area service", () => {
         name: "Program Admin Condition Target",
         conditions: ["789"],
       });
-      await logInAsProgramAdmin([
-        accessibleProgramAreaId,
-        targetProgramAreaId,
-      ]);
+      await logInAsProgramAdmin([accessibleProgramAreaId, targetProgramAreaId]);
 
       await updateProgramArea({
         uuid: targetProgramAreaId,
@@ -398,7 +403,8 @@ describe("program area service", () => {
         ({ uuid }) => uuid === targetProgramAreaId,
       );
       expect(programArea?.conditions.map(({ code }) => code)).toStrictEqual([
-        "123", "789"
+        "123",
+        "789",
       ]);
     });
 
@@ -411,14 +417,9 @@ describe("program area service", () => {
         name: "Program Admin Restricted Condition Target",
         conditions: ["789"],
       });
-      await logInAsProgramAdmin([
-        accessibleProgramAreaId,
-        targetProgramAreaId,
-      ]);
+      await logInAsProgramAdmin([accessibleProgramAreaId, targetProgramAreaId]);
 
-      const consoleError = jest
-        .spyOn(console, "error")
-        .mockImplementation();
+      const consoleError = jest.spyOn(console, "error").mockImplementation();
       try {
         await expect(
           updateProgramArea({

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/ProgramAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/ProgramAdminPage.test.tsx.snap
@@ -70,7 +70,9 @@ exports[`Program Admin Page Creating programs should render a create program pag
           class="dibbs-fieldset"
         >
           <legend>
-            Name program area
+            <span>
+              Name program area
+            </span>
           </legend>
           <span>
             Required fields are marked with an asterisk (

--- a/containers/ecr-viewer/tests/unit/app/admin/components/ProgramForm.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/components/ProgramForm.test.tsx
@@ -48,6 +48,7 @@ describe("ProgramForm", () => {
           ],
         }}
         submitAction={async () => ({})}
+        isLoggedInUserAdmin={true}
       />,
     );
 
@@ -194,6 +195,7 @@ describe("ProgramForm", () => {
           ],
         }}
         submitAction={async () => ({})}
+        isLoggedInUserAdmin={true}
       />,
     );
 
@@ -260,5 +262,33 @@ describe("ProgramForm", () => {
     expect(checkboxes[1]).toBeChecked();
     expect(checkboxes[2]).not.toBeChecked();
     expect(checkboxes[3]).not.toBeChecked();
+  });
+
+  it("should disable name editing when isLoggedInUserAdmin is false", () => {
+    render(
+      <ProgramForm
+        action="Edit"
+        initValues={{
+          name: "I have a name",
+          conditions: [
+            {
+              code: "456",
+              concept_name: null,
+              condition_name: "condition 1",
+              condition_category: "first category",
+              program_area_uuid: "789",
+              program_area_name: "I have a name",
+              checked: true,
+            },
+          ],
+        }}
+        submitAction={async () => ({})}
+        isLoggedInUserAdmin={false}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText("Program area name");
+    expect(nameInput).toHaveValue("I have a name");
+    expect(nameInput).toBeDisabled();
   });
 });

--- a/containers/ecr-viewer/tests/unit/app/services/programAreaService.test.ts
+++ b/containers/ecr-viewer/tests/unit/app/services/programAreaService.test.ts
@@ -1,0 +1,73 @@
+import { User } from "@/app/data/metadataDb/types/core";
+import { listAdminConditionReferencesQuery } from "@/app/services/listConditionsService";
+import { validateAdminConditionAccess } from "@/app/services/programAreaService";
+import { isAdmin } from "@/app/services/userService";
+
+jest.mock("@/app/services/listConditionsService", () => ({
+  listAdminConditionReferencesQuery: jest.fn(),
+}));
+
+jest.mock("@/app/services/auditLogService", () => ({
+  audit: jest.fn((_subject, _action, fn) => fn),
+}));
+
+jest.mock("@/app/services/userService", () => ({
+  isAdmin: jest.fn(),
+}));
+
+const programAdmin: User = {
+  uuid: "program-admin-uuid",
+  email: "programadmin@example.com",
+  name: "Program Admin",
+  date_of_last_login: null,
+  user_type: "prog_admin",
+  status: "active",
+  date_created: new Date(),
+  author_uuid: "admin-uuid",
+};
+
+const transaction = {} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (isAdmin as unknown as jest.Mock).mockReturnValue(false);
+  (listAdminConditionReferencesQuery as jest.Mock).mockResolvedValue([
+    { code: "accessible" },
+  ]);
+});
+
+describe("validateAdminConditionAccess", () => {
+  it.each([
+    { scenario: "an empty condition list", conditions: [] },
+    {
+      scenario: "a condition the program admin can access",
+      conditions: ["accessible"],
+    },
+  ])("allows $scenario", async ({ conditions }) => {
+    await expect(
+      validateAdminConditionAccess(programAdmin, conditions, transaction),
+    ).resolves.toBeUndefined();
+  });
+
+  it("for admins, can manage any conditions", async () => {
+    (isAdmin as unknown as jest.Mock).mockReturnValue(true);
+
+    await expect(
+      validateAdminConditionAccess(programAdmin, ["inaccessible"], transaction),
+    ).resolves.toBeUndefined();
+
+    expect(listAdminConditionReferencesQuery).not.toHaveBeenCalled();
+  });
+
+  it("for a program admin, rejects when a condition is inaccessible from their program areas", async () => {
+    await expect(
+      validateAdminConditionAccess(
+        programAdmin,
+        ["accessible", "inaccessible"],
+        transaction,
+      ),
+    ).rejects.toThrow(
+      "Program admins cannot manage conditions outside of their program areas.",
+    );
+  });
+});


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Program admins cannot create or delete program areas
- When editing program areas, program admins 1) can not rename program areas (text is disabled), and 2) can only remove or swap conditions between their authorized program areas
- Add unit tests, add/update integration tests, add e2e tests

## Screenshot
Program admin does not see `Create program area` button
<img width="1876" height="941" alt="Screenshot 2026-08-18 at 14 50 35" src="https://github.com/user-attachments/assets/fb35d6c2-5327-45c7-8b19-7767aab7131a" />

Program admin does not see `Delete program area` button
<img width="1503" height="886" alt="Screenshot 2026-08-18 at 14 50 50" src="https://github.com/user-attachments/assets/4c79601f-8ff3-41c5-924a-164e0220caf1" />

Program admin (COVID and Zika) can swap or remove conditions between their authorized program areas
<img width="1095" height="941" alt="Screenshot 2026-08-18 at 14 50 13" src="https://github.com/user-attachments/assets/255dbd2f-0fb8-440c-8831-e717d882fb5b" />

## Related Issue

Fixes #1643 

## Acceptance Criteria
- [ ] Program admins cannot add or delete ANY program area(s).
- [ ] Program admins can remove or swap conditions that are in their program area(s).
- [ ] Program admins cannot rename program areas OR add conditions they don't already have program area access to.
- [ ] Ensure that functionality for (super) admins and standard users remains the same.
- [ ] Add/update any tests, esp. e2e tests

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
