### PR TITLE
fix: prevent focus ring clipping on Back to eCR Library button

### DIFF
--- a/containers/ecr-viewer/src/styles/ecr-viewer.scss
+++ b/containers/ecr-viewer/src/styles/ecr-viewer.scss
@@ -378,6 +378,7 @@ main {
 .nav-wrapper {
   padding-top: 2rem;
   padding-bottom: 2rem;
+  padding-left: 0.25rem;
   width: $nav-wrapper-width;
   min-width: $nav-wrapper-width;
   position: sticky;

--- a/containers/ecr-viewer/tests/unit/app/components/BackButton.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/BackButton.test.tsx
@@ -53,4 +53,11 @@ describe("Back button", () => {
       "some-icon-class",
     );
   });
+    it("should have display-inline-block class to prevent focus ring clipping", () => {
+    (useIsLoggedInUser as jest.Mock).mockReturnValue(true);
+    render(<BackButton />);
+
+    const link = screen.getByRole("link");
+    expect(link.className).toContain("display-inline-block");
+  });
 });

--- a/containers/ecr-viewer/tests/unit/app/components/BackButton.test.tsx
+++ b/containers/ecr-viewer/tests/unit/app/components/BackButton.test.tsx
@@ -53,7 +53,7 @@ describe("Back button", () => {
       "some-icon-class",
     );
   });
-    it("should have display-inline-block class to prevent focus ring clipping", () => {
+  it("should have display-inline-block class to prevent focus ring clipping", () => {
     (useIsLoggedInUser as jest.Mock).mockReturnValue(true);
     render(<BackButton />);
 


### PR DESCRIPTION
## Summary

Fixed the focus ring clipping on the "Back to eCR Library" button by adding
padding-left: 0.25rem to the .nav-wrapper container. The clipping was caused
by overflow-y: auto implicitly setting overflow-x: hidden on the parent
container, which cut off the focus outline on the left side of the button.

## Related issue

Closes #1464

## Changes

- containers/ecr-viewer/src/styles/ecr-viewer.scss: Added padding-left: 0.25rem
  to .nav-wrapper to give the focus ring sufficient clearance on the left side
- containers/ecr-viewer/tests/unit/app/components/BackButton.test.tsx: Added
  test to verify the button renders with display-inline-block class

## Testing

- 6 unit tests passing in BackButton.test.tsx with 0 failures
- No existing tests broken
- Fix is viewable on any test eCR as noted in technical notes

## Breaking change

This is not a breaking change.