### PR TITLE
chore: Upgrade zod to 4.5

### DIFF
--- a/containers/ecr-viewer/package-lock.json
+++ b/containers/ecr-viewer/package-lock.json
@@ -42,7 +42,7 @@
         "tarn": "^3.0.2",
         "tedious": "^20.0.0",
         "undici": "^8.10.0",
-        "zod": "^3.24.1"
+        "zod": "4.5.4"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.1",
@@ -12348,6 +12348,16 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -24886,9 +24896,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/containers/ecr-viewer/package.json
+++ b/containers/ecr-viewer/package.json
@@ -73,7 +73,7 @@
     "tarn": "^3.0.2",
     "tedious": "^20.0.0",
     "undici": "^8.10.0",
-    "zod": "^3.24.1"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",

--- a/containers/ecr-viewer/src/app/api/migrate-db/route.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/route.ts
@@ -9,10 +9,8 @@ import { updateConditions } from "./updateConditions";
 
 const schema = z.object({
   migration_secret: z.string({
-    errorMap: () => ({
-      message:
-        "migration secret is required. Check the server logs for the value",
-    }),
+    error:
+      "migration secret is required. Check the server logs for the value",
   }),
   direction: z.string().default("up"),
   skip_condition_update: z
@@ -107,7 +105,7 @@ export async function POST(
       return NextResponse.json(
         {
           message: "Validation error",
-          errors: error.errors,
+          errors: error.issues,
         },
         { status: 400 },
       );

--- a/containers/ecr-viewer/src/app/api/migrate-db/route.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/route.ts
@@ -19,7 +19,7 @@ const schema = z.compile(
       .optional()
       .transform((v) => v?.toLowerCase()),
     init_admin_email: z.string().optional(),
-  })
+  }),
 );
 
 interface MigrationResponse {

--- a/containers/ecr-viewer/src/app/api/migrate-db/route.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/route.ts
@@ -7,18 +7,20 @@ import { createInitialAdminUser } from "@/app/services/userService";
 import { migrateDown, migrateUp } from "./migrate";
 import { updateConditions } from "./updateConditions";
 
-const schema = z.object({
-  migration_secret: z.string({
-    error:
-      "migration secret is required. Check the server logs for the value",
-  }),
-  direction: z.string().default("up"),
-  skip_condition_update: z
-    .string()
-    .optional()
-    .transform((v) => v?.toLowerCase()),
-  init_admin_email: z.string().optional(),
-});
+const schema = z.compile(
+  z.object({
+    migration_secret: z.string({
+      error:
+        "migration secret is required. Check the server logs for the value",
+    }),
+    direction: z.string().default("up"),
+    skip_condition_update: z
+      .string()
+      .optional()
+      .transform((v) => v?.toLowerCase()),
+    init_admin_email: z.string().optional(),
+  })
+);
 
 interface MigrationResponse {
   message: string;

--- a/containers/ecr-viewer/src/app/api/migrate-db/route.ts
+++ b/containers/ecr-viewer/src/app/api/migrate-db/route.ts
@@ -9,8 +9,7 @@ import { updateConditions } from "./updateConditions";
 
 const schema = z.object({
   migration_secret: z.string({
-    error:
-      "migration secret is required. Check the server logs for the value",
+    error: "migration secret is required. Check the server logs for the value",
   }),
   direction: z.string().default("up"),
   skip_condition_update: z

--- a/containers/ecr-viewer/src/app/api/process-ecr/route.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/route.ts
@@ -23,11 +23,12 @@ const schema = z.compile(
     ecr: z.union([z.string(), z.instanceof(File)]),
     rr: z.union([z.string(), z.instanceof(File)]).optional(),
     ...returnBundle,
-  })
+  }),
 );
 
 const processZipSchema = z.compile(
-  z.object({
+  z
+    .object({
       upload_file: z
         .instanceof(File)
         .refine(
@@ -43,7 +44,7 @@ const processZipSchema = z.compile(
     .transform((input) => ({
       ...input,
       ecr: input.upload_file,
-    }))
+    })),
 );
 
 /**

--- a/containers/ecr-viewer/src/app/api/process-ecr/route.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/route.ts
@@ -18,30 +18,33 @@ const returnBundle = {
     .transform((v) => v?.toLowerCase()),
 };
 
-const schema = z.object({
-  ecr: z.union([z.string(), z.instanceof(File)]),
-  rr: z.union([z.string(), z.instanceof(File)]).optional(),
-  ...returnBundle,
-});
-
-const processZipSchema = z
-  .object({
-    upload_file: z
-      .instanceof(File)
-      .refine(
-        (file) =>
-          file.type === "application/zip" ||
-          file.type === "application/octet-stream",
-        {
-          message: "File must be a zip",
-        },
-      ),
+const schema = z.compile(
+  z.object({
+    ecr: z.union([z.string(), z.instanceof(File)]),
+    rr: z.union([z.string(), z.instanceof(File)]).optional(),
     ...returnBundle,
   })
-  .transform((input) => ({
-    ...input,
-    ecr: input.upload_file,
-  }));
+);
+
+const processZipSchema = z.compile(
+  z.object({
+      upload_file: z
+        .instanceof(File)
+        .refine(
+          (file) =>
+            file.type === "application/zip" ||
+            file.type === "application/octet-stream",
+          {
+            message: "File must be a zip",
+          },
+        ),
+      ...returnBundle,
+    })
+    .transform((input) => ({
+      ...input,
+      ecr: input.upload_file,
+    }))
+);
 
 /**
  * Handles POST requests and saves the FHIR Bundle to the database.

--- a/containers/ecr-viewer/src/app/api/process-ecr/route.ts
+++ b/containers/ecr-viewer/src/app/api/process-ecr/route.ts
@@ -87,7 +87,7 @@ export const POST = async (
       return NextResponse.json(
         {
           message: "Validation error",
-          errors: error.errors,
+          errors: error.issues,
         },
         { status: 400 },
       );


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

* Bumps zod from 3.24 to 4.5.4. Only two files actually use it directly (the process-ecr and migrate-db API routes), so this ended up being a pretty small change. 

  - `errorMap` is gone in v4, replaced with a single `error` param. Updated the migration_secret schema in migrate-db/route.ts.                                                                                           
  - `ZodError.errors` was renamed to `.issues`. Fixed both places we read it off a caught ZodError (process-ecr and migrate-db routes).

## Related Issue

Fixes #

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
