### PR TITLE
patch: Add entry references to FHIR resources

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.8.2 --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch resolve-entry-references --depth 1 /App
 
 WORKDIR /App
 
@@ -13,8 +13,6 @@ RUN dotnet publish \
   -r linux-x64 \
   --self-contained true \
   -o output
-
-RUN apt-get update && apt-get install -y curl
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /App

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Download FHIR-Converter
 
-RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch resolve-entry-references --depth 1 /App
+RUN git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch 8.8.3 --depth 1 /App
 
 WORKDIR /App
 


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

FHIR resources representing CDA elements that contain entry references (2.16.840.1.113883.10.20.22.4.122) now contain entry reference extension with reference to the relevant FHIR resource.

## Related Issue

Fixes #602 

## Acceptance Criteria

N/A

## Additional Information

Deleted line in Dockerfile that was left over from RxNorm removal.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
