### PR TITLE
CI: add CI flag to ecr viewer workflow

### DIFF
--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -178,6 +178,7 @@ jobs:
           # -e CI=true                     : Propagates CI status so playwright.config.ts uses workers:1 and retries:1
           # -v ...:/work & -w /work        : Mounts our code into the container and sets the working directory
           CMD="docker run --rm --network host --ipc=host --security-opt seccomp=unconfined -e HOME=/tmp -e CI=true --user 1001:1001 -v ${{ github.workspace }}/containers/${{ env.CONTAINER }}:/work -w /work mcr.microsoft.com/playwright:v1.58.2-jammy"
+          echo "PLAYWRIGHT_DOCKER=$CMD" >> $GITHUB_ENV
 
       - name: Run Playwright tests - Migrations
         working-directory: ./containers/${{env.CONTAINER}}

--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -175,9 +175,9 @@ jobs:
           # --network host                 : Allows the container to hit our local docker compose (localhost:3000)
           # --ipc=host & --security-opt    : Prevents Firefox/Chromium from crashing due to sandbox restrictions
           # -e HOME=/tmp & --user 1001     : Runs as the GitHub runner user to prevent root file permission errors
+          # -e CI=true                     : Propagates CI status so playwright.config.ts uses workers:1 and retries:1
           # -v ...:/work & -w /work        : Mounts our code into the container and sets the working directory
-          CMD="docker run --rm --network host --ipc=host --security-opt seccomp=unconfined -e HOME=/tmp --user 1001:1001 -v ${{ github.workspace }}/containers/${{ env.CONTAINER }}:/work -w /work mcr.microsoft.com/playwright:v1.58.2-jammy"
-          echo "PLAYWRIGHT_DOCKER=$CMD" >> $GITHUB_ENV
+          CMD="docker run --rm --network host --ipc=host --security-opt seccomp=unconfined -e HOME=/tmp -e CI=true --user 1001:1001 -v ${{ github.workspace }}/containers/${{ env.CONTAINER }}:/work -w /work mcr.microsoft.com/playwright:v1.58.2-jammy"
 
       - name: Run Playwright tests - Migrations
         working-directory: ./containers/${{env.CONTAINER}}


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Adds flag to command to run playwright docker container in hopes that end to end tests will be more reliable in CI.

## Related Issue

Fixes #NA

## Acceptance Criteria

- [ ] End to end tests pass

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
