### PR TITLE
fix: Updated min width for user management table

### DIFF
--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -118,6 +118,7 @@ export const UserTable = ({
     {
       id: "email",
       value: "Email",
+      className: "minw-23",
       dataSortable: true,
       sortDirection: "",
       formatter: (v: string, user: ListedUser) => (
@@ -134,6 +135,7 @@ export const UserTable = ({
     {
       id: "user_type",
       value: "User type",
+      className: "minw-20",
       dataSortable: true,
       sortDirection: "",
       formatter: (userType: string) => USER_TYPE_DISPLAY[userType],
@@ -141,6 +143,7 @@ export const UserTable = ({
     {
       id: "program_areas",
       value: "Program areas",
+      className: "minw-28",
       dataSortable: false,
       sortDirection: "",
       formatter: (pas: NamedUserProgramArea[], user) =>
@@ -154,6 +157,7 @@ export const UserTable = ({
     {
       id: "date_of_last_login",
       value: "Last logged in",
+      className: "minw-23",
       dataSortable: true,
       sortDirection: "",
       formatter: (d: Date | null) => (

--- a/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
+++ b/containers/ecr-viewer/tests/unit/app/admin/__snapshots__/UserAdminPage.test.tsx.snap
@@ -1207,6 +1207,7 @@ exports[`User Admin Page for an admin, should list all users and program areas 1
             <thead>
               <tr>
                 <th
+                  class="minw-23"
                   data-sortable="true"
                   id="email-header"
                   role="columnheader"
@@ -1242,6 +1243,7 @@ exports[`User Admin Page for an admin, should list all users and program areas 1
                   </button>
                 </th>
                 <th
+                  class="minw-20"
                   data-sortable="true"
                   id="user_type-header"
                   role="columnheader"
@@ -1277,6 +1279,7 @@ exports[`User Admin Page for an admin, should list all users and program areas 1
                   </button>
                 </th>
                 <th
+                  class="minw-28"
                   data-sortable="false"
                   id="program_areas-header"
                   role="columnheader"
@@ -1290,6 +1293,7 @@ exports[`User Admin Page for an admin, should list all users and program areas 1
                   </div>
                 </th>
                 <th
+                  class="minw-23"
                   data-sortable="true"
                   id="date_of_last_login-header"
                   role="columnheader"


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

* added `min-width` classes to the User management table

## Related Issue

Fixes #1733 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

**Before**
<img width="1401" height="659" alt="image" src="https://github.com/user-attachments/assets/11e7ac87-5651-4c3d-bc97-cd9271985101" />

**After**
<img width="1352" height="605" alt="image" src="https://github.com/user-attachments/assets/fac5836e-821f-4020-80b8-bf2db9423742" />


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
