### PR TITLE
feat: Updated program area filter design

### DIFF
--- a/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
+++ b/containers/ecr-viewer/src/app/admin/user/UserTable.tsx
@@ -307,6 +307,20 @@ const FilterByProgramArea = ({
     });
   };
 
+  const isSpecialOption = (name: string) =>
+    name === ALL_PROGRAM_AREAS_OPTION || name === NO_PROGRAM_AREA_OPTION;
+
+  const specialProgramAreas = Object.fromEntries(
+    Object.entries(filterProgramAreas).filter(([name]) =>
+      isSpecialOption(name),
+    ),
+  );
+  const regularProgramAreas = Object.fromEntries(
+    Object.entries(filterProgramAreas).filter(
+      ([name]) => !isSpecialOption(name),
+    ),
+  );
+
   return (
     <Filter
       isActive={!isAllSelected}
@@ -316,22 +330,46 @@ const FilterByProgramArea = ({
       icon={Folder}
       tag={`${numSelected}`}
     >
-      <div className="display-flex flex-column">
-        {/* Select All button */}
-        <SelectDeselectAllButton
-          groupName="program area"
-          onToggle={handleSelectDeselectAll}
-          numSelected={numSelected}
-          numOptions={numProgramAreas}
-        />
-        <div className="border-top-1px border-base-lighter margin-bottom-1"></div>
+      <div className="display-flex flex-column height-full">
+        <div className="flex-0">
+          {/* Select All button */}
+          <SelectDeselectAllButton
+            groupName="program area"
+            onToggle={handleSelectDeselectAll}
+            numSelected={numSelected}
+            numOptions={numProgramAreas}
+          />
+          <div className="border-top-1px border-base-lighter margin-bottom-1"></div>
+        </div>
 
-        {/* Filter by Program Area checkboxes */}
-        <CheckboxOptions
-          groupName="program area"
-          filterItems={filterProgramAreas}
-          onChange={handleCheckboxChange}
-        />
+        <div className="flex-1 overflow-y-auto">
+          {/* All/No program areas (Admin/Standard) checkboxes */}
+          {Object.keys(specialProgramAreas).length > 0 && (
+            <CheckboxOptions
+              groupName="program area"
+              filterItems={specialProgramAreas}
+              onChange={handleCheckboxChange}
+            />
+          )}
+
+          {/* border line between if both present */}
+          {Object.keys(specialProgramAreas).length > 0 &&
+            Object.keys(regularProgramAreas).length > 0 && (
+              <div
+                className="border-top-1px border-base-lighter margin-x-105 margin-y-1"
+                data-testid="program-area-divider"
+              ></div>
+            )}
+
+          {/* Filter by Program Area checkboxes */}
+          {Object.keys(regularProgramAreas).length > 0 && (
+            <CheckboxOptions
+              groupName="program area"
+              filterItems={regularProgramAreas}
+              onChange={handleCheckboxChange}
+            />
+          )}
+        </div>
       </div>
     </Filter>
   );

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -102,7 +102,9 @@
 }
 
 .maxh-6205 {
-  max-height: 31.25rem;
+  // Capped at 31.25rem normally, but shrinks on short viewports so
+  // they don't run off to the bottom of the screen past the footer.
+  max-height: min(31.25rem, 55vh);
 }
 
 .maxw7 {

--- a/containers/ecr-viewer/tests/unit/app/admin/components/UserTable.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/admin/components/UserTable.test.tsx
@@ -99,7 +99,12 @@ const standardUserUnassigned = makeUser(
   [],
 );
 
-const renderTable = (isLoggedInUserAdmin: boolean) =>
+const renderTable = (
+  isLoggedInUserAdmin: boolean,
+  programAreas: ListedProgramArea[] = isLoggedInUserAdmin
+    ? [programA, programB]
+    : [programA],
+) =>
   render(
     <UserTable
       users={[
@@ -109,7 +114,7 @@ const renderTable = (isLoggedInUserAdmin: boolean) =>
         standardUserRestricted,
         standardUserUnassigned,
       ]}
-      programAreas={isLoggedInUserAdmin ? [programA, programB] : [programA]}
+      programAreas={programAreas}
       detailProgramAreas={[programA, programB]}
       isLoggedInUserAdmin={isLoggedInUserAdmin}
       deleteAction={jest.fn().mockResolvedValue({})}
@@ -134,6 +139,30 @@ describe("UserTable", () => {
           name: "No program areas (Standard)",
         }),
       ).toBeInTheDocument();
+    });
+
+    it("shows a divider between the All/No program area checkboxes and the program areas when program areas exist", async () => {
+      const user = userEvent.setup();
+      renderTable(true, [programA, programB]);
+
+      await user.click(screen.getByLabelText(/Filter by program area/));
+      expect(screen.getByTestId("program-area-divider")).toBeInTheDocument();
+      expect(
+        screen.getByRole("checkbox", { name: "Program A" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show a divider when no program areas exist to filter on", async () => {
+      const user = userEvent.setup();
+      renderTable(true, []);
+
+      await user.click(screen.getByLabelText(/Filter by program area/));
+      expect(
+        screen.getByRole("checkbox", { name: "All program areas (Admin)" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("program-area-divider"),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Updates the "Filter by program area" dropdown on the User management page to match the eCR Library's condition filter design:                                                                                  
  - Adds a divider between the `All program areas (Admin)`/`No program areas (Standard)` checkboxes and the actual program area checkboxes, but only when there are program areas to separate them from.     

## Related Issue

Fixes #954 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

**Before**
<img width="1059" height="273" alt="image" src="https://github.com/user-attachments/assets/078c882a-c37b-4c34-b5c5-dda73806683b" />


**After**
<img width="1057" height="316" alt="image" src="https://github.com/user-attachments/assets/73e148b1-a320-448d-b2bf-f84a50862776" />


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
