### PR TITLE
fix: Added ability to display multiple ethnicities

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/services/demographicsService.tsx
+++ b/containers/ecr-viewer/src/app/view-data/services/demographicsService.tsx
@@ -1,11 +1,12 @@
 import "server-only"; // FHIR evaluation should be done server side
 
-import { Bundle, Encounter, Patient, RelatedPerson } from "fhir/r4";
+import { Bundle, Coding, Encounter, Patient, RelatedPerson } from "fhir/r4";
 import { DateTime } from "luxon";
 
 import { formatDate, formatDateTime } from "@/app/services/formatDateService";
 import {
   formatAddressList,
+  formatCoding,
   formatContactPoint,
   formatName,
   formatNameList,
@@ -256,19 +257,22 @@ export const evaluatePatientRace = (patient: Patient | undefined) => {
 /**
  * Evaluates the patients ethnicity from the FHIR bundle and formats for display.
  * @param fhirBundle - The FHIR bundle containing patient contact info.
- * @returns - The patient's ethnicity information, including additional ethnicity extension (if available).
+ * @returns - The patient's ethnicity information, including all ombCategory and detailed extensions (if available).
  */
 export const evaluatePatientEthnicity = (patient: Patient | undefined) => {
-  const ethnicity: string = evaluateValue(
+  const ethnicities = evaluateAll(
     patient,
     fhirPathMappings.patientEthnicity,
-  );
-  const ethnicityDetailed = evaluateValue(
+  ) as Coding[];
+  const ethnicitiesDetailed = evaluateAll(
     patient,
     fhirPathMappings.patientEthnicityDetailed,
-  );
+  ) as Coding[];
 
-  return [ethnicity, ethnicityDetailed].filter(Boolean).join("\n");
+  return [...ethnicities, ...ethnicitiesDetailed]
+    .map(formatCoding)
+    .filter(Boolean)
+    .join("\n");
 };
 
 /**

--- a/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/view-data/services/demographicsService.test.tsx
@@ -428,6 +428,13 @@ describe("Evaluate Patient Info: Demographics", () => {
     expect(actual).toEqual("Hispanic or Latino\nWhite");
   });
 
+  it("should return all ethnicity categories and extensions when multiple are available", () => {
+    const actual = evaluatePatientEthnicity(patientMultiple);
+    expect(actual).toEqual(
+      "Hispanic or Latino\nNot Hispanic or Latino\nWhite\nOther Pacific Islander",
+    );
+  });
+
   it("should return Tribal Affiliation if available", () => {
     const actual = evaluateDemographicsData(
       BundleWithPatient,

--- a/test-data/fhir/BundlePatientMultiple.json
+++ b/test-data/fhir/BundlePatientMultiple.json
@@ -68,10 +68,24 @@
                 }
               },
               {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
+                }
+              },
+              {
                 "url": "detailed",
                 "valueCoding": {
                   "code": "2106-3",
                   "display": "White"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "code": "2131-1",
+                  "display": "Other Pacific Islander"
                 }
               },
               {


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

* Added ability to display multiple ethnicities

## Related Issue

Fixes #1706 

## Acceptance Criteria

* If multiple ethnicities are listed, all are displayed in the Viewer

## Additional Information
### Before
<img width="599" height="458" alt="image" src="https://github.com/user-attachments/assets/75598860-9719-48fe-804c-7427045ed64a" />


### After
<img width="594" height="528" alt="image" src="https://github.com/user-attachments/assets/ead1a342-bef1-4428-9fae-be3aa55fe81e" />


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
